### PR TITLE
chore(workflows): OmniRoute safe audit normalization (r3)

### DIFF
--- a/.github/workflows/lock-released-branch.yml
+++ b/.github/workflows/lock-released-branch.yml
@@ -1,6 +1,17 @@
 name: Lock released branch
+
 on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - "release/v*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag of the released version (e.g. v3.8.2)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -27,18 +38,6 @@ concurrency:
 # lock step will fail loudly (which is what we want — silent failure caused the
 # v3.8.3 incident on 2026-05-26 where 6 commits landed post-release).
 
-on:
-  release:
-    types: [published]
-  push:
-    branches:
-      - "release/v*"
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag of the released version (e.g. v3.8.2)"
-        required: true
-        type: string
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
   # Job 1 — Lock the release branch when a Release is published.
@@ -106,7 +105,7 @@ jobs:
     steps:
       - name: Reject push if matching release tag exists
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           REF: ${{ github.ref_name }}
         run: |


### PR DESCRIPTION
## **User description**
## Summary
- Audit-normalized 1 workflow files in `OmniRoute` (round 3).
- All files parse-validated; no placeholder SHA refs.

## Test plan
- [x] YAML parsed locally for each touched file
- [x] SHA refs verified against target repositories
- [ ] CI unavailable due to account Actions billing constraint

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic workflow reordering plus an equivalent default token reference; no change to lock logic or permissions model.
> 
> **Overview**
> **Restructures** `lock-released-branch.yml` so triggers and metadata follow a consistent order: `on:` (release published, `release/v*` pushes, manual tag input) sits near the top, with the Hard Rule #18 comment block moved below `concurrency` instead of splitting the trigger section.
> 
> **Updates** the preventive guard job (`guard-no-push-after-release`) to authenticate GitHub API tag checks with `${{ github.token }}` instead of `${{ secrets.GITHUB_TOKEN }}` — same default token, aligned with common Actions conventions. Branch-lock behavior and job conditions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5a23e077aa76159648666f5a7fb161976013d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Keep release branch locking workflow ordered and reliable**

### What Changed
- Reordered the release-lock workflow so its triggers and notes are grouped clearly at the top
- Kept the release publish and release branch push checks in place to lock shipped branches and reject late pushes
- Switched the push guard to use the standard built-in GitHub token reference, with the same behavior

### Impact
`✅ Clearer release-branch protection`
`✅ Fewer workflow setup issues`
`✅ Safer detection of post-release pushes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
