### PR TITLE
chore(workflows): OmniRoute safe audit normalization (r5)

### DIFF
--- a/.github/workflows/lock-released-branch.yml
+++ b/.github/workflows/lock-released-branch.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       - name: Reject push if matching release tag exists
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           REF: ${{ github.ref_name }}
         run: |


### PR DESCRIPTION
## **User description**
## Summary
- Audit-normalized 1 workflow file in OmniRoute (round 5).
- File parses cleanly, no placeholder SHA refs.

## Test plan
- [x] YAML parsed locally
- [x] SHA refs verified
- [ ] CI unavailable due to account Actions billing constraint

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-token expression swap in a read-only guard job; no change to branch-lock credentials or application logic.
> 
> **Overview**
> In **`lock-released-branch.yml`**, the **`guard-no-push-after-release`** job now sets **`GH_TOKEN`** from **`${{ github.token }}`** instead of **`${{ secrets.GITHUB_TOKEN }}`**.
> 
> That aligns this workflow with other repo workflows that pass the default Actions token via the **`github.token`** context. Behavior for the guard step (read-only **`gh api`** checks for an existing release tag) should be unchanged; **`lock-branch`** still uses **`secrets.BRANCH_LOCK_TOKEN`** for branch protection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 267efa27b4cfdbfbd136e9e64b1ccf0320a68536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Keep the release-branch guard using the default Actions token

### What Changed
- The release-tag check now uses the workflow’s built-in GitHub token for its read-only check
- Branch protection handling remains unchanged

### Impact
`✅ Fewer release-guard auth failures`
`✅ Reliable push blocking after release`
`✅ Safer release branch protection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
