### PR TITLE
chore(OmniRoute): add concurrency blocks to 6 remaining workflows

### DIFF
--- a/.github/workflows/build-fork.yml
+++ b/.github/workflows/build-fork.yml
@@ -1,4 +1,7 @@
 name: Publish Fork Image to GHCR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,7 @@
 name: Claude Code
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   issue_comment:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,7 @@
 name: Publish to Docker Hub
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -1,4 +1,7 @@
 name: Build Electron Desktop App
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/lock-released-branch.yml
+++ b/.github/workflows/lock-released-branch.yml
@@ -1,5 +1,9 @@
 name: Lock released branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Two responsibilities (defense in depth — Hard Rule #18 enforcement):
 #
 # 1. `on: release: published` — when a GitHub Release publishes tag v3.X.Y,

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,7 @@
 name: Publish to npm
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   # 'released' (not 'published') so editing/re-publishing old releases does NOT


### PR DESCRIPTION
## **User description**
## Summary
- Add `cancel-in-progress` concurrency groups to 6 workflows missing them:
  - `build-fork.yml`
  - `claude.yml`
  - `docker-publish.yml`
  - `electron-release.yml`
  - `lock-released-branch.yml`
  - `npm-publish.yml`

## Test plan
- [ ] Verify each workflow has `concurrency:` block at top level
- [ ] Confirm cancel-in-progress on rapid push

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only YAML; behavior change is cancelling superseded CI runs, not application or release logic.
> 
> **Overview**
> Adds **GitHub Actions concurrency** to six workflows that did not have it yet, matching the existing `ci.yml` pattern: one group per workflow plus ref, with **`cancel-in-progress: true`**.
> 
> Affected workflows: fork GHCR build, Claude Code, Docker Hub publish, Electron release, lock released branch, and npm publish. Rapid re-triggers on the same ref will cancel older runs instead of stacking parallel jobs (fewer duplicate builds/publishes and less runner queue pressure).
> 
> No job steps, triggers, or secrets change—only top-level workflow YAML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d20ed5e77728e2079e91de516c2a03e4bf69de6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Prevent overlapping workflow runs from piling up on the same branch or tag

### What Changed
- Six GitHub Actions workflows now cancel older runs when a newer run starts on the same ref
- This applies to builds, publishing, release, and Claude comment workflows
- Re-triggering one of these workflows no longer leaves duplicate runs waiting or executing at the same time

### Impact
`✅ Fewer duplicate CI runs`
`✅ Less runner queue pressure`
`✅ Faster feedback on the latest push`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
