### PR TITLE
docs: Electrobun desktop spike scaffold (ADR-ECO-015)

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,0 +1,9 @@
+# OmniRoute desktop (canonical entry)
+
+This path is the **registry-canonical** desktop client location per [ADR-ECO-015](https://github.com/KooshaPari/phenotype-registry/blob/main/docs/adrs/ADR-ECO-015-hybrid-gateway-app-layer.md) (FFI + Electrobun spike).
+
+Implementation lives at the repo root until promotion is complete:
+
+**→ [`../../desktop-electrobun/`](../../desktop-electrobun/)**
+
+Work there; this directory is a redirect only (no duplicated source).

--- a/desktop-electrobun/README.md
+++ b/desktop-electrobun/README.md
@@ -1,0 +1,70 @@
+# OmniRoute desktop — Electrobun spike
+
+> **Status:** Selection-gate spike (ADR-ECO-015 hybrid gateway app layer)  
+> **Registry choice:** FFI + Electrobun → canonical path `apps/desktop/` (this tree promoted from repo root)
+
+Electrobun + Bun shell that wraps the OmniRoute web UI (`RENDERER_URL`, default `http://localhost:3000`) with optional one-click `process-compose` service boot. Existing Electron shell remains in [`../electron/`](../electron/) until this spike passes the gate below.
+
+## Selection gate
+
+Prototype must demonstrate all three before replacing Electron / absorbing vibeproxy client work:
+
+| # | Gate | Pass criteria |
+|---|------|----------------|
+| 1 | **Tray / menu-bar UX** | CLI proxy control (start/stop/status) from a native tray or menu-bar affordance — harvest patterns from [vibeproxy `apps/macos/`](https://github.com/automazeio/vibeproxy/tree/main/src) (menu-bar OAuth, status, local endpoint copy) |
+| 2 | **Local OpenAI endpoint** | App exposes or surfaces an OpenAI-compatible local base URL wired to phenotype-gateway planes (cliproxy++ / router), consumable by coding tools without extra config |
+| 3 | **macOS build** | Reproducible signed or ad-hoc `.app` from `bun run build:release` on macOS (P0). Linux build optional (P1) |
+
+Checklist:
+
+- [ ] Tray or menu-bar UX for CLI proxy control
+- [ ] OpenAI-compatible local endpoint to gateway planes
+- [ ] Reproducible macOS build (P0)
+- [ ] Linux build (P1, optional)
+
+## vibeproxy disposition
+
+Per ADR-ECO-015, **vibeproxy is ABSORB (redirect only)** — no third canonical desktop repo. Harvest reference UX from vibeproxy macOS client sources; do not fork or duplicate large Swift trees here.
+
+| Harvest | Source |
+|---------|--------|
+| Menu-bar / tray patterns | [automazeio/vibeproxy](https://github.com/automazeio/vibeproxy) — `src/` (Swift menu-bar app; registry audit label: `apps/macos/`) |
+| OAuth + proxy UX flows | Same repo — status indicators, local endpoint surfacing |
+| Router UI + deploy | OmniRoute dashboard + existing `electron/` integration |
+
+## Quick start
+
+```bash
+cd desktop-electrobun   # or apps/desktop/ (redirect)
+cp .env.example .env
+bun install
+bun dev                 # or: just dev
+```
+
+Optional service boot — set in `.env`:
+
+```bash
+SERVICES_COMPOSE_FILE=/path/to/OmniRoute/process-compose.yml
+```
+
+Build:
+
+```bash
+bun run build           # dev bundle
+bun run build:release   # release .app (macOS)
+```
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `src/main.ts` | Electrobun main process — window, menu, optional process-compose boot |
+| `src/views/` | Bundled fallback renderer (polls dev server) |
+| `electrobun.config.ts` | App identity, views entrypoint |
+| `.env.example` | `RENDERER_URL`, `SERVICES_COMPOSE_FILE`, window overrides |
+
+## Related
+
+- Registry: [ADR-ECO-015 hybrid gateway app layer](https://github.com/KooshaPari/phenotype-registry/blob/main/docs/adrs/ADR-ECO-015-hybrid-gateway-app-layer.md)
+- Spike matrix: [DESKTOP_CLIENT_SPIKE_MATRIX.md](https://github.com/KooshaPari/phenotype-registry/blob/main/docs/rationalization/DESKTOP_CLIENT_SPIKE_MATRIX.md)
+- Canonical entry: [`../apps/desktop/`](../apps/desktop/) (redirect only — no duplicate code)


### PR DESCRIPTION
## **User description**
## Summary

- Adds \desktop-electrobun/README.md\ with the ADR-ECO-015 selection-gate checklist (tray UX, local OpenAI endpoint, macOS build) and harvest pointers to vibeproxy macOS client patterns
- Adds \pps/desktop/README.md\ as the registry-canonical redirect to \desktop-electrobun/\ (no duplicated source)
- vibeproxy disposition: **ABSORB** (redirect only) — reference harvest, no third desktop repo

## Context

Registry selected **FFI + Electrobun** for OmniRoute desktop per [ADR-ECO-015](https://github.com/KooshaPari/phenotype-registry/blob/main/docs/adrs/ADR-ECO-015-hybrid-gateway-app-layer.md) and [DESKTOP_CLIENT_SPIKE_MATRIX](https://github.com/KooshaPari/phenotype-registry/blob/main/docs/rationalization/DESKTOP_CLIENT_SPIKE_MATRIX.md).

Existing \desktop-electrobun/\ Electrobun shell (main.ts, electrobun.config.ts) is unchanged — this PR is documentation + canonical path only.

## Test plan

- [ ] README links resolve (apps/desktop → desktop-electrobun, registry ADR links)
- [ ] Selection-gate checklist matches spike matrix criteria
- [ ] No changes to G18/G19/H14 or phenotype-registry

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Add Electrobun desktop spike docs and canonical app path**

### What Changed
- Added a new Electrobun desktop README that defines the spike goals, pass/fail checklist, and expected macOS build outcome
- Documented the tray/menu-bar control, local OpenAI-compatible endpoint, and macOS build requirements needed before replacing Electron
- Added the canonical `apps/desktop/` README as a redirect to `desktop-electrobun/` so there is one documented desktop entry point

### Impact
`✅ Clearer desktop build path`
`✅ Fewer wrong-entry redirects`
`✅ Faster spike review decisions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
