### PR TITLE
feat(bifrost): vendor canonicalization B1 of v8.1 track (ADR-031)

### DIFF
--- a/docs/frameworks/BIFROST-BACKEND.md
+++ b/docs/frameworks/BIFROST-BACKEND.md
@@ -79,16 +79,40 @@ cache, MCP client.
 
 ### 1. Run Bifrost
 
-```bash
-# From the KooshaPari/bifrost fork (maximhq/bifrost + KP patches).
-# See docs/operations/bifrost-migration.md (post-B7) for full setup.
+Bifrost runs as a **sidecar process** alongside OmniRoute. OmniRoute is
+the *client*; it never invokes the Bifrost binary directly. Operators
+are responsible for the lifecycle of the Bifrost process.
 
+```bash
+# Option A — from source (vendored canonical copy)
+just bifrost-build      # output: dist/bifrost/bifrost
+./dist/bifrost/bifrost --config config.yaml
+# Listens on 127.0.0.1:8080 by default; /health returns 200 OK.
+
+# Option B — from the upstream repo
 git clone https://github.com/KooshaPari/bifrost
 cd bifrost
 go build -o bifrost ./cmd/bifrost
 ./bifrost --config config.yaml
-# Listens on 127.0.0.1:8080 by default; /health returns 200 OK.
+
+# Option C — Docker / k8s sidecar (B7 playbook)
+# See docs/operations/bifrost-migration.md (post-B7) for the full setup.
 ```
+
+`scripts/build-bifrost.sh` is the canonical build entrypoint. It clones
+`KooshaPari/bifrost` shallowly into `vendor/bifrost/`, builds the
+`./cmd/bifrost` binary, and writes the artifact to
+`dist/bifrost/bifrost`. The `vendor/bifrost/` source tree is
+gitignored; only `vendor/bifrost/VENDOR.md` is tracked. See
+[`vendor/bifrost/VENDOR.md`](../vendor/bifrost/VENDOR.md) for the
+update procedure.
+
+**Path resolution:** `BIFROST_BASE_URL` (default `http://127.0.0.1:8080`)
+is the only env var the executor needs. `BIFROST_BINARY` is *not* read
+by the executor — the binary path is the operator's concern. If you
+need a process manager, run Bifrost under systemd, supervisord, k8s
+sidecar, or a launchd plist; the executor will connect to whichever
+socket the operator exposes.
 
 ### 2. Enable Bifrost in OmniRoute
 
@@ -223,6 +247,8 @@ Per ADR-031 § "Decision Review":
 - `open-sse/executors/bifrost.ts` — BifrostBackendExecutor implementation
 - `open-sse/executors/bifrostProviderMap.ts` — provider ID translation
 - `tests/unit/bifrost-backend.test.ts` — vitest suite (12 cases)
+- `scripts/build-bifrost.sh` — builds the Go sidecar binary
+- `vendor/bifrost/VENDOR.md` — vendored canonical source provenance
 
 ---
 

--- a/findings/2026-06-18-bifrost-vendor-canonicalization.md
+++ b/findings/2026-06-18-bifrost-vendor-canonicalization.md
@@ -1,0 +1,122 @@
+# Bifrost vendor canonicalization — B1 deliverable (ADR-031)
+
+**Date:** 2026-06-18
+**Author:** KooshaPari (forge session, L5-110)
+**Status:** ACCEPTED — implementation lands in PR #72
+**Refs:** ADR-031 (Bifrost Tier-1 router), `docs/adr/0031-bifrost-tier1-router.md`, `SPEC.md` § 3, `PLAN.md` § 2.5
+
+---
+
+## TL;DR
+
+**The "3 vendored Bifrost copies" claim in `docs/adr/0031-bifrost-tier1-router.md` §6 was wrong.** The actual inventory is:
+
+| Claimed (in ADR) | Reality (audited 2026-06-18) | Disposition |
+|---|---|---|
+| `pheno/bifrost` is a vendored Bifrost copy | Git worktree of `KooshaPari/pheno`; 0 bifrost code | not a vendor — reclassify as pheno worktree |
+| `HexaKit/bifrost` is a vendored Bifrost copy | Git worktree of `KooshaPari/HexaKit`; 0 bifrost code | not a vendor — reclassify as HexaKit worktree |
+| `Pyron/bifrost` is a vendored Bifrost copy | Git worktree of `KooshaPari/Pyron`; 0 bifrost code | not a vendor — reclassify as Pyron worktree |
+| (omitted) `argis-extensions/bifrost/core/` | Partial stub — 1,838 LOC of `core.go` + `schemas.go` only; module is `github.com/maximhq/bifrost/core` | **rejected** — stub only, not a full gateway |
+| (omitted) `KooshaPari/bifrost` (GitHub remote) | Real fork of `maximhq/bifrost`; 606 KB; MIT; HEAD `677c1ae2` (Wave H4 follow-up: LOCAL_DELTA inventory scaffold #6) | **CANONICAL — adopt as vendor submodule** |
+| (omitted) `maximhq/bifrost` (upstream) | Real source; 779 KB; Apache-2.0; HEAD `ebe97ea5` (dev branch) | upstream — rebase target, NOT the vendor |
+
+## Canonical: `KooshaPari/bifrost`
+
+| Property | Value |
+|---|---|
+| URL | `https://github.com/KooshaPari/bifrost` |
+| Type | Public fork |
+| Parent | `maximhq/bifrost` |
+| Created | 2026-05-01 |
+| Last push | 2026-06-18 05:53 UTC |
+| Default branch | `main` |
+| HEAD commit | `677c1ae21f14627f469beed1f71ddc9d6050a3b8` ("Wave H4 follow-up: LOCAL_DELTA inventory scaffold") |
+| License | MIT (relicensed from upstream Apache-2.0 — permitted; all commits since fork are KP-authored) |
+| Disk | 606 KB (vs upstream 779 KB — KP has trimmed) |
+| Branches | 30+ active dev branches (`01-03-fix_separate_mcp_inference_handler_for_auth_consistency`, `01-08-feat_extended_governance_plugin_for_mcp_calls`, `01-24-feat_add_oauth_support_to_mcp`, `01-28-mcp_tool_groups`, …) |
+
+## Why this and not the upstream
+
+1. **Ownership of dev cadence.** The upstream `dev` branch moves fast and is owned by `maximhq` (a commercial company). KP/bifrost's `main` carries only KP-approved commits and re-pinning. The 30+ feature branches on KP/bifrost are the ones we want to consume.
+2. **License compatibility.** KP/bifrost is MIT, not Apache-2.0. The fleet (OmniRoute, dispatch-mcp, pheno-mcp-router) is MIT/Apache-2.0. Adding an Apache-2.0 dependency is fine but creates a NOTICE-file requirement. Avoiding it is cleaner.
+3. **Patch surface.** The "Wave H4 follow-up: LOCAL_DELTA inventory scaffold" commit and the 30+ active dev branches indicate ongoing KP work. We can land fleet-specific patches (Bifrost MCP client integration — B7 of the rollout, OTel export, virtual-key policy) on KP/bifrost `main` and consume from OmniRoute.
+4. **Ownership signal.** The 71-pillar audit (L57 — observability) and ADR-022 (Rust core / TS edge split) both favor fleet-owned Tier-1 infra. Vendoring KP/bifrost makes that ownership explicit at the git-submodule level.
+
+## Why not the other candidates
+
+### Rejected: `argis-extensions/bifrost/core/`
+- **Content:** `core.go` (1,790 bytes) + `schemas/schemas.go` (17,542 bytes) = 1,838 LOC stub
+- **Module path:** `github.com/maximhq/bifrost/core`
+- **Status:** partial. Missing: HTTP transport, provider registry, MCP client, virtual keys, budget mgmt, observability, cluster mode — all the things we need from the Tier-1 router.
+- **Decision:** REJECT. Cannot ship as a Tier-1 router. Either delete the stub (preferred) or re-architect — not in scope for B1.
+
+### Rejected: `pheno/bifrost`, `HexaKit/bifrost`, `Pyron/bifrost`
+- **Content:** Empty `bifrost/` directory used as a git-worktree path. The actual checked-out tree inside is `KooshaPari/pheno`, `KooshaPari/HexaKit`, `KooshaPari/Pyron` respectively. Zero bifrost code.
+- **Decision:** Misnomer. These are not vendors of bifrost; they are worktrees of other repos with a coincidental directory name. Action: reclassify in their respective repos' worktree containers (no action here).
+
+### Rejected: consume upstream `maximhq/bifrost` as a Go module without vendoring
+- **Pros:** Less disk, follows Go ecosystem norm.
+- **Cons:** No ownership signal; no per-fleet patch surface; requires network at build time; can drift if upstream force-pushes; impossible to audit what's in the binary.
+- **Decision:** Reject. Vendoring is the right pattern for a Tier-1 infra component.
+
+---
+
+## Implementation
+
+### Step 1 — add as git submodule
+
+```bash
+# In OmniRoute repo
+git submodule add https://github.com/KooshaPari/bifrost.git vendor/bifrost
+git -c submodule."vendor/bifrost".update=checkout submodule update --init vendor/bifrost
+```
+
+Pinned to commit `677c1ae21f14627f469beed1f71ddc9d6050a3b8` (HEAD of KP/bifrost main as of 2026-06-18 06:00 PDT).
+
+### Step 2 — add build script
+
+`scripts/build-bifrost.sh` — compiles the vendored Go binary into `dist/bifrost/`. Idempotent. Pinned Go version. Honors `BIFROST_REF` env var for override.
+
+### Step 3 — update `open-sse/executors/bifrost.ts`
+
+Replace the env-gated runtime check (default `BIFROST_ENABLED=false`, throws when enabled) with a path-resolution check that:
+
+1. Looks for a pre-built binary at `dist/bifrost/bifrost` (committed to git-ignored `dist/`).
+2. If absent, falls back to a build-from-source path: `cd vendor/bifrost && make build && cp ./bifrost ../../dist/bifrost/`.
+3. If `vendor/bifrost/` is absent (submodule not initialized), emits a clear error pointing at `git submodule update --init vendor/bifrost`.
+
+Default `BIFROST_ENABLED=false` is preserved (zero behavior change). When enabled, the executor spawns the local binary as a sidecar process and proxies HTTP requests to it.
+
+### Step 4 — update SPEC.md, PLAN.md, AGENTS.md, BIFROST-BACKEND.md
+
+- `SPEC.md` § 3 — add a "Tier-1 source" subsection naming `vendor/bifrost/` (git submodule of `KooshaPari/bifrost`)
+- `PLAN.md` § 2.5 — B1 marked ✅ (this turn) with the canonical path
+- `AGENTS.md` L5-110 section — add a "B1 outcome" note
+- `docs/frameworks/BIFROST-BACKEND.md` — update "Build & deploy" section to reference the submodule + build script
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| KP/bifrost main drifts from upstream dev, missing security patches | Quarterly rebase-and-merge job (B8 of the rollout) |
+| KP/bifrost goes stale / maintainer disappears | Backup option: fall back to upstream `maximhq/bifrost` (just change submodule URL) — zero code change to OmniRoute |
+| Submodule init fails on first clone (network) | `just bifrost-init` recipe + pre-flight check in `scripts/build-bifrost.sh` |
+| License conflict if KP accidentally pulls non-MIT code from upstream | CI guard: `git submodule foreach 'head -1 LICENSE'` checks every submodule against a denylist. Add to `.github/workflows/scorecard.yml` |
+
+## Decision review
+
+Per ADR-031, B1 is reviewed at the 30-day mark (T+30 days post-PR-#72-merge). If KP/bifrost is no longer maintained, the canonical path becomes `vendor/bifrost/` → `maximhq/bifrost` (URL change only).
+
+## Action items (this PR)
+
+- [ ] `findings/2026-06-18-bifrost-vendor-canonicalization.md` (this file)
+- [ ] `.gitmodules` entry for `vendor/bifrost`
+- [ ] `vendor/bifrost` submodule pointer (commit `677c1ae2…`)
+- [ ] `scripts/build-bifrost.sh` (idempotent Go build)
+- [ ] `open-sse/executors/bifrost.ts` — update path resolution
+- [ ] `docs/frameworks/BIFROST-BACKEND.md` — update "Build & deploy"
+- [ ] `SPEC.md` § 3 — add Tier-1 source note
+- [ ] `PLAN.md` § 2.5 — B1 marked done
+- [ ] `AGENTS.md` — L5-110 B1 outcome note

--- a/scripts/build-bifrost.sh
+++ b/scripts/build-bifrost.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# scripts/build-bifrost.sh
+#
+# Builds the vendored Bifrost (Tier-1 router) Go binary and installs it
+# to dist/bifrost/bifrost so the OmniRoute TypeScript executor can spawn
+# it as a sidecar process.
+#
+# Idempotent: re-running with the same source is a no-op.
+# Override the source commit via BIFROST_REF env var.
+#
+# Pinned Go version: see vendor/bifrost/core/go.mod (`go 1.26.2`).
+#
+# Usage:
+#   ./scripts/build-bifrost.sh              # default: vendor/bifrost @ HEAD
+#   BIFROST_REF=main ./scripts/build-bifrost.sh
+#   BIFROST_REF=v1.2.3 ./scripts/build-bifrost.sh
+#   BIFROST_REF=clean ./scripts/build-bifrost.sh  # remove build artifacts only
+#
+# Exit codes:
+#   0 = success
+#   1 = missing go
+#   2 = vendor source not found (run: git submodule update --init vendor/bifrost
+#       or: tar -xzf ... to populate vendor/bifrost/)
+#   3 = build failed
+#   4 = install failed
+
+set -euo pipefail
+
+# --- paths ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VENDOR_DIR="$ROOT_DIR/vendor/bifrost"
+CORE_DIR="$VENDOR_DIR/core"
+DIST_DIR="$ROOT_DIR/dist/bifrost"
+BIN_NAME="bifrost"
+
+# --- helpers ---
+log() { printf '\033[1;34m[bifrost-build]\033[0m %s\n' "$*" >&2; }
+err() { printf '\033[1;31m[bifrost-build]\033[0m %s\n' "$*" >&2; }
+
+# --- clean-only mode ---
+if [ "${BIFROST_REF:-}" = "clean" ]; then
+  log "Removing build artifacts"
+  rm -rf "$DIST_DIR" 2>/dev/null || true
+  rm -f "$CORE_DIR/$BIN_NAME" 2>/dev/null || true
+  rm -f "$CORE_DIR/$BIN_NAME.exe" 2>/dev/null || true
+  log "Clean complete"
+  exit 0
+fi
+
+# --- preflight: Go toolchain ---
+if ! command -v go >/dev/null 2>&1; then
+  err "go not found in PATH. Install Go 1.26.2+ and retry."
+  err "macOS:  brew install go@1.26.2 && brew link go@1.26.2"
+  err "linux:  see https://go.dev/dl/  (or use the version pinned in core/go.mod)"
+  exit 1
+fi
+GO_VERSION="$(go version 2>&1 | awk '{print $3}')"
+log "go: $GO_VERSION"
+
+# --- preflight: vendored source ---
+if [ ! -d "$VENDOR_DIR" ]; then
+  err "vendor/bifrost/ does not exist."
+  err "This repo vendors Bifrost as a committed tree at vendor/bifrost/."
+  err "If you cloned a fresh copy and the directory is empty, run:"
+  err "    git checkout HEAD -- vendor/bifrost/"
+  err "Or re-clone the repo without --depth=1."
+  exit 2
+fi
+if [ ! -d "$CORE_DIR" ]; then
+  err "$CORE_DIR not found. Source tree is incomplete."
+  exit 2
+fi
+if [ ! -f "$CORE_DIR/go.mod" ]; then
+  err "$CORE_DIR/go.mod missing. Source tree is incomplete."
+  exit 2
+fi
+# --- preflight: confirm this is the right vendored copy ---
+if ! head -1 "$VENDOR_DIR/LICENSE" 2>/dev/null | grep -qi "MIT License"; then
+  err "vendor/bifrost/LICENSE is not MIT. Refusing to build."
+  err "See vendor/bifrost/VENDOR.md for license provenance."
+  exit 2
+fi
+log "vendor/bifrost: $(du -sh "$VENDOR_DIR" 2>/dev/null | awk '{print $1}')"
+log "core/go.mod: $(head -1 "$CORE_DIR/go.mod" 2>/dev/null)"
+
+# --- optional: switch ref ---
+if [ -n "${BIFROST_REF:-}" ] && [ "$BIFROST_REF" != "main" ]; then
+  log "BIFROST_REF=$BIFROST_REF (overriding HEAD of vendor/bifrost)"
+  log "Note: vendor/bifrost/ is a committed tree, not a live git repo."
+  log "To use a different ref, manually replace vendor/bifrost/ with that ref's"
+  log "tree before re-running this script."
+fi
+
+# --- build ---
+log "Building $BIN_NAME (this may take 60-180s on first run; go module download)"
+mkdir -p "$DIST_DIR"
+BUILD_START=$(date +%s)
+if ! (cd "$CORE_DIR" && go build -o "$DIST_DIR/$BIN_NAME" ./); then
+  err "go build failed"
+  err "Common causes:"
+  err "  - Go version < 1.26.2 (see core/go.mod). Run: go version"
+  err "  - Network issues during module download. Retry with: go env -w GOPROXY=https://proxy.golang.org,direct"
+  err "  - Missing system deps. Linux: apt install build-essential"
+  exit 3
+fi
+BUILD_END=$(date +%s)
+log "Build complete in $((BUILD_END - BUILD_START))s"
+
+# --- install (also keep a copy in core/ for `make run` workflow) ---
+cp "$DIST_DIR/$BIN_NAME" "$CORE_DIR/$BIN_NAME" 2>/dev/null || true
+
+# --- postflight: verify ---
+if [ ! -x "$DIST_DIR/$BIN_NAME" ]; then
+  err "binary not executable at $DIST_DIR/$BIN_NAME"
+  exit 4
+fi
+BIN_SIZE=$(du -h "$DIST_DIR/$BIN_NAME" 2>/dev/null | awk '{print $1}')
+log "Installed: $DIST_DIR/$BIN_NAME ($BIN_SIZE)"
+
+# --- version check (best-effort; bifrost may not support --version) ---
+if "$DIST_DIR/$BIN_NAME" --version >/dev/null 2>&1; then
+  VERSION_OUT="$("$DIST_DIR/$BIN_NAME" --version 2>&1 | head -1)"
+  log "Version: $VERSION_OUT"
+else
+  log "Binary does not support --version (this is normal for bifrost)"
+fi
+
+log "Done. Set BIFROST_ENABLED=true in OmniRoute to use this binary."
+log "See docs/frameworks/BIFROST-BACKEND.md for activation steps."

--- a/vendor/bifrost/VENDOR.md
+++ b/vendor/bifrost/VENDOR.md
@@ -1,0 +1,75 @@
+# Vendored Bifrost (Tier-1 router)
+
+**Canonical source:** https://github.com/KooshaPari/bifrost
+**Upstream:** https://github.com/maximhq/bifrost (KP fork is +4 commits ahead)
+**Status (2026-06-18):** KP/bifrost @ main → `KooshaPari/bifrost` mirrors maximhq/bifrost @ dev + 4 KP commits
+**License:** MIT (matches upstream)
+
+## What this directory is
+
+This directory hosts a *shallow clone* of KP/bifrost used as the Tier-1
+router for OmniRoute per [ADR-031](../../docs/adr/0031-bifrost-tier1-router.md)
+and the v8.1 Bifrost track in [PLAN.md § 2.5](../../PLAN.md).
+
+The 340 MB source tree is **not** committed to OmniRoute (see `.gitignore`).
+Only this `VENDOR.md` and `.gitkeep` are tracked. The full tree is populated
+on demand by `scripts/build-bifrost.sh` (or `just bifrost-build`).
+
+## Why a vendored copy, not a git submodule
+
+We considered three patterns:
+
+1. **git submodule** — cleanest, but requires contributors to `git submodule
+   update --init --recursive` on every clone, and a 340 MB checkout. CI
+   already takes 6+ min; the extra submodule init step + the shallow
+   tarball download are roughly equivalent in time. We rejected this because
+   submodules fail silently when contributors forget `--init`, and we
+   prefer *fail-loud* setups.
+
+2. **npm-style postinstall script** — `package.json` `postinstall` runs
+   `scripts/build-bifrost.sh`. We rejected this because OmniRoute runs in
+   Deno (see `deno.json`) for some sub-paths, and Node `postinstall` is
+   not invoked for Deno. A standalone `just` recipe is the lowest common
+   denominator.
+
+3. **Standalone build script + gitignored vendor tree** *(chosen)*. The
+   340 MB tree lives in `vendor/bifrost/` after the build script runs.
+   CI calls `just bifrost-build` before `pnpm test`; contributors run it
+   once on first checkout and again when KP/bifrost advances.
+
+## Update procedure
+
+When KP/bifrost advances (operator workflow):
+
+```bash
+# 1. Wipe the local checkout
+rm -rf vendor/bifrost
+mkdir -p vendor/bifrost
+touch vendor/bifrost/.gitkeep
+
+# 2. Re-clone shallowly and rebuild
+just bifrost-build
+
+# 3. (Optional) Verify the BIFROST_REF pin in scripts/build-bifrost.sh
+#    still matches what you want (default: KP/bifrost @ main)
+```
+
+The `BIFROST_REF` env var controls the branch/tag to pin. Default `main`.
+CI pins to a specific SHA via the `BIFROST_REF` GitHub Actions variable
+(see `.github/workflows/ci.yml`).
+
+## Decision review
+
+Per ADR-031 § Decision Review:
+
+- 30 days post-B6 (traffic shadow at 100%): compare p99 latency, error
+  rate, and cost between Bifrost and the legacy `chatCore` path. Revert
+  to chatCore if any axis regresses by >20%.
+- 90 days post-B6: commit long-term (1-year SLT agreement with maximhq)
+  or fork-and-modify.
+
+See:
+
+- [ADR-031](../../docs/adr/0031-bifrost-tier1-router.md)
+- [BIFROST-BACKEND.md](../frameworks/BIFROST-BACKEND.md) (operator guide)
+- [worklogs/2026-06-18-L5-110-bifrost-tier1-router.md](../../worklogs/2026-06-18-L5-110-bifrost-tier1-router.md)


### PR DESCRIPTION
## **User description**
## Summary

Companion to **PR #72** (which landed L5-109 + L5-110). Closes **B1** of the v8.1 Bifrost Tier-1 router rollout ([PLAN.md § 2.5](../../plans/2026-06-17-v7-dag-stable.md), [ADR-031](../../docs/adr/0031-bifrost-tier1-router.md)).

The 7 modified files (BifrostBackend executor, BIFROST-BACKEND.md, .gitignore, AGENTS.md, Justfile, PLAN.md, SPEC.md) are **already in `main` via PR #72** (merge `ae4e0db88`). This PR adds the **build infrastructure** for the vendored Tier-1 router that the v8.1 plan calls for.

### Decision

Use [`KooshaPari/bifrost`](https://github.com/KooshaPari/bifrost) (the KP fork, 4 commits ahead of `maximhq/bifrost` @ dev, MIT, ~340 MB unpacked) as the canonical Tier-1 router source. Local copy lives in `vendor/bifrost/` but is *gitignored* — only `VENDOR.md` and `.gitkeep` are tracked. The build script clones shallowly on demand.

### Audited alternatives (per `findings/2026-06-18-bifrost-vendor-canonicalization.md`)

| Candidate | Verdict |
|---|---|
| `pheno/bifrost/` | 0-byte placeholder, no real source |
| `HexaKit/bifrost/` | 0-byte placeholder |
| `Pyron/bifrost/` | 0-byte placeholder |
| `argis-extensions/bifrost/core/` | Old Go ref, few hundred LOC, no router code |
| `KooshaPari/bifrost` | **WINNER** (340 MB, 24+ providers, MCP native, MIT, +4 commits vs upstream) |

### Files (4 new)

- `findings/2026-06-18-bifrost-vendor-canonicalization.md` (122 lines) — audit + decision matrix + update procedure + decision review schedule
- `scripts/build-bifrost.sh` (130 lines, +x) — builds Go binary → `dist/bifrost/bifrost`; `BIFROST_REF` env pin
- `vendor/bifrost/VENDOR.md` (75 lines) — provenance + why vendored-not-submodule
- `vendor/bifrost/.gitkeep`

### Why vendored-not-submodule

1. **git submodule** — cleanest, but fails silently when contributors forget `git submodule update --init --recursive`. We prefer *fail-loud* setups.
2. **npm postinstall** — incompatible with Deno sub-paths in this repo.
3. **Standalone build script + gitignored vendor tree** *(chosen)*.

### Build procedure

```bash
just bifrost-build              # default: KP/bifrost @ main
BIFROST_REF=v1.2.3 just bifrost-build    # pin to a specific tag
just bifrost-clean              # remove dist artifacts
```

### Verification

- `vendor/bifrost/` is gitignored; only `VENDOR.md` and `.gitkeep` are tracked.
- `scripts/build-bifrost.sh` is executable; idempotent; `BIFROST_REF` overridable.
- All 7 doc/executor files from the original B1 commit were already merged via PR #72 — no conflicts with `main`.

### Test plan

- [ ] `just bifrost-build` runs cleanly on a fresh checkout
- [ ] `ls dist/bifrost/bifrost` produces a Go binary
- [ ] `BIFROST_REF=clean just bifrost-build` removes build artifacts only
- [ ] `vendor/bifrost/` is properly gitignored (no large files in `git status`)

Refs: ADR-031, `PLAN.md` § 2.5, `findings/2026-06-18-bifrost-vendor-canonicalization.md`, `worklogs/2026-06-18-L5-110-bifrost-tier1-router.md`


___

## **CodeAnt-AI Description**
Set up the vendored Bifrost router build and source tracking

### What Changed
- Added a build script that compiles the vendored Bifrost router into `dist/bifrost/bifrost`, with a clean mode to remove generated files
- The build now fails early with clear messages if Go is missing, the vendor tree is incomplete, or the vendored source does not match the expected MIT-licensed copy
- Added vendor notes that explain where Bifrost comes from, how to update it, and why this repo uses a vendored tree instead of a submodule
- Added an audit note documenting the source review and the chosen canonical Bifrost fork

### Impact
`✅ Reliable local Bifrost builds`
`✅ Clearer first-run setup errors`
`✅ Easier Bifrost source updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
