### PR TITLE
fix: Antigravity invalid argument fallback + NVIDIA Minimax model family

### DIFF
--- a/open-sse/services/modelFamilyFallback.ts
+++ b/open-sse/services/modelFamilyFallback.ts
@@ -81,6 +81,10 @@ const MODEL_FAMILIES: Record<string, string[]> = {
   "claude-sonnet-4-6": ["claude-sonnet-4-5-20250929", "claude-sonnet-4-20250514"],
   "claude-sonnet-4-5-20250929": ["claude-sonnet-4-6", "claude-sonnet-4-20250514"],
 
+  // NVIDIA Minimax family
+  "minimaxai/minimax-m2.7": ["minimaxai/minimax-m2.5", "minimax-m2.7", "minimax-m2.5"],
+  "minimaxai/minimax-m2.5": ["minimaxai/minimax-m2.7", "minimax-m2.5", "minimax-m2.7"],
+
   // GPT-5 family
   "gpt-5": ["gpt-5-mini", "gpt-4o"],
   "gpt-5.1": ["gpt-5.1-mini", "gpt-5", "gpt-4o"],
@@ -107,6 +111,7 @@ const MODEL_UNAVAILABLE_FRAGMENTS = [
   "not enabled for",
   "access to model",
   "improperly formed request", // Kiro 400 (model unavailable)
+  "invalid argument", // Antigravity 400 (model unavailable)
 ];
 
 /**


### PR DESCRIPTION
## **User description**
## Summary

Fixes two OmniRoute issues:

### Fix 1: Antigravity `[400]: Request contains an invalid argument`

When OmniRoute tries to use `claude-opus-4-6-thinking` via Antigravity and it returns a 400 error with "invalid argument", this was not recognized as a model-unavailable signal. No fallback was triggered.

**Solution:** Added `"invalid argument"` to `MODEL_UNAVAILABLE_FRAGMENTS` in `open-sse/services/modelFamilyFallback.ts:114`. Now Antigravity 400 errors automatically trigger fallback to `claude-opus-4-6` or `claude-opus-4-5-20251101`.

### Fix 2: NVIDIA/Minimaxi `[404]: Function '...' Not Found`

The `nvidia/minimaxai/minimax-m2.7` model wasn't in the model family fallback registry. When NVIDIA's internal function ID became stale, the 404 error had no fallback path.

**Solution:** Added NVIDIA Minimax model family to `MODEL_FAMILIES` in `open-sse/services/modelFamilyFallback.ts:85-86`:
```typescript
"minimaxai/minimax-m2.7": ["minimaxai/minimax-m2.5", "minimax-m2.7", "minimax-m2.5"],
"minimaxai/minimax-m2.5": ["minimaxai/minimax-m2.7", "minimax-m2.5", "minimax-m2.7"],
```

## Changes

- `open-sse/services/modelFamilyFallback.ts`: +5 lines
  - Added NVIDIA Minimax family for cross-model fallback
  - Added `"invalid argument"` error pattern for Antigravity 400 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model-unavailable detection and family fallback mappings, which can alter provider/model routing behavior and affect request success paths. Risk is limited in scope to fallback triggers for specific error strings and Minimax model IDs.
> 
> **Overview**
> Improves post-error model fallback behavior in `modelFamilyFallback.ts`.
> 
> Adds a NVIDIA Minimax family mapping so `minimaxai/minimax-m2.7` and `minimaxai/minimax-m2.5` can fall back to each other (and their unprefixed variants) when a model is unavailable.
> 
> Treats Antigravity `400` errors containing `"invalid argument"` as *model unavailable*, enabling automatic fallback instead of failing the request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51736aeb399c22bcb2d1f4d14f817f5bb0740730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Improve fallback when model requests fail with provider-specific errors

### What Changed
- Antigravity requests that return a 400 error with “invalid argument” now count as unavailable models, so they can fall back instead of failing immediately
- NVIDIA Minimax models are now part of the fallback path, letting `minimax-m2.7` and `minimax-m2.5` switch to each other when one is unavailable

### Impact
`✅ Fewer hard failures on Antigravity model requests`
`✅ More reliable fallback for NVIDIA Minimax models`
`✅ Fewer broken requests when a provider returns a model-unavailable error`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=0m_K0Bqwy49oe2440QOoFHJPsZbrYWIOcAWPNm2W-l0&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
