### PR TITLE
chore(OmniRoute): add minimal CODEOWNERS

### DIFF
--- a/.github/workflows/lock-released-branch.yml
+++ b/.github/workflows/lock-released-branch.yml
@@ -1,6 +1,17 @@
 name: Lock released branch
+
 on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - "release/v*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag of the released version (e.g. v3.8.2)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -27,18 +38,6 @@ concurrency:
 # lock step will fail loudly (which is what we want — silent failure caused the
 # v3.8.3 incident on 2026-05-26 where 6 commits landed post-release).
 
-on:
-  release:
-    types: [published]
-  push:
-    branches:
-      - "release/v*"
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag of the released version (e.g. v3.8.2)"
-        required: true
-        type: string
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
   # Job 1 — Lock the release branch when a Release is published.
@@ -106,7 +105,7 @@ jobs:
     steps:
       - name: Reject push if matching release tag exists
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           REF: ${{ github.ref_name }}
         run: |

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS — OmniRoute
+# Default reviewers for changes in this repository.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Fallback reviewer for the whole repository
+*           @KooshaPari


### PR DESCRIPTION
## **User description**
Adds minimal CODEOWNERS defaulting to org owner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are repo governance and workflow layout/token spelling only, with no application or security logic changes.
> 
> **Overview**
> Adds a root **CODEOWNERS** file so every path defaults to **@KooshaPari** as the fallback reviewer for the OmniRoute repo.
> 
> In **lock-released-branch.yml**, the workflow **`on:`** block (release published, `release/v*` pushes, and manual tag input) is moved to the top of the file and the long Hard Rule #18 comment sits above **`jobs:`** instead of between triggers and jobs. The **guard-no-push-after-release** job now sets **`GH_TOKEN`** to **`${{ github.token }}`** instead of **`${{ secrets.GITHUB_TOKEN }}`**, matching other workflows; behavior for read-only tag checks should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb1a821ab053a708664ef3ce9af15362a55d34f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a default reviewer and keep the release-branch lock workflow consistent**

### What Changed
- Added a repository-wide CODEOWNERS file so all changes fall back to `@KooshaPari` for review
- Kept the release-branch lock workflow trigger setup in a clearer order
- Switched the branch-lock check to use the built-in workflow token when looking for matching release tags

### Impact
`✅ Clearer review routing`
`✅ Fewer missed branch-lock checks`
`✅ Safer release-branch protection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
