### PR TITLE
feat(routing): hexagonal RouterPort + BifrostAdapter (ADR-001)

### DIFF
--- a/src/domain/router/index.ts
+++ b/src/domain/router/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Domain router barrel — re-exports the port and config types.
+ * Adapters are NOT re-exported here to keep the domain layer dependency-free.
+ *
+ * @module domain/router
+ */
+export * from "./port.ts";

--- a/src/domain/router/port.ts
+++ b/src/domain/router/port.ts
@@ -1,0 +1,116 @@
+/**
+ * RouterPort — hexagonal port for canonical LLM routing.
+ *
+ * ADR-001: OmniRoute is the canonical routing project; the routing core is
+ * replaced with bifrost. This port is the inbound/outbound boundary: callers
+ * depend on these types only, adapters plug in at the edges.
+ *
+ * @module domain/router/port
+ */
+
+// ---------------------------------------------------------------------------
+// Value objects
+// ---------------------------------------------------------------------------
+
+export type ProviderName =
+  | "openai"
+  | "anthropic"
+  | "gemini"
+  | "groq"
+  | "mistral"
+  | "azure"
+  | "bedrock"
+  | "vertex"
+  | "ollama"
+  | "openrouter"
+  | string; // open for extension
+
+export type FitnessTier = "best-reasoning" | "cheapest" | "moderate" | "balanced";
+
+export interface RouteRequest {
+  /** Canonical model string (e.g. "gpt-4o", "claude-opus-4-5"). */
+  model: string;
+  messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+  /** Optional hint for provider-selection policy. */
+  fitnessTier?: FitnessTier;
+  /** Max tokens for response. */
+  maxTokens?: number;
+  /** Streaming mode — adapter must honour this flag. */
+  stream?: boolean;
+  /** Pass-through provider overrides (e.g. temperature). */
+  params?: Record<string, unknown>;
+}
+
+export interface RouteResponse {
+  text: string;
+  provider: ProviderName;
+  model: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  latencyMs: number;
+  /** True when a fallback provider was used. */
+  usedFallback: boolean;
+  /** Raw adapter-level response (opaque). */
+  raw?: unknown;
+}
+
+export interface RouteError {
+  code: "provider_error" | "timeout" | "rate_limit" | "model_unavailable" | "config_error" | "unknown";
+  message: string;
+  provider?: ProviderName;
+  retriable: boolean;
+  cause?: unknown;
+}
+
+export type RouteResult =
+  | { ok: true; value: RouteResponse }
+  | { ok: false; error: RouteError };
+
+// ---------------------------------------------------------------------------
+// Port interface (hexagonal outbound port)
+// ---------------------------------------------------------------------------
+
+/**
+ * RouterPort is the sole routing abstraction all OmniRoute request handlers
+ * depend on. Adapters (bifrost, cliproxy, native) implement this interface.
+ */
+export interface RouterPort {
+  /**
+   * Route a single chat-completion request. Returns a RouteResult so callers
+   * can handle failures without exceptions.
+   */
+  route(req: RouteRequest): Promise<RouteResult>;
+
+  /**
+   * Return which providers are currently healthy / available.
+   * Used by health-check endpoints and combo selection.
+   */
+  listAvailableProviders(): Promise<ProviderName[]>;
+
+  /**
+   * Optional: provider-specific model listing.
+   * Returns empty array if not supported by the adapter.
+   */
+  listModels(provider?: ProviderName): Promise<string[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Provider-selection config (loaded from env / settings.json)
+// ---------------------------------------------------------------------------
+
+export interface RouterConfig {
+  /** Ordered list of providers to try. First healthy one wins. */
+  providerPriority: ProviderName[];
+  /** Map of fitnessTier → preferred provider (overrides priority list). */
+  tierOverrides?: Partial<Record<FitnessTier, ProviderName>>;
+  /** Default request timeout in milliseconds. */
+  timeoutMs?: number;
+  /** If true, automatically try next provider on transient failure. */
+  enableFallback?: boolean;
+}
+
+export const DEFAULT_ROUTER_CONFIG: RouterConfig = {
+  providerPriority: ["openai", "anthropic", "groq"],
+  timeoutMs: 30_000,
+  enableFallback: true,
+};

--- a/src/lib/adapters/bifrostAdapter.ts
+++ b/src/lib/adapters/bifrostAdapter.ts
@@ -1,0 +1,267 @@
+/**
+ * BifrostAdapter — wraps the bifrost gateway (KooshaPari/bifrost) as a
+ * RouterPort. Bifrost exposes an OpenAI-compatible HTTP API, so this adapter
+ * calls /v1/chat/completions on the configured base URL and translates the
+ * response into the canonical RouteResult shape.
+ *
+ * ADR-001: bifrost is the default routing substrate for OmniRoute.
+ * Swap to ClipproxyAdapter or NativeAdapter by injecting a different
+ * RouterPort implementation.
+ *
+ * @module lib/adapters/bifrostAdapter
+ */
+
+import type {
+  RouterPort,
+  RouterConfig,
+  RouteRequest,
+  RouteResult,
+  ProviderName,
+} from "../../domain/router/port.ts";
+import { DEFAULT_ROUTER_CONFIG } from "../../domain/router/port.ts";
+
+// ---------------------------------------------------------------------------
+// Config / env resolution
+// ---------------------------------------------------------------------------
+
+export interface BifrostAdapterConfig {
+  /** Base URL of the running bifrost gateway (default: env BIFROST_BASE_URL). */
+  baseUrl?: string;
+  /** Bearer token / API key for bifrost auth (default: env BIFROST_API_KEY). */
+  apiKey?: string;
+  /** RouterConfig for provider priority + fallback policy. */
+  router?: RouterConfig;
+}
+
+function resolveBaseUrl(cfg: BifrostAdapterConfig): string {
+  return (
+    cfg.baseUrl ??
+    (typeof process !== "undefined" ? process.env["BIFROST_BASE_URL"] : undefined) ??
+    "http://localhost:8080"
+  );
+}
+
+function resolveApiKey(cfg: BifrostAdapterConfig): string | undefined {
+  return (
+    cfg.apiKey ??
+    (typeof process !== "undefined" ? process.env["BIFROST_API_KEY"] : undefined)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI-compat types (minimal — bifrost follows this spec)
+// ---------------------------------------------------------------------------
+
+interface OAIChatMessage {
+  role: string;
+  content: string;
+}
+
+interface OAIChatRequest {
+  model: string;
+  messages: OAIChatMessage[];
+  max_tokens?: number;
+  stream?: boolean;
+  [k: string]: unknown;
+}
+
+interface OAIChatResponse {
+  id: string;
+  choices: Array<{
+    message: { role: string; content: string };
+    finish_reason: string | null;
+  }>;
+  usage?: { prompt_tokens?: number; completion_tokens?: number };
+  model?: string;
+  // bifrost adds x-provider header, reflected here when available
+  _provider?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export class BifrostAdapter implements RouterPort {
+  private readonly baseUrl: string;
+  private readonly apiKey: string | undefined;
+  private readonly routerConfig: RouterConfig;
+
+  constructor(cfg: BifrostAdapterConfig = {}) {
+    this.baseUrl = resolveBaseUrl(cfg).replace(/\/$/, "");
+    this.apiKey = resolveApiKey(cfg);
+    this.routerConfig = { ...DEFAULT_ROUTER_CONFIG, ...(cfg.router ?? {}) };
+  }
+
+  // -------------------------------------------------------------------------
+  // RouterPort: route
+  // -------------------------------------------------------------------------
+
+  async route(req: RouteRequest): Promise<RouteResult> {
+    const startMs = Date.now();
+
+    // Build provider priority list: tier override → global priority
+    const priority = this._resolveProviderPriority(req);
+    const timeoutMs = this.routerConfig.timeoutMs ?? 30_000;
+
+    let lastError: RouteResult["error"] | undefined;
+
+    for (let i = 0; i < priority.length; i++) {
+      const provider = priority[i]!;
+      const usedFallback = i > 0;
+
+      try {
+        const body: OAIChatRequest = {
+          model: req.model,
+          messages: req.messages,
+          ...(req.maxTokens !== undefined ? { max_tokens: req.maxTokens } : {}),
+          ...(req.stream !== undefined ? { stream: req.stream } : {}),
+          ...(req.params ?? {}),
+        };
+
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+          // bifrost uses x-provider header to select the backend
+          "x-provider": provider,
+        };
+        if (this.apiKey) {
+          headers["Authorization"] = `Bearer ${this.apiKey}`;
+        }
+
+        const ac = new AbortController();
+        const tid = setTimeout(() => ac.abort(), timeoutMs);
+
+        let resp: Response;
+        try {
+          resp = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(body),
+            signal: ac.signal,
+          });
+        } finally {
+          clearTimeout(tid);
+        }
+
+        if (!resp.ok) {
+          const errText = await resp.text().catch(() => resp.statusText);
+          const code =
+            resp.status === 429
+              ? "rate_limit"
+              : resp.status >= 500
+              ? "provider_error"
+              : "unknown";
+          lastError = {
+            code,
+            message: `bifrost returned ${resp.status}: ${errText}`,
+            provider,
+            retriable: resp.status === 429 || resp.status >= 500,
+          };
+          if (this.routerConfig.enableFallback && lastError.retriable) {
+            continue; // try next provider
+          }
+          return { ok: false, error: lastError };
+        }
+
+        const data = (await resp.json()) as OAIChatResponse;
+        const text = data.choices[0]?.message?.content ?? "";
+        const resolvedProvider: ProviderName =
+          resp.headers.get("x-provider") ?? data._provider ?? provider;
+
+        return {
+          ok: true,
+          value: {
+            text,
+            provider: resolvedProvider,
+            model: data.model ?? req.model,
+            inputTokens: data.usage?.prompt_tokens,
+            outputTokens: data.usage?.completion_tokens,
+            latencyMs: Date.now() - startMs,
+            usedFallback,
+            raw: data,
+          },
+        };
+      } catch (err) {
+        const isAbort =
+          err instanceof Error && err.name === "AbortError";
+        lastError = {
+          code: isAbort ? "timeout" : "provider_error",
+          message: err instanceof Error ? err.message : String(err),
+          provider,
+          retriable: true,
+          cause: err,
+        };
+        if (this.routerConfig.enableFallback) {
+          continue;
+        }
+        return { ok: false, error: lastError };
+      }
+    }
+
+    return {
+      ok: false,
+      error: lastError ?? {
+        code: "config_error",
+        message: "No providers configured",
+        retriable: false,
+      },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // RouterPort: listAvailableProviders
+  // -------------------------------------------------------------------------
+
+  async listAvailableProviders(): Promise<ProviderName[]> {
+    try {
+      const headers: Record<string, string> = {};
+      if (this.apiKey) headers["Authorization"] = `Bearer ${this.apiKey}`;
+
+      const resp = await fetch(`${this.baseUrl}/v1/providers`, { headers });
+      if (!resp.ok) return [...this.routerConfig.providerPriority];
+
+      const data = (await resp.json()) as { providers?: string[] };
+      return data.providers ?? [...this.routerConfig.providerPriority];
+    } catch {
+      // bifrost not reachable — return config list
+      return [...this.routerConfig.providerPriority];
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // RouterPort: listModels
+  // -------------------------------------------------------------------------
+
+  async listModels(provider?: ProviderName): Promise<string[]> {
+    try {
+      const headers: Record<string, string> = {};
+      if (this.apiKey) headers["Authorization"] = `Bearer ${this.apiKey}`;
+      if (provider) headers["x-provider"] = provider;
+
+      const resp = await fetch(`${this.baseUrl}/v1/models`, { headers });
+      if (!resp.ok) return [];
+
+      const data = (await resp.json()) as { data?: Array<{ id: string }> };
+      return (data.data ?? []).map((m) => m.id);
+    } catch {
+      return [];
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private _resolveProviderPriority(req: RouteRequest): ProviderName[] {
+    if (req.fitnessTier && this.routerConfig.tierOverrides) {
+      const override = this.routerConfig.tierOverrides[req.fitnessTier];
+      if (override) {
+        // Put tier-preferred provider first, rest follow
+        const rest = this.routerConfig.providerPriority.filter(
+          (p) => p !== override
+        );
+        return [override, ...rest];
+      }
+    }
+    return [...this.routerConfig.providerPriority];
+  }
+}

--- a/src/lib/adapters/fakeRouterAdapter.ts
+++ b/src/lib/adapters/fakeRouterAdapter.ts
@@ -1,0 +1,81 @@
+/**
+ * FakeRouterAdapter — in-memory RouterPort for unit tests.
+ *
+ * Supports:
+ *  - Preconfigured response queue (FIFO).
+ *  - Simulated provider failure + fallback.
+ *  - Introspectable call log.
+ *
+ * @module lib/adapters/fakeRouterAdapter
+ */
+
+import type {
+  RouterPort,
+  RouteRequest,
+  RouteResult,
+  ProviderName,
+} from "../../domain/router/port.ts";
+
+export type FakeEntry =
+  | { ok: true; provider?: ProviderName; text?: string }
+  | { ok: false; code?: RouteResult extends { ok: false } ? RouteResult["error"]["code"] : never; message?: string; retriable?: boolean };
+
+export class FakeRouterAdapter implements RouterPort {
+  private readonly queue: FakeEntry[];
+  private readonly _providers: ProviderName[];
+  readonly calls: RouteRequest[] = [];
+
+  constructor(
+    responses: FakeEntry[] = [],
+    providers: ProviderName[] = ["fake-provider"]
+  ) {
+    this.queue = [...responses];
+    this._providers = providers;
+  }
+
+  async route(req: RouteRequest): Promise<RouteResult> {
+    this.calls.push(req);
+    const entry = this.queue.shift();
+
+    if (!entry) {
+      return {
+        ok: false,
+        error: {
+          code: "config_error",
+          message: "FakeRouterAdapter: response queue empty",
+          retriable: false,
+        },
+      };
+    }
+
+    if (entry.ok) {
+      return {
+        ok: true,
+        value: {
+          text: entry.text ?? "fake response",
+          provider: entry.provider ?? "fake-provider",
+          model: req.model,
+          latencyMs: 0,
+          usedFallback: false,
+        },
+      };
+    }
+
+    return {
+      ok: false,
+      error: {
+        code: (entry as { ok: false; code?: string }).code ?? "provider_error",
+        message: (entry as { ok: false; message?: string }).message ?? "fake error",
+        retriable: (entry as { ok: false; retriable?: boolean }).retriable ?? false,
+      } as RouteResult extends { ok: false } ? RouteResult["error"] : never,
+    };
+  }
+
+  async listAvailableProviders(): Promise<ProviderName[]> {
+    return [...this._providers];
+  }
+
+  async listModels(_provider?: ProviderName): Promise<string[]> {
+    return ["fake-model-1", "fake-model-2"];
+  }
+}

--- a/tests/unit/bifrost-routing-core.test.ts
+++ b/tests/unit/bifrost-routing-core.test.ts
@@ -1,0 +1,379 @@
+/**
+ * bifrost-routing-core.test.ts
+ *
+ * TDD suite for the hexagonal RouterPort + BifrostAdapter + FakeRouterAdapter.
+ * No live gateway required — all network calls are intercepted via globalThis.fetch mock.
+ *
+ * Coverage targets:
+ *  1. RouterPort contract (FakeRouterAdapter)
+ *     a. route() returns ok:true on success
+ *     b. route() returns ok:false on failure
+ *     c. empty queue returns config_error
+ *     d. calls are recorded
+ *     e. listAvailableProviders() returns injected list
+ *     f. listModels() returns fake list
+ *
+ *  2. BifrostAdapter (fetch-intercepted)
+ *     a. Happy path — 200 from bifrost → ok:true, correct fields
+ *     b. Provider header propagated in request
+ *     c. API key injected as Bearer when set
+ *     d. bifrost 429 → rate_limit error, retriable
+ *     e. bifrost 500 → provider_error, retriable
+ *     f. Fallback: first provider 500, second succeeds → usedFallback=true
+ *     g. fitnessTier override reorders provider list
+ *     h. No fallback config: first failure returns immediately
+ *     i. fetch throws (network error) → provider_error, retriable
+ *     j. listAvailableProviders() — bifrost responds with provider list
+ *     k. listAvailableProviders() — bifrost unreachable → returns config list
+ *     l. listModels() — bifrost responds with model list
+ *     m. listModels() — bifrost 404 → returns []
+ *
+ *  3. DEFAULT_ROUTER_CONFIG shape validation
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { RouteRequest } from "../../src/domain/router/port.ts";
+import {
+  DEFAULT_ROUTER_CONFIG,
+} from "../../src/domain/router/port.ts";
+import { FakeRouterAdapter } from "../../src/lib/adapters/fakeRouterAdapter.ts";
+import { BifrostAdapter } from "../../src/lib/adapters/bifrostAdapter.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReq(overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    model: "gpt-4o",
+    messages: [{ role: "user", content: "hello" }],
+    ...overrides,
+  };
+}
+
+type FetchMock = (
+  input: string | URL | Request,
+  init?: RequestInit
+) => Promise<Response>;
+
+function withFetch(mock: FetchMock, fn: () => Promise<void>): Promise<void> {
+  const orig = globalThis.fetch;
+  globalThis.fetch = mock as typeof fetch;
+  return fn().finally(() => {
+    globalThis.fetch = orig;
+  });
+}
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. FakeRouterAdapter (RouterPort contract)
+// ---------------------------------------------------------------------------
+
+test("FakeRouterAdapter: route() ok:true on success", async () => {
+  const adapter = new FakeRouterAdapter([{ ok: true, text: "hi there", provider: "openai" }]);
+  const result = await adapter.route(makeReq());
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.value.text, "hi there");
+    assert.equal(result.value.provider, "openai");
+    assert.equal(result.value.model, "gpt-4o");
+    assert.equal(result.value.usedFallback, false);
+  }
+});
+
+test("FakeRouterAdapter: route() ok:false on failure", async () => {
+  const adapter = new FakeRouterAdapter([
+    { ok: false, code: "rate_limit", message: "quota exceeded", retriable: true },
+  ]);
+  const result = await adapter.route(makeReq());
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error.code, "rate_limit");
+    assert.equal(result.error.retriable, true);
+  }
+});
+
+test("FakeRouterAdapter: empty queue returns config_error", async () => {
+  const adapter = new FakeRouterAdapter([]);
+  const result = await adapter.route(makeReq());
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error.code, "config_error");
+  }
+});
+
+test("FakeRouterAdapter: calls are recorded", async () => {
+  const adapter = new FakeRouterAdapter([{ ok: true }, { ok: true }]);
+  const req1 = makeReq({ model: "model-a" });
+  const req2 = makeReq({ model: "model-b" });
+  await adapter.route(req1);
+  await adapter.route(req2);
+  assert.equal(adapter.calls.length, 2);
+  assert.equal(adapter.calls[0]!.model, "model-a");
+  assert.equal(adapter.calls[1]!.model, "model-b");
+});
+
+test("FakeRouterAdapter: listAvailableProviders returns injected list", async () => {
+  const adapter = new FakeRouterAdapter([], ["anthropic", "groq"]);
+  const providers = await adapter.listAvailableProviders();
+  assert.deepEqual(providers, ["anthropic", "groq"]);
+});
+
+test("FakeRouterAdapter: listModels returns fake list", async () => {
+  const adapter = new FakeRouterAdapter();
+  const models = await adapter.listModels();
+  assert.ok(models.length > 0);
+});
+
+// ---------------------------------------------------------------------------
+// 2. BifrostAdapter (fetch-intercepted)
+// ---------------------------------------------------------------------------
+
+const FAKE_BIFROST_RESPONSE = {
+  id: "chat-123",
+  choices: [{ message: { role: "assistant", content: "hello world" }, finish_reason: "stop" }],
+  usage: { prompt_tokens: 10, completion_tokens: 5 },
+  model: "gpt-4o",
+};
+
+test("BifrostAdapter: happy path 200 → ok:true with correct fields", async () => {
+  const adapter = new BifrostAdapter({
+    baseUrl: "http://bifrost-test",
+    router: { providerPriority: ["openai"] },
+  });
+
+  await withFetch(async (_url, _init) => {
+    return jsonResponse(FAKE_BIFROST_RESPONSE, 200, { "x-provider": "openai" });
+  }, async () => {
+    const result = await adapter.route(makeReq());
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.value.text, "hello world");
+      assert.equal(result.value.provider, "openai");
+      assert.equal(result.value.model, "gpt-4o");
+      assert.equal(result.value.inputTokens, 10);
+      assert.equal(result.value.outputTokens, 5);
+      assert.equal(result.value.usedFallback, false);
+    }
+  });
+});
+
+test("BifrostAdapter: x-provider header propagated in request", async () => {
+  const adapter = new BifrostAdapter({
+    baseUrl: "http://bifrost-test",
+    router: { providerPriority: ["anthropic"] },
+  });
+
+  let capturedProvider: string | null = null;
+  await withFetch(async (_url, init) => {
+    capturedProvider = (init?.headers as Record<string, string>)?.["x-provider"] ?? null;
+    return jsonResponse(FAKE_BIFROST_RESPONSE);
+  }, async () => {
+    await adapter.route(makeReq());
+    assert.equal(capturedProvider, "anthropic");
+  });
+});
+
+test("BifrostAdapter: api key injected as Bearer when set", async () => {
+  const adapter = new BifrostAdapter({
+    baseUrl: "http://bifrost-test",
+    apiKey: "test-key-abc",
+    router: { providerPriority: ["openai"] },
+  });
+
+  let capturedAuth: string | null = null;
+  await withFetch(async (_url, init) => {
+    capturedAuth = (init?.headers as Record<string, string>)?.["Authorization"] ?? null;
+    return jsonResponse(FAKE_BIFROST_RESPONSE);
+  }, async () => {
+    await adapter.route(makeReq());
+    assert.equal(capturedAuth, "Bearer test-key-abc");
+  });
+});
+
+test("BifrostAdapter: 429 → rate_limit error, retriable=true", async () => {
+  const adapter = new BifrostAdapter({
+    baseUrl: "http://bifrost-test",
+    router: { providerPriority: ["openai"], enableFallback: false },
+  });
+
+  await withFetch(async () => {
+    return new Response("rate limited", { status: 429 });
+  }, async () => {
+    const result = await adapter.route(makeReq());
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.error.code, "rate_limit");
+      assert.equal(result.error.retriable, true);
+    }
+  });
+});
+
+test("BifrostAdapter: 500 → provider_error, retriable=true", async () => {
+  const adapter = new BifrostAdapter({
+    baseUrl: "http://bifrost-test",
+    router: { providerPriority: ["openai"], enableFallback: false },
+  });
+
+  await withFetch(async () => {
+    return new Response("internal server error", { status: 500 });
+  }, async () => {
+    const result = await adapter.route(makeReq());
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.error.code, "provider_error");
+      assert.equal(result.error.retriable, true);
+    }
+  });
+});
+
+test("BifrostAdapter: fallback — first 500, second succeeds → usedFallback=true", async () => {
+  const adapter = new BifrostAdapter({
+    baseUrl: "http://bifrost-test",
+    router: { providerPriority: ["openai", "anthropic"], enableFallback: true },
+  });
+
+  let callCount = 0;
+  await withFetch(async (_url, init) => {
+    callCount++;
+    const provider = (init?.headers as Record<string, string>)?.["x-provider"];
+    if (provider === "openai") {
+      return new Response("overloaded", { status: 500 });
+    }
+    return jsonResponse(FAKE_BIFROST_RESPONSE, 200, { "x-provider": "anthropic" });
+  }, async () => {
+    const result = await adapter.route(makeReq());
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.value.usedFallback, true);
+      assert.equal(result.value.provider, "anthropic");
+    }
+    assert.equal(callCount, 2);
+  });
+});
+
+test("BifrostAdapter: fitnessTier override reorders providers", async () => {
+  const adapter = new BifrostAdapter({
+    baseUrl: "http://bifrost-test",
+    router: {
+      providerPriority: ["openai", "anthropic"],
+      tierOverrides: { "best-reasoning": "anthropic" },
+      enableFallback: false,
+    },
+  });
+
+  let firstProvider: string | null = null;
+  await withFetch(async (_url, init) => {
+    if (!firstProvider) {
+      firstProvider = (init?.headers as Record<string, string>)?.["x-provider"] ?? null;
+    }
+    return jsonResponse(FAKE_BIFROST_RESPONSE, 200, { "x-provider": firstProvider ?? "" });
+  }, async () => {
+    await adapter.route(makeReq({ fitnessTier: "best-reasoning" }));
+    assert.equal(firstProvider, "anthropic");
+  });
+});
+
+test("BifrostAdapter: no fallback — first failure returns immediately", async () => {
+  const adapter = new BifrostAdapter({
+    baseUrl: "http://bifrost-test",
+    router: { providerPriority: ["openai", "anthropic"], enableFallback: false },
+  });
+
+  let callCount = 0;
+  await withFetch(async () => {
+    callCount++;
+    return new Response("err", { status: 500 });
+  }, async () => {
+    const result = await adapter.route(makeReq());
+    assert.equal(result.ok, false);
+    assert.equal(callCount, 1); // did NOT try anthropic
+  });
+});
+
+test("BifrostAdapter: network error → provider_error retriable=true", async () => {
+  const adapter = new BifrostAdapter({
+    baseUrl: "http://bifrost-test",
+    router: { providerPriority: ["openai"], enableFallback: false },
+  });
+
+  await withFetch(async () => {
+    throw new TypeError("fetch failed");
+  }, async () => {
+    const result = await adapter.route(makeReq());
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.error.code, "provider_error");
+      assert.equal(result.error.retriable, true);
+    }
+  });
+});
+
+test("BifrostAdapter: listAvailableProviders — bifrost returns provider list", async () => {
+  const adapter = new BifrostAdapter({
+    baseUrl: "http://bifrost-test",
+    router: { providerPriority: ["openai"] },
+  });
+
+  await withFetch(async () => {
+    return jsonResponse({ providers: ["openai", "anthropic", "groq"] });
+  }, async () => {
+    const providers = await adapter.listAvailableProviders();
+    assert.deepEqual(providers, ["openai", "anthropic", "groq"]);
+  });
+});
+
+test("BifrostAdapter: listAvailableProviders — bifrost unreachable falls back to config", async () => {
+  const adapter = new BifrostAdapter({
+    baseUrl: "http://bifrost-test",
+    router: { providerPriority: ["openai", "mistral"] },
+  });
+
+  await withFetch(async () => {
+    throw new TypeError("network error");
+  }, async () => {
+    const providers = await adapter.listAvailableProviders();
+    assert.deepEqual(providers, ["openai", "mistral"]);
+  });
+});
+
+test("BifrostAdapter: listModels — bifrost returns model list", async () => {
+  const adapter = new BifrostAdapter({ baseUrl: "http://bifrost-test" });
+
+  await withFetch(async () => {
+    return jsonResponse({ data: [{ id: "gpt-4o" }, { id: "gpt-4o-mini" }] });
+  }, async () => {
+    const models = await adapter.listModels("openai");
+    assert.deepEqual(models, ["gpt-4o", "gpt-4o-mini"]);
+  });
+});
+
+test("BifrostAdapter: listModels — non-200 returns empty array", async () => {
+  const adapter = new BifrostAdapter({ baseUrl: "http://bifrost-test" });
+
+  await withFetch(async () => {
+    return new Response("not found", { status: 404 });
+  }, async () => {
+    const models = await adapter.listModels();
+    assert.deepEqual(models, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. DEFAULT_ROUTER_CONFIG shape
+// ---------------------------------------------------------------------------
+
+test("DEFAULT_ROUTER_CONFIG has required shape", () => {
+  assert.ok(Array.isArray(DEFAULT_ROUTER_CONFIG.providerPriority));
+  assert.ok(DEFAULT_ROUTER_CONFIG.providerPriority.length > 0);
+  assert.equal(typeof DEFAULT_ROUTER_CONFIG.timeoutMs, "number");
+  assert.equal(DEFAULT_ROUTER_CONFIG.enableFallback, true);
+});


### PR DESCRIPTION
## **User description**
## Summary

Implements the bifrost-consuming routing core per [ADR-001](docs/ADR-001-canonical-routing.md).

- **`src/domain/router/port.ts`** — hexagonal `RouterPort` outbound port: `RouteRequest / RouteResponse / RouteError / RouteResult` value objects, `RouterConfig` with provider priority list + fitnessTier overrides, `DEFAULT_ROUTER_CONFIG`.
- **`src/lib/adapters/bifrostAdapter.ts`** — `BifrostAdapter implements RouterPort`: wraps the bifrost OpenAI-compat HTTP gateway (`/v1/chat/completions`). Injects `x-provider` header for backend selection, Bearer auth from env/config, ordered fallback across `providerPriority`, fitnessTier-driven provider reordering, `listAvailableProviders()`, `listModels()`. Config sourced from `BIFROST_BASE_URL` / `BIFROST_API_KEY` env vars.
- **`src/lib/adapters/fakeRouterAdapter.ts`** — `FakeRouterAdapter implements RouterPort`: in-memory FIFO response queue + introspectable call log for unit tests. No live gateway needed.
- **`tests/unit/bifrost-routing-core.test.ts`** — 20 TDD tests (all green): port contract, happy-path, 429/500 error mapping, fallback chain, tier overrides, no-fallback short-circuit, network errors, provider/model listing, unreachable-gateway fallback.

## Relation to previous PRs
- PR #9 landed ADR-001 and upstream tracking. This PR delivers the code core that ADR-001 specifies.

## Test plan
- [ ] `node --import tsx/esm --test tests/unit/bifrost-routing-core.test.ts` → 20 pass, 0 fail
- [ ] Point `BIFROST_BASE_URL` at a running bifrost gateway and smoke with `BifrostAdapter.route()`
- [ ] Inject `BifrostAdapter` into an existing chat-route handler as a drop-in `RouterPort`

Refs: ADR-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds the canonical LLM routing abstraction and live HTTP gateway integration with multi-provider fallback; behavior is well covered by tests but will affect all chat traffic once handlers inject this adapter.
> 
> **Overview**
> Introduces a **hexagonal routing boundary** for OmniRoute (ADR-001): callers will depend on `RouterPort` and shared request/result types in `src/domain/router`, without pulling in adapter implementations from the domain barrel.
> 
> **`BifrostAdapter`** is the default implementation: it POSTs to the bifrost OpenAI-compatible `/v1/chat/completions` endpoint, sets `x-provider` and optional Bearer auth from config/env, maps HTTP failures to structured `RouteError`s, and walks **`providerPriority`** with optional **fallback** on retriable errors. **`fitnessTier`** can reorder providers via `tierOverrides`. It also exposes **`listAvailableProviders`** and **`listModels`** against bifrost with config fallbacks when the gateway is down.
> 
> A **`FakeRouterAdapter`** plus a **20-test** unit suite (mocked `fetch`) cover the port contract, happy path, 429/500/timeout/network handling, fallback vs no-fallback, and listing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 196701ebb025f169bb129e0130f017e6dfc7e8ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add the bifrost routing core and test coverage**

### What Changed
- Introduced a routing contract with request, response, error, and provider settings used by all routing adapters
- Added a bifrost-backed router that sends chat requests through the gateway, selects providers by priority, honors fitness-tier overrides, and falls back to the next provider when allowed
- Added support for provider and model lookups, plus a test double that records calls and returns queued responses for unit tests
- Added tests for successful routing, provider headers, API key auth, rate-limit and server errors, fallback behavior, timeout handling, and provider/model listing

### Impact
`✅ Fewer routing failures during provider outages`
`✅ Clearer routing errors and fallback behavior`
`✅ Safer adapter changes with test coverage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
