### PR TITLE
chore: normalize root .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,4 @@
-# EditorConfig — Phenotype org canonical
-# https://editorconfig.org
+# EditorConfig — https://editorconfig.org
 root = true
 
 [*]
@@ -10,9 +9,6 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
-[*.{rs,toml,py,go,md,yaml,yml,json,html,css,scss}]
-indent_size = 4
-
 [*.{ts,tsx,js,jsx,mjs,cjs}]
 indent_size = 2
 
@@ -20,4 +16,4 @@ indent_size = 2
 indent_style = tab
 
 [*.md]
-trim_trailing_whitespace = false  # trailing spaces = line break in Markdown
+trim_trailing_whitespace = false


### PR DESCRIPTION
Normalize the root .editorconfig file: remove redundant sections, fix encoding artifacts, and keep essential rules.