### PR TITLE
layer: test/onefn2 — test: add unit tests for batch-utils mapBatchApiToRecord and

### DIFF
--- a/tests/unit/batch-utils.test.ts
+++ b/tests/unit/batch-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { mapBatchApiToRecord, mapFileApiToRecord } from "@/app/(dashboard)/dashboard/batch/batch-utils";
+
+describe("mapBatchApiToRecord", () => {
+  it("maps a full batch API response to a BatchRecord with request counts", () => {
+    const apiResponse = {
+      id: "batch_123",
+      endpoint: "/v1/chat/completions",
+      completion_window: "24h",
+      status: "in_progress",
+      input_file_id: "file_in",
+      output_file_id: "file_out",
+      error_file_id: "file_err",
+      created_at: 1700000000,
+      in_progress_at: 1700000100,
+      expires_at: 1700086400,
+      finalizing_at: null,
+      completed_at: null,
+      failed_at: null,
+      expired_at: null,
+      cancelling_at: null,
+      cancelled_at: null,
+      request_counts: { total: 100, completed: 50, failed: 2 },
+      metadata: { key: "value" },
+      errors: null,
+      model: "gpt-4",
+      usage: null,
+    };
+
+    const result = mapBatchApiToRecord(apiResponse);
+
+    expect(result.id).toBe("batch_123");
+    expect(result.endpoint).toBe("/v1/chat/completions");
+    expect(result.completionWindow).toBe("24h");
+    expect(result.status).toBe("in_progress");
+    expect(result.inputFileId).toBe("file_in");
+    expect(result.outputFileId).toBe("file_out");
+    expect(result.errorFileId).toBe("file_err");
+    expect(result.createdAt).toBe(1700000000);
+    expect(result.inProgressAt).toBe(1700000100);
+    expect(result.expiresAt).toBe(1700086400);
+    expect(result.finalizingAt).toBeNull();
+    expect(result.completedAt).toBeNull();
+    expect(result.failedAt).toBeNull();
+    expect(result.expiredAt).toBeNull();
+    expect(result.cancellingAt).toBeNull();
+    expect(result.cancelledAt).toBeNull();
+    expect(result.requestCountsTotal).toBe(100);
+    expect(result.requestCountsCompleted).toBe(50);
+    expect(result.requestCountsFailed).toBe(2);
+    expect(result.metadata).toEqual({ key: "value" });
+    expect(result.errors).toBeNull();
+    expect(result.model).toBe("gpt-4");
+    expect(result.usage).toBeNull();
+  });
+
+  it("defaults request_counts to 0 when missing or partially missing", () => {
+    const apiResponse = {
+      id: "batch_456",
+      endpoint: "/v1/embeddings",
+      completion_window: "24h",
+      status: "completed",
+      input_file_id: "file_in",
+      output_file_id: "file_out",
+      error_file_id: null,
+      created_at: 1700000000,
+      in_progress_at: null,
+      expires_at: null,
+      finalizing_at: null,
+      completed_at: 1700001000,
+      failed_at: null,
+      expired_at: null,
+      cancelling_at: null,
+      cancelled_at: null,
+      request_counts: { total: 10, completed: 10 },
+      metadata: null,
+      errors: null,
+      model: null,
+      usage: null,
+    };
+
+    const result = mapBatchApiToRecord(apiResponse);
+
+    expect(result.requestCountsTotal).toBe(10);
+    expect(result.requestCountsCompleted).toBe(10);
+    expect(result.requestCountsFailed).toBe(0);
+  });
+});
+
+describe("mapFileApiToRecord", () => {
+  it("maps a file API response to a FileRecord", () => {
+    const apiResponse = {
+      id: "file_abc",
+      filename: "batch.jsonl",
+      bytes: 2048,
+      purpose: "batch",
+      created_at: 1700000000,
+      expires_at: 1700086400,
+    };
+
+    const result = mapFileApiToRecord(apiResponse);
+
+    expect(result.id).toBe("file_abc");
+    expect(result.filename).toBe("batch.jsonl");
+    expect(result.bytes).toBe(2048);
+    expect(result.purpose).toBe("batch");
+    expect(result.createdAt).toBe(1700000000);
+    expect(result.expiresAt).toBe(1700086400);
+  });
+});


### PR DESCRIPTION
## **User description**
Layered PR: `test/onefn2` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior modifications.
> 
> **Overview**
> Adds **Vitest** coverage in `tests/unit/batch-utils.test.ts` for the dashboard batch helpers **`mapBatchApiToRecord`** and **`mapFileApiToRecord`**.
> 
> Tests assert snake_case API payloads map to camelCase **`BatchRecord`** / **`FileRecord`** fields, including lifecycle timestamps and metadata. A second case locks in **`request_counts.failed`** defaulting to **0** when omitted from the API response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c036c0f3e5427cf109c8c36f83401eaa258b3820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add test coverage for batch and file data mapping**

### What Changed
- Added unit tests that verify batch API data is shown in the expected dashboard format, including timestamps, metadata, file links, and request counts.
- Locked in the fallback that treats a missing failed request count as zero.
- Added a test for file data mapping so file details continue to appear correctly.

### Impact
`✅ Safer batch data display`
`✅ Fewer missing-count errors`
`✅ More reliable file details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
