### PR TITLE
layer: test/cover-5 — test: add focused unit test for collectCliToolChecks in doct

### DIFF
--- a/tests/unit/cli-helper/doctor-checks.test.ts
+++ b/tests/unit/cli-helper/doctor-checks.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, before } from "node:test";
+import assert from "node:assert";
+import { collectCliToolChecks } from "../../../src/lib/cli-helper/doctor/checks.ts";
+import * as toolDetector from "../../../src/lib/cli-helper/tool-detector.ts";
+
+describe("doctor checks - collectCliToolChecks", () => {
+  before(() => {
+    // @ts-expect-error - internal test hook
+    toolDetector.__setExecFileImpl(async (cmd) => {
+      if (cmd === "claude") {
+        return { stdout: "v0.9.0\n" };
+      }
+      if (cmd === "codex") {
+        return { stdout: "v1.2.3\n" };
+      }
+      if (cmd === "which") {
+        return { stdout: "/usr/bin/claude\n" };
+      }
+      throw new Error("Command not found");
+    });
+  });
+
+  it("returns warn for uninstalled tools", async () => {
+    const results = await collectCliToolChecks();
+    const opencode = results.find((r) => r.name === "CLI: OpenCode");
+    assert.ok(opencode, "Expected OpenCode check result");
+    assert.strictEqual(opencode.status, "warn");
+    assert.ok(opencode.message.includes("not installed"));
+    assert.strictEqual(opencode.details.installed, false);
+  });
+
+  it("returns warn for installed but unconfigured tools", async () => {
+    const results = await collectCliToolChecks();
+    const claude = results.find((r) => r.name === "CLI: Claude Code");
+    assert.ok(claude, "Expected Claude Code check result");
+    assert.strictEqual(claude.status, "warn");
+    assert.ok(claude.message.includes("not configured"));
+    assert.strictEqual(claude.details.configured, false);
+  });
+
+  it("returns consistent DoctorCheckResult shape for every tool", async () => {
+    const results = await collectCliToolChecks();
+    assert.ok(results.length > 0, "Expected at least one check result");
+    for (const r of results) {
+      assert.ok(r.name.startsWith("CLI: "), `Expected CLI prefix in name: ${r.name}`);
+      assert.ok(["ok", "warn", "fail"].includes(r.status), `Expected valid status: ${r.status}`);
+      assert.strictEqual(typeof r.message, "string");
+      assert.strictEqual(typeof r.details, "object");
+      assert.ok("id" in r.details);
+    }
+  });
+});


### PR DESCRIPTION
## **User description**
Layered PR: `test/cover-5` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications.
> 
> **Overview**
> Adds **`tests/unit/cli-helper/doctor-checks.test.ts`** with focused coverage for **`collectCliToolChecks`**.
> 
> Tests stub **`toolDetector.__setExecFileImpl`** so doctor checks run without real CLI binaries. They assert **warn** when a tool is missing (OpenCode / “not installed”), **warn** when a tool is present but not configured (Claude Code), and that every result matches the **`DoctorCheckResult`** shape (`CLI:` name prefix, status, message, **`details.id`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9539f30039dbc41fae84a8d19b881c62fa505ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Add focused coverage for CLI doctor checks

### What Changed
- Adds a unit test for CLI doctor checks without needing real installed tools
- Verifies missing tools are reported with a warning and a clear “not installed” message
- Verifies installed but unconfigured tools are reported with a warning and a clear “not configured” message
- Confirms every doctor check result includes the expected name, status, message, and details fields

### Impact
`✅ More reliable CLI doctor checks`
`✅ Fewer false test failures from missing local tools`
`✅ Clearer coverage for tool status reporting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
