### PR TITLE
layer: chore/gitignore-hardening — chore: harden .gitignore for build/cache artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,100 @@ scripts/i18n/_pending-keys.json
 # Added by cargo
 
 /target
+
+# === Hardened build/cache artifacts ===
+
+# Python
+__pycache__/
+*.py[cod]
+*.class
+*.egg-info/
+.eggs/
+.pytest_cache/
+.mypy_cache/
+.tox/
+.venv/
+venv/
+env/
+ENV/
+
+# General cache / temp
+.cache/
+*.tmp
+tmp/
+temp/
+*.temp
+
+# Build output (cross-platform)
+dist/
+build/
+out/
+site/
+docs/_build/
+
+# Compiled binaries / objects
+*.o
+*.a
+*.so
+*.dylib
+*.dll
+*.exe
+*.class
+*.jar
+
+# IDE / editor
+.vscode/
+*.swp
+*.swo
+*~
+*.sublime-*
+
+# OS
+Thumbs.db
+desktop.ini
+ehthumbs.db
+
+# JS/TS tooling caches
+.eslintcache
+.stylelintcache
+.nyc_output/
+.parcel-cache/
+.rpt2_cache/
+.rts2_cache_*
+
+# Framework / monorepo caches
+.turbo/
+.nx/
+.svelte-kit/
+.astro/
+.nuxt/
+.output/
+.wrangler/
+.netlify/
+.firebase/
+.expo/
+.metro/
+
+# Package manager stores
+vendor/
+bower_components/
+.pnpm-store/
+.npm/
+.yarn-integrity
+
+# Runtime / lock files
+*.pid
+*.seed
+*.pid.lock
+.lock-wscript
+.node_repl_history
+
+# Infrastructure
+.terraform/
+*.tfstate
+*.tfstate.*
+
+# Misc generated
+*.bak
+*.orig
+*.rej


### PR DESCRIPTION
Layered PR: `chore/gitignore-hardening` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ignore-list-only change with no runtime impact; the only caveat is broader patterns like `build/`/`dist/` could hide untracked dirs that some workflows expect to see locally.
> 
> **Overview**
> Expands **`.gitignore`** with a dedicated **“Hardened build/cache artifacts”** section so local and CI-generated junk is less likely to be committed accidentally.
> 
> The new rules cover **Python** caches and virtualenvs, **general temp/cache** paths, **cross-platform build output** (`dist/`, `build/`, `site/`, `docs/_build/`, etc.), **compiled binaries**, **IDE/editor** droppings (including **`.vscode/`**), extra **OS** files, **JS/TS tooling caches**, **framework/monorepo** caches (Turbo, Nx, SvelteKit, etc.), **package manager stores**, **runtime pid/lock** files, **Terraform** state, and common **backup/patch** suffixes (`*.bak`, `*.orig`, `*.rej`).
> 
> This does not change application code or runtime behavior—only what Git ignores. Some patterns (e.g. root-level **`build/`** vs the existing **`/build`**) are slightly broader than before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb760716ffab39695482a70f6ea90b23865bb01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->