### PR TITLE
chore: normalize root .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,11 +6,8 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-indent_style = space
-indent_size = 4
 trim_trailing_whitespace = true
-
-[*.{rs,toml,py,go,md,yaml,yml,json,html,css,scss}]
+indent_style = space
 indent_size = 4
 
 [*.{ts,tsx,js,jsx,mjs,cjs}]
@@ -20,4 +17,4 @@ indent_size = 2
 indent_style = tab
 
 [*.md]
-trim_trailing_whitespace = false  # trailing spaces = line break in Markdown
+trim_trailing_whitespace = false


### PR DESCRIPTION
Normalize root .editorconfig: deduplicate indent_size rules, remove redundant file extensions, and keep canonical formatting.