### PR TITLE
feat(step10): upstream tracking + canonical routing ADR

### DIFF
--- a/UPSTREAM_SYNC.md
+++ b/UPSTREAM_SYNC.md
@@ -1,0 +1,52 @@
+# Upstream Sync Guide — OmniRoute
+
+## Upstream
+- Remote: `upstream` → https://github.com/diegosouzapw/OmniRoute
+- Branch tracking: `upstream/main`
+- Latest synced upstream tag: check `git log upstream/main --oneline -1`
+
+## How to Sync Upstream Changes
+
+```bash
+# Fetch latest upstream
+git fetch upstream
+
+# Compare our fork vs upstream
+git log upstream/main..HEAD  # commits we're ahead
+git diff upstream/main HEAD  # full delta
+
+# Cherry-pick selective upstream fixes
+git cherry-pick <sha>
+
+# NEVER rebase onto upstream/main:
+# Our routing core diverges at the bifrost layer.
+# Rebasing would conflict with our arch changes.
+```
+
+## Our Divergence Point
+
+OmniRoute is being rebuilt around:
+- **bifrost** — Phenotype routing substrate (intelligent multi-provider routing crate)
+- **cliproxy** — Proxy and policy layer
+
+The upstream OpenAI-compatible gateway API surface is preserved for compatibility,
+but the routing core, load balancing, and provider selection are replaced by bifrost.
+
+## What to Backport from Upstream
+- Bug fixes in the OpenAI-compatible API layer
+- New provider integrations (endpoint schema changes)
+- Documentation improvements
+- Security patches
+
+## What NOT to Backport from Upstream
+- Routing algorithm changes (replaced by bifrost)
+- Load balancing logic (replaced by bifrost policies)
+- Retry/fallback logic (replaced by phenotype-retry + bifrost)
+
+## Upstream Release Tracking
+Latest upstream releases:
+- `upstream/release/v3.8.6`
+- `upstream/release/v3.8.7`
+- `upstream/release/v3.8.8`
+
+Monitor https://github.com/diegosouzapw/OmniRoute/releases for new tags.

--- a/docs/ADR-001-canonical-routing.md
+++ b/docs/ADR-001-canonical-routing.md
@@ -1,0 +1,84 @@
+# ADR-001: OmniRoute as Canonical Routing Project
+
+**Date**: 2026-05-30
+**Status**: Accepted
+**Author**: KooshaPari (Phenotype org)
+
+## Context
+
+Multiple routing-related projects exist across the Phenotype org:
+- **OmniRoute** (this repo) — fork of `diegosouzapw/OmniRoute`, an OpenAI-compatible
+  AI gateway with routing, load balancing, retries, and fallbacks
+- **phenoAI** — Phenotype AI agent workspace and tooling
+- **phenoRouterMonitor** — LLM router with Prometheus monitoring + Pareto dashboard
+- **Tokn** — TokenLedger: LLM cost and usage tracking
+- **helios-router** — routing primitives from the helios cluster
+- **bifrost** (in `pheno` monorepo) — Phenotype routing substrate crate
+
+This fragmentation creates duplicated effort, inconsistent APIs, and maintenance burden.
+A canonical routing project is needed.
+
+## Decision
+
+**OmniRoute is the canonical routing project for the Phenotype org.**
+
+OmniRoute is a hard fork of `diegosouzapw/OmniRoute` (tracked via `upstream` remote).
+Rather than archiving, it is undergoing a ground-up rebuild of the routing core around:
+
+- **bifrost** — Phenotype routing substrate (intelligent multi-provider routing,
+  policy evaluation, circuit breaking, cost-aware selection)
+- **cliproxy** — Proxy and policy enforcement layer
+
+The upstream OpenAI-compatible API surface is **preserved** for consumer compatibility.
+The routing core, load balancing, and provider-selection logic are **replaced**.
+
+## Cluster Convergence Plan
+
+The LLM-routing cluster consolidates toward OmniRoute + bifrost:
+
+| Project | Current Role | Migration Target |
+|---------|-------------|-----------------|
+| phenoAI | Agent workspace + tooling | Migrate agent tooling → OmniRoute workspace |
+| phenoRouterMonitor | Pareto dashboard + monitoring backend | → OmniRoute/monitoring/ |
+| Tokn | TokenLedger cost tracking | → OmniRoute/crates/tokn |
+| helios-router | Routing primitives | → bifrost crate |
+
+These migrations are **follow-on initiatives**. Source repos remain intact until migration
+is complete. Archive decisions are deferred to the user after migration.
+
+## Architecture
+
+```
+OmniRoute/
+├── src/               # OpenAI-compatible API gateway (from upstream)
+├── crates/
+│   ├── bifrost/       # Phenotype routing substrate (new)
+│   └── tokn/          # TokenLedger (migrated from Tokn repo)
+├── monitoring/        # Pareto dashboard (migrated from phenoRouterMonitor)
+└── docs/
+    ├── ADR-001-canonical-routing.md  (this file)
+    └── architecture/
+```
+
+## Consequences
+
+**Positive:**
+- Single canonical routing project for all LLM traffic in Phenotype services
+- Upstream OpenAI API compatibility maintained for existing consumers
+- bifrost provides a richer, more testable routing substrate than the upstream's approach
+- Consolidated observability: Metron + Traceon (in HexaKit) feed OmniRoute metrics
+
+**Negative:**
+- phenoAI/phenoRouterMonitor/Tokn/helios-router are archive candidates but cannot be
+  archived until migrations complete (tracked separately)
+- bifrost rebuild is a significant engineering investment
+
+**Neutral:**
+- Upstream (diegosouzapw/OmniRoute) continues independently; we cherry-pick fixes
+- See UPSTREAM_SYNC.md for sync protocol
+
+## References
+- `UPSTREAM_SYNC.md` — How to track and backport upstream changes
+- `KooshaPari/bifrost` — Routing substrate (to be extracted from pheno monorepo)
+- `KooshaPari/Metron` + `KooshaPari/Traceon` — Observability (now in HexaKit)
+- STEP 10 of phenotype-registry RATIONALIZATION_PLAN.md


### PR DESCRIPTION
## **User description**
Adds upstream remote (diegosouzapw/OmniRoute v3.8.8), UPSTREAM_SYNC.md tracking protocol, and docs/ADR-001-canonical-routing.md. OmniRoute is the canonical Phenotype routing project rebuilt on bifrost+cliproxy. LLM cluster (phenoAI/phenoRouterMonitor/Tokn/helios-router) converges here. Completes STEP 10 of rationalization plan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only governance docs; no application code, auth, or deployment behavior changes.
> 
> **Overview**
> Adds **documentation only** to formalize how this fork relates to `diegosouzapw/OmniRoute` and how Phenotype org routing will consolidate.
> 
> **`UPSTREAM_SYNC.md`** documents the `upstream` remote, fetch/compare/cherry-pick workflow, and an explicit rule **not** to rebase onto `upstream/main` because the routing core diverges at **bifrost**. It lists what to backport (API-layer fixes, provider schemas, docs, security) vs what to skip (upstream routing, load balancing, retry/fallback), and tracks release tags through v3.8.8.
> 
> **`docs/ADR-001-canonical-routing.md`** accepts **OmniRoute as the canonical Phenotype routing project**: hard fork with OpenAI-compatible API preserved while **bifrost** + **cliproxy** replace routing/LB/provider selection. It outlines a **cluster convergence** table (phenoAI, phenoRouterMonitor, Tokn, helios-router → OmniRoute paths) as follow-on migrations without archiving source repos yet, plus a target repo layout under `crates/` and `monitoring/`.
> 
> Together these complete **STEP 10** of the rationalization plan; no runtime or config changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a4012a98ed91d1a51706fc55e6406c9b9079a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Document the upstream sync process and make OmniRoute the canonical routing project**

### What Changed
- Added a guide for checking upstream changes, comparing diffs, and cherry-picking fixes from `diegosouzapw/OmniRoute`
- Clarified that OmniRoute keeps the OpenAI-compatible API surface, but routing, load balancing, and provider selection now follow the Phenotype direction
- Added an ADR that names OmniRoute as the canonical routing project and maps related projects to their migration targets
- Noted which upstream changes should be brought in, and which routing behaviors should stay out

### Impact
`✅ Clearer upstream maintenance`
`✅ Fewer routing-source conflicts`
`✅ Easier project consolidation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
