### PR TITLE
feat(desktop): native Electrobun shell (HMR) for OmniRoute

### DIFF
--- a/desktop-electrobun/.env.example
+++ b/desktop-electrobun/.env.example
@@ -1,0 +1,10 @@
+# Override renderer URL (default: http://localhost:3000)
+RENDERER_URL=http://localhost:3000
+
+# Path to process-compose.yml for one-click service boot
+# Leave unset to skip service boot
+SERVICES_COMPOSE_FILE=
+
+# Optional window size overrides
+# WINDOW_WIDTH=1400
+# WINDOW_HEIGHT=900

--- a/desktop-electrobun/.gitignore
+++ b/desktop-electrobun/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+.env
+*.log

--- a/desktop-electrobun/electrobun.config.ts
+++ b/desktop-electrobun/electrobun.config.ts
@@ -1,0 +1,49 @@
+/**
+ * phenotype-desktop Electrobun shell template
+ *
+ * USAGE: Copy this directory alongside your web app, then edit the three
+ * CONFIGURE sections below. Run `bun install && bun dev` on macOS.
+ *
+ * Template variables (find-replace before use):
+ *   OmniRoute         e.g. "MyApp"
+ *   com.phenotype.omniroute           e.g. "com.example.myapp"
+ *   0.1.0      e.g. "0.1.0"
+ *   http://localhost:3000  e.g. "http://localhost:3000"
+ *   ../web/dist/index.html e.g. "../web/dist/index.html"  (relative from this dir)
+ */
+import type { ElectrobunConfig } from "electrobun";
+
+// ── CONFIGURE 1: App identity ─────────────────────────────────────────────────
+const APP_NAME = "OmniRoute";
+const APP_ID = "com.phenotype.omniroute";
+const APP_VERSION = "0.1.0";
+
+// ── CONFIGURE 2: Renderer (dev server URL or bundled views path) ──────────────
+const DEFAULT_DEV_URL = "http://localhost:3000";
+
+// ── CONFIGURE 3: Bundled views entrypoint (production) ───────────────────────
+const VIEWS_ENTRYPOINT = "src/views/index.html";
+
+export default {
+  app: {
+    name: APP_NAME,
+    identifier: APP_ID,
+    version: APP_VERSION,
+  },
+  runtime: {
+    exitOnLastWindowClosed: true,
+    // Passed through to main.ts via BuildConfig at runtime
+    devRendererUrl: process.env.RENDERER_URL ?? DEFAULT_DEV_URL,
+  },
+  build: {
+    bun: {
+      entrypoint: "src/main.ts",
+    },
+    views: [
+      {
+        name: "app",
+        entrypoint: VIEWS_ENTRYPOINT,
+      },
+    ],
+  },
+} satisfies ElectrobunConfig;

--- a/desktop-electrobun/justfile
+++ b/desktop-electrobun/justfile
@@ -1,0 +1,17 @@
+# OmniRoute desktop shell
+set dotenv-load
+
+dev:
+  bun dev
+
+build:
+  bun run build
+
+release:
+  bun run build:release
+
+install:
+  bun install
+
+typecheck:
+  bun run typecheck

--- a/desktop-electrobun/package.json
+++ b/desktop-electrobun/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@phenotype/desktop-shell",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "electrobun dev",
+    "build": "electrobun build",
+    "build:release": "electrobun build --release",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "electrobun": "^1.18.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/bun": "latest"
+  }
+}

--- a/desktop-electrobun/src/main.ts
+++ b/desktop-electrobun/src/main.ts
@@ -1,0 +1,133 @@
+/**
+ * phenotype-desktop Electrobun shell — main process template
+ *
+ * Features out of the box:
+ *  - One-click service boot: runs `process-compose up -d` if SERVICES_COMPOSE_FILE is set
+ *  - Loads renderer from RENDERER_URL env or falls back to bundled views://app/index.html
+ *  - Standard window with hiddenInset title bar, 1400x900 default
+ *  - Minimal app menu wired to webview JS dispatch
+ */
+import { BrowserWindow, ApplicationMenu } from "electrobun/bun";
+import { $ } from "bun";
+import { join } from "node:path";
+
+// ── Config ────────────────────────────────────────────────────────────────────
+const APP_NAME = process.env.APP_NAME ?? "OmniRoute";
+// Bundled fallback page (polls + redirects to the live dev server).
+const RENDERER_URL = "views://app/index.html";
+// Live dev server (HMR) the window navigates to once reachable.
+const DEV_URL = process.env.RENDERER_URL ?? "http://localhost:3000";
+
+/**
+ * Path to process-compose.yml (absolute or relative to CWD).
+ * Set SERVICES_COMPOSE_FILE env var, e.g.:
+ *   SERVICES_COMPOSE_FILE=/path/to/repo/process-compose.yml
+ * Leave unset to skip service boot.
+ */
+const SERVICES_COMPOSE_FILE = process.env.SERVICES_COMPOSE_FILE;
+
+// ── Service boot ─────────────────────────────────────────────────────────────
+async function bootServices(): Promise<void> {
+  if (!SERVICES_COMPOSE_FILE) {
+    console.log(`[${APP_NAME}] SERVICES_COMPOSE_FILE not set — skipping service boot`);
+    return;
+  }
+  console.log(`[${APP_NAME}] Booting services: process-compose up -d`);
+  try {
+    const result = await $`process-compose up -d --config ${SERVICES_COMPOSE_FILE}`.quiet();
+    console.log(`[${APP_NAME}] Services:`, result.text().trim());
+  } catch (err) {
+    console.warn(
+      `[${APP_NAME}] process-compose boot skipped (not found or services already running):`,
+      (err as Error).message
+    );
+  }
+}
+
+// ── Window ───────────────────────────────────────────────────────────────────
+function createMainWindow(): BrowserWindow {
+  const win = new BrowserWindow({
+    title: APP_NAME,
+    url: RENDERER_URL,
+    frame: {
+      x: 0,
+      y: 0,
+      width: parseInt(process.env.WINDOW_WIDTH ?? "1400"),
+      height: parseInt(process.env.WINDOW_HEIGHT ?? "900"),
+    },
+    titleBarStyle: "hiddenInset",
+  });
+  try {
+    win.webview.executeJavascript(`window.__RENDERER_URL__ = ${JSON.stringify(DEV_URL)};`);
+  } catch {
+    /* webview not ready yet — fallback page uses its baked-in default */
+  }
+  return win;
+}
+
+// ── Menu ─────────────────────────────────────────────────────────────────────
+function setupMenu(win: BrowserWindow): void {
+  ApplicationMenu.setApplicationMenu([
+    {
+      label: APP_NAME,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        { role: "services" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    },
+    {
+      label: "Edit",
+      submenu: [
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "selectAll" },
+      ],
+    },
+    {
+      label: "View",
+      submenu: [
+        { role: "reload" },
+        { role: "forceReload" },
+        { role: "toggleDevTools" },
+        { type: "separator" },
+        { role: "togglefullscreen" },
+      ],
+    },
+    // Add app-specific menus below this line
+    // Example — dispatch to webview via executeJavaScript:
+    // {
+    //   label: "File",
+    //   submenu: [
+    //     {
+    //       label: "New",
+    //       accelerator: "CmdOrCtrl+N",
+    //       click: () => win.webview.executeJavaScript("window.__app?.onNew?.()"),
+    //     },
+    //   ],
+    // },
+  ]);
+}
+
+// ── Bootstrap ────────────────────────────────────────────────────────────────
+async function main(): Promise<void> {
+  await bootServices();
+  const win = createMainWindow();
+  setupMenu(win);
+  console.log(`[${APP_NAME}] Launched → ${DEV_URL} (fallback ${RENDERER_URL})`);
+}
+
+main().catch((err) => {
+  console.error(`[${APP_NAME}] Fatal:`, err);
+  process.exit(1);
+});

--- a/desktop-electrobun/src/views/index.html
+++ b/desktop-electrobun/src/views/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OmniRoute</title>
+    <style>
+      html, body { margin: 0; height: 100%; background: #0b0e14; color: #e6e6e6;
+        font: 15px/1.5 system-ui, sans-serif; display: grid; place-items: center; }
+      .card { text-align: center; max-width: 28rem; padding: 2rem; }
+      code { background: #1b2030; padding: 2px 6px; border-radius: 4px; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>OmniRoute</h1>
+      <p>Waiting for the dev server at <code id="u"></code>.</p>
+      <p>Start it, then this native window reloads with HMR.</p>
+    </div>
+    <script>
+      const url = (window.__RENDERER_URL__) || "http://localhost:3000";
+      document.getElementById("u").textContent = url;
+      (function poll() {
+        fetch(url, { mode: "no-cors" })
+          .then(() => { location.href = url; })
+          .catch(() => setTimeout(poll, 1000));
+      })();
+    </script>
+  </body>
+</html>

--- a/desktop-electrobun/tsconfig.json
+++ b/desktop-electrobun/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "lib": ["ESNext"],
+    "types": ["bun-types"],
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "electrobun.config.ts"]
+}


### PR DESCRIPTION
## **User description**
Native Electrobun WebView2 desktop shell for OmniRoute, wrapping the Next.js dev server (:3000) with live reload.

- Added under `desktop-electrobun/` from the phenotype-tooling electrobun-shell template (adopt.sh).
- Self-contained fallback page polls + redirects to the dev URL, so the launcher opens a genuine native window (not a browser).
- `bun install && bun run build` → `build/dev-win-x64/OmniRoute-dev/bin/launcher.exe` (verified on win-x64, exit 0; full native bundle incl. WebView2Loader.dll, libNativeWrapper.dll).

Makes the Phenotype Apps Start-Menu launcher point at a real native app. DO NOT MERGE pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Greenfield desktop wrapper with no changes to existing app code; optional local `process-compose` invocation is dev-only and failures are logged, not fatal.
> 
> **Overview**
> Adds a new **`desktop-electrobun/`** package that wraps the web UI in a native **Electrobun** window instead of opening a browser, aimed at Phenotype Start-Menu style launchers.
> 
> The main process opens a **1400×900** window on a bundled **`views://app/index.html`** splash that polls **`RENDERER_URL`** (default **`http://localhost:3000`**) and navigates there once the dev server responds, so HMR works in the native WebView. Optional **`SERVICES_COMPOSE_FILE`** runs **`process-compose up -d`** on startup; **`.env.example`**, **`justfile`**, and **`electrobun build` / `build:release`** scripts support dev and packaged builds (**OmniRoute**, **`com.phenotype.omniroute`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21b5eec48e7adf884563003a11d4d165cb3b8265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a native Electrobun desktop shell for OmniRoute with live reload**

### What Changed
- Added a native desktop window that opens OmniRoute inside the app instead of a browser
- The window starts on a built-in waiting screen, then switches to the local dev server as soon as it is available so hot reload works
- Added optional startup of local services when a compose file path is provided
- Included desktop setup files, build commands, and a sample environment file for running and packaging the shell

### Impact
`✅ Native desktop launch instead of browser launch`
`✅ Live reload inside the desktop window`
`✅ Easier local startup with optional service boot`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
