### PR TITLE
docs: add journey-traceability standard

### DIFF
--- a/docs/ops/journey-traceability.md
+++ b/docs/ops/journey-traceability.md
@@ -1,0 +1,77 @@
+# Journey Traceability
+
+Implements the phenotype-infra journey-traceability standard for OmniRoute as the canonical routing framework for the Phenotype org.
+
+## Traceability Model
+
+Every user-facing or operator-facing flow should be traceable across:
+
+1. **FR/NFR** — requirement ID and user story.
+2. **Spec/ADR** — acceptance criteria, routing invariants, and non-regression constraints.
+3. **Docs** — operator/user documentation and rich media placeholders.
+4. **Code** — API route, handler, executor, provider adapter, MCP tool, or desktop/UI surface implementing the flow.
+5. **Tests/Gates** — unit, integration, BDD, typecheck, lint, coverage, and journey verification acting as autograders.
+6. **Evidence** — journey manifest, recording/keyframes, and evaluation verdict.
+
+## User-Facing Flows
+
+| Flow | Requirement | Implementation surface | Autograder gates | Evidence status |
+| --- | --- | --- | --- | --- |
+| Chat request routes through fallback providers | FR-OMNI-CHAT-001, NFR-OMNI-RELIABILITY-001 | `src/app/api/v1/`, `open-sse/handlers/`, provider executors | unit tests, provider fixture tests, typecheck, BDD journey, eval verdict | Stubbed |
+| Operator reviews provider health and routing state | FR-OMNI-HEALTH-001, NFR-OMNI-OBSERVABILITY-001 | dashboard health screens, provider status docs, routing metrics/logs | UI smoke, metric/log assertions, journey manifest | Stubbed |
+| MCP tool invocation succeeds through the gateway | FR-OMNI-MCP-001, NFR-OMNI-CONTRACT-001 | MCP Server tools, API handlers, tool registry | MCP contract tests, schema validation, journey eval | Stubbed |
+| Desktop/user config updates endpoint and provider settings | FR-OMNI-CONFIG-001, NFR-OMNI-USABILITY-001 | Electron/Desktop UI, settings screen, CLI config path | config tests, screenshot journey, accessibility checks | Stubbed |
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="animated-gif" subject="Chat fallback routing journey" journey="chat-fallback-routing" status="TODO" -->
+![Chat fallback routing — request, primary provider failure, fallback provider success, and final response](../assets/rich-media/omniroute/chat-fallback-routing.gif)
+
+*Expected capture: send an OpenAI-compatible chat request, simulate or fixture a primary-provider failure, show fallback selection, and verify final response plus provider trace metadata.*
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="Provider health dashboard" journey="provider-health-dashboard" status="TODO" -->
+![Provider health dashboard — available providers, degraded providers, routing policy, and last-check timestamp](../assets/rich-media/omniroute/provider-health-dashboard.png)
+
+*Expected capture: open the dashboard health/provider view, annotate stale/degraded provider states, freshness timestamp, and operator remediation action.*
+
+<!-- RICH-MEDIA-STUB type="journey-eval" subject="MCP tool invocation contract verdict" journey="mcp-tool-invocation" status="TODO" -->
+![MCP tool invocation verdict — tool request, schema validation, response, and eval verdict](../assets/rich-media/omniroute/mcp-tool-invocation.png)
+
+*Expected capture: invoke a representative MCP tool through OmniRoute, validate request/response schema, and attach a pass/fail verdict for FR-OMNI-MCP-001 and NFR-OMNI-CONTRACT-001.*
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="Endpoint and provider settings update" journey="endpoint-provider-settings" status="TODO" -->
+![Endpoint and provider settings — endpoint URL, provider key state, validation feedback, and save result](../assets/rich-media/omniroute/endpoint-provider-settings.png)
+
+*Expected capture: update endpoint/provider settings in the UI or CLI, show validation feedback, and prove the saved configuration affects a subsequent request.*
+
+## Journey Manifests
+
+Journey manifests should live in `docs/journeys/manifests/` and include:
+
+- FR/NFR IDs covered by the journey;
+- API endpoint, CLI command, UI route, or MCP tool entrypoint used to reproduce the flow;
+- provider fixtures or mock configuration needed for deterministic replay;
+- expected screenshots/GIFs/keyframes;
+- tests and gates that must pass before the journey is accepted;
+- eval verdict schema and pass/fail criteria.
+
+## Autograder Gates
+
+Minimum gates before marking a journey complete:
+
+- `npm run lint` for style and static checks;
+- `npm run typecheck:core` for TypeScript correctness;
+- provider and handler unit tests for routing behavior;
+- MCP contract tests for tool requests/responses;
+- BDD journey replay for user-visible and operator-facing flows;
+- doc link validation for every referenced rich media asset;
+- journey manifest validation via `phenotype-journey verify` when available;
+- eval verdict linked to the FR/NFR IDs in the manifest.
+
+## Status
+
+- [x] Identify initial user-facing and operator-facing flows
+- [x] Stub rich media embeds for expected screenshots/GIFs/evals
+- [ ] Author manifests in `docs/journeys/manifests/`
+- [ ] Record journey captures for each flow
+- [ ] Run `phenotype-journey verify` in CI


### PR DESCRIPTION
## **User description**
## Summary
- Add `docs/ops/journey-traceability.md` implementing the phenotype-infra journey-traceability standard.
- Map OmniRoute user-facing flows (chat routing, provider health, MCP tool invocation, desktop config) to FR/NFR IDs, implementation surface, autograder gates, and evidence stubs.

## Test plan
- [x] Inspected diff locally
- [ ] CI unavailable due to account Actions billing constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime, auth, or routing code changes.
> 
> **Overview**
> Adds **`docs/ops/journey-traceability.md`**, documenting how OmniRoute will satisfy the phenotype-infra journey-traceability standard (FR/NFR → spec → docs → code → tests → evidence).
> 
> The doc defines a **six-layer traceability model** and a table for four initial flows—chat fallback routing, provider health, MCP tool invocation, and endpoint/provider config—each tied to FR/NFR IDs, expected implementation surfaces, autograder gates, and **Stubbed** evidence status. It also adds **TODO rich-media stubs** (GIF/screenshots under `docs/assets/rich-media/omniroute/`), expectations for manifests in `docs/journeys/manifests/`, minimum CI/test gates (lint, typecheck, BDD, `phenotype-journey verify`), and a checklist marking flow identification and media stubs done while manifests, captures, and CI verify remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb0d595ebec770b752f41d7ef9183d386383b76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Document the journey traceability standard for OmniRoute**

### What Changed
- Adds a guide that maps key OmniRoute flows to requirements, design docs, code areas, tests, and evidence
- Lists the initial flows covered: chat fallback routing, provider health, MCP tool invocation, and endpoint/provider settings
- Defines the expected rich media, journey manifests, and validation checks needed before a flow is marked complete

### Impact
`✅ Clearer journey tracking`
`✅ Easier release verification`
`✅ Fewer missed test and evidence steps`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
