### PR TITLE
feat(a2a): implement providerDiscovery skill (closes 1/9 of DEBT-006)

### DIFF
--- a/src/lib/a2a/skills/providerDiscovery.ts
+++ b/src/lib/a2a/skills/providerDiscovery.ts
@@ -1,19 +1,530 @@
 /**
  * Provider Discovery A2A Skill
- * Lists installed providers with capabilities, free-tier flags, OAuth status
+ *
+ * Auto-discovers LLM provider endpoints from environment, config, filesystem,
+ * and (optionally) the MCP server, and returns them in a normalized catalog.
+ *
+ * The skill is read-only: it does not enqueue or forward any LLM call and never
+ * makes network requests. It only reads local env vars, the user-level
+ * `~/.omniroute/config.json` (or `$DATA_DIR/config.json`), JSON files in
+ * `${baseDir}/providers/*.json` and `${baseDir}/credentials/*.json`, and
+ * delegates to the MCP client when present.
+ *
+ * Sources (selected via `task.metadata.sources`, default: all four):
+ *   - env         — scan `process.env` for keys matching `*API_KEY`, `*TOKEN`,
+ *                   `*BASE_URL`, `*ENDPOINT`. Grouped by the key prefix
+ *                   (e.g. OPENAI_API_KEY + OPENAI_BASE_URL → vendor `openai`).
+ *   - config      — read `<DATA_DIR>/config.json` or `~/.omniroute/config.json`
+ *                   and parse its `providers` array.
+ *   - filesystem  — scan `${baseDir}/providers/*.json` and
+ *                   `${baseDir}/credentials/*.json`. Skips symlinks and any
+ *                   file larger than 1 MB to avoid accidentally reading
+ *                   credential dumps.
+ *   - mcp         — call the MCP client's `list_providers` tool when reachable.
+ *                   If the client is absent or throws, returns an empty array;
+ *                   this source never fails the whole discovery.
+ *
+ * Inputs (via task.metadata):
+ *   - sources    (optional, Array<'env'|'config'|'filesystem'|'mcp'>) —
+ *                restrict which sources to scan. Default: all four.
+ *   - baseDir    (optional, string) — root for filesystem scan.
+ *                Default: `$DATA_DIR` if set, else `~/.omniroute`.
+ *   - vendor     (optional, string) — case-insensitive substring filter.
+ *   - envSnapshot (optional, Record<string,string>) — override `process.env`
+ *                for the `env` source. Useful for testing.
+ *
+ * Output (A2ASkillResult.artifacts[0].content is JSON):
+ *   {
+ *     providers: [{
+ *       id, vendor, source, discoveredAt,
+ *       hasApiKey, hasBaseUrl,
+ *       metadata: Record<string, unknown>
+ *     }],
+ *     stats: { total, bySource, byVendor }
+ *   }
+ *
+ * Note: same vendor found via different sources is reported as multiple
+ * providers (different `source`). This is intentional — each source is a
+ * different origin and may carry different metadata.
  */
 
+import { promises as fs, Dirent, Stats } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
 import { A2ATask } from "../taskManager";
 import { A2ASkillResult } from "../taskExecution";
 
+export type DiscoverySource = "env" | "config" | "filesystem" | "mcp";
+
+export interface DiscoveryInputs {
+  sources?: DiscoverySource[];
+  baseDir?: string;
+  /** optional: case-insensitive substring filter on vendor */
+  vendor?: string;
+  /** optional: env override for tests; ignored if absent */
+  envSnapshot?: Record<string, string>;
+}
+
+export interface DiscoveredProvider {
+  id: string;
+  vendor: string;
+  source: DiscoverySource;
+  discoveredAt: string;
+  hasApiKey: boolean;
+  hasBaseUrl: boolean;
+  metadata: Record<string, unknown>;
+}
+
+export interface ProviderDiscoveryOutput {
+  providers: DiscoveredProvider[];
+  stats: {
+    total: number;
+    bySource: Record<string, number>;
+    byVendor: Record<string, number>;
+  };
+}
+
+interface SourceScanResult {
+  providers: DiscoveredProvider[];
+  filesScanned: number;
+  errorsEncountered: number;
+  sourcesScanned: DiscoverySource[];
+}
+
+const ENV_SUFFIXES = ["API_KEY", "TOKEN", "BASE_URL", "ENDPOINT"] as const;
+const MAX_FILE_BYTES = 1024 * 1024; // 1 MB
+const DEFAULT_SOURCES: DiscoverySource[] = ["env", "config", "filesystem", "mcp"];
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function defaultBaseDir(): string {
+  if (process.env.DATA_DIR && process.env.DATA_DIR.trim() !== "") {
+    return process.env.DATA_DIR.trim();
+  }
+  return path.join(os.homedir(), ".omniroute");
+}
+
+function isProviderShape(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return (
+    typeof (value as Record<string, unknown>).id === "string" ||
+    typeof (value as Record<string, unknown>).vendor === "string" ||
+    typeof (value as Record<string, unknown>).provider === "string"
+  );
+}
+
+function coerceString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+function normalizeVendor(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function pickProviderShapeFields(
+  raw: Record<string, unknown>,
+): { id: string; vendor: string; hasApiKey: boolean; hasBaseUrl: boolean } {
+  const idRaw =
+    coerceString(raw.id) ||
+    coerceString(raw.provider) ||
+    coerceString(raw.name) ||
+    "unknown";
+  const vendorRaw =
+    coerceString(raw.vendor) ||
+    coerceString(raw.provider) ||
+    coerceString(raw.id) ||
+    idRaw;
+  const apiKey =
+    coerceString(raw.apiKey) ||
+    coerceString(raw.api_key) ||
+    coerceString(raw.token);
+  const baseUrl =
+    coerceString(raw.baseUrl) ||
+    coerceString(raw.base_url) ||
+    coerceString(raw.endpoint) ||
+    coerceString(raw.url);
+  return {
+    id: idRaw,
+    vendor: normalizeVendor(vendorRaw),
+    hasApiKey: Boolean(apiKey),
+    hasBaseUrl: Boolean(baseUrl),
+  };
+}
+
+/**
+ * Env source — scan process.env for keys matching `*API_KEY`, `*TOKEN`,
+ * `*BASE_URL`, `*ENDPOINT`. Group by the key prefix (everything before the
+ * last underscore-separated suffix) so that OPENAI_API_KEY and
+ * OPENAI_BASE_URL collapse into one `openai` provider.
+ */
+function discoverFromEnv(
+  inputs: DiscoveryInputs,
+  discoveredAt: string,
+): DiscoveredProvider[] {
+  const env =
+    inputs.envSnapshot ?? (process.env as unknown as Record<string, string | undefined>);
+  const byPrefix = new Map<
+    string,
+    { hasApiKey: boolean; hasBaseUrl: boolean; rawKeys: string[] }
+  >();
+
+  for (const key of Object.keys(env)) {
+    const upper = key.toUpperCase();
+    const matchedSuffix = ENV_SUFFIXES.find((s) => upper.endsWith("_" + s));
+    if (!matchedSuffix) continue;
+    const value = env[key];
+    if (typeof value !== "string" || value.trim() === "") continue;
+
+    const prefixRaw = key.slice(0, key.length - matchedSuffix.length - 1);
+    if (!prefixRaw) continue;
+    const prefix = normalizeVendor(prefixRaw);
+    if (!prefix) continue;
+
+    const entry = byPrefix.get(prefix) ?? {
+      hasApiKey: false,
+      hasBaseUrl: false,
+      rawKeys: [],
+    };
+    if (matchedSuffix === "API_KEY" || matchedSuffix === "TOKEN") entry.hasApiKey = true;
+    if (matchedSuffix === "BASE_URL" || matchedSuffix === "ENDPOINT") entry.hasBaseUrl = true;
+    entry.rawKeys.push(key);
+    byPrefix.set(prefix, entry);
+  }
+
+  const providers: DiscoveredProvider[] = [];
+  for (const [vendor, info] of byPrefix.entries()) {
+    providers.push({
+      id: vendor,
+      vendor,
+      source: "env",
+      discoveredAt,
+      hasApiKey: info.hasApiKey,
+      hasBaseUrl: info.hasBaseUrl,
+      metadata: { envKeys: info.rawKeys.sort() },
+    });
+  }
+  return providers;
+}
+
+/**
+ * Config source — read `<DATA_DIR>/config.json` or `~/.omniroute/config.json`
+ * and parse its `providers` array. Returns [] if the file is absent.
+ */
+async function discoverFromConfig(
+  baseDir: string,
+  discoveredAt: string,
+): Promise<SourceScanResult> {
+  const result: SourceScanResult = {
+    providers: [],
+    filesScanned: 0,
+    errorsEncountered: 0,
+    sourcesScanned: ["config"],
+  };
+  const configPath = path.join(baseDir, "config.json");
+  let raw: string;
+  try {
+    const stat = await fs.stat(configPath);
+    if (stat.isSymbolicLink() || !stat.isFile()) return result;
+    if (stat.size > MAX_FILE_BYTES) {
+      result.errorsEncountered += 1;
+      return result;
+    }
+    result.filesScanned += 1;
+    raw = await fs.readFile(configPath, "utf8");
+  } catch {
+    // File missing or unreadable — treat as empty catalog (not an error).
+    return result;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    result.errorsEncountered += 1;
+    return result;
+  }
+
+  const list: unknown[] =
+    parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? Array.isArray((parsed as Record<string, unknown>).providers)
+        ? ((parsed as Record<string, unknown>).providers as unknown[])
+        : []
+      : Array.isArray(parsed)
+        ? (parsed as unknown[])
+        : [];
+
+  for (const entry of list) {
+    if (!isProviderShape(entry)) continue;
+    const fields = pickProviderShapeFields(entry);
+    result.providers.push({
+      ...fields,
+      source: "config",
+      discoveredAt,
+      metadata: { ...entry, sourceFile: configPath },
+    });
+  }
+  return result;
+}
+
+/**
+ * Filesystem source — scan `${baseDir}/providers/*.json` and
+ * `${baseDir}/credentials/*.json`. Each file is one provider if it has a
+ * recognizable shape.
+ */
+async function discoverFromFilesystem(
+  baseDir: string,
+  discoveredAt: string,
+): Promise<SourceScanResult> {
+  const result: SourceScanResult = {
+    providers: [],
+    filesScanned: 0,
+    errorsEncountered: 0,
+    sourcesScanned: ["filesystem"],
+  };
+  const subdirs = ["providers", "credentials"];
+
+  for (const sub of subdirs) {
+    const dir = path.join(baseDir, sub);
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue; // missing dir is not an error
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (entry.name.startsWith(".")) continue;
+      if (!entry.name.endsWith(".json")) continue;
+      const filePath = path.join(dir, entry.name);
+
+      let stat: Stats;
+      try {
+        stat = await fs.stat(filePath);
+      } catch {
+        result.errorsEncountered += 1;
+        continue;
+      }
+      // Don't follow symlinks (already excluded by isFile() but be explicit).
+      if (stat.isSymbolicLink()) continue;
+      if (stat.size > MAX_FILE_BYTES) {
+        result.errorsEncountered += 1;
+        continue;
+      }
+      result.filesScanned += 1;
+
+      let raw: string;
+      try {
+        raw = await fs.readFile(filePath, "utf8");
+      } catch {
+        result.errorsEncountered += 1;
+        continue;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        result.errorsEncountered += 1;
+        continue;
+      }
+
+      // A file may contain either a single provider object or `{ providers: [...] }`.
+      const candidates: unknown[] = isProviderShape(parsed)
+        ? [parsed]
+        : parsed &&
+            typeof parsed === "object" &&
+            !Array.isArray(parsed) &&
+            Array.isArray((parsed as Record<string, unknown>).providers)
+          ? ((parsed as Record<string, unknown>).providers as unknown[])
+          : [];
+
+      for (const candidate of candidates) {
+        if (!isProviderShape(candidate)) continue;
+        const fields = pickProviderShapeFields(candidate);
+        result.providers.push({
+          ...fields,
+          source: "filesystem",
+          discoveredAt,
+          metadata: { ...candidate, sourceFile: filePath },
+        });
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * MCP source — call the MCP client's `listProviders` tool when reachable.
+ * The MCP client lives in `src/lib/mcp/` (deferred dynamic import so we don't
+ * pull it in if the caller doesn't ask for the `mcp` source).
+ * If the module isn't there, or the call throws, return an empty array and
+ * count it as one error — never fail the whole discovery.
+ */
+async function discoverFromMcp(discoveredAt: string): Promise<SourceScanResult> {
+  const result: SourceScanResult = {
+    providers: [],
+    filesScanned: 0,
+    errorsEncountered: 0,
+    sourcesScanned: ["mcp"],
+  };
+
+  type McpClient = { listProviders?: () => Promise<unknown[]> };
+  let mod: McpClient | undefined;
+  // The MCP client module is optional infrastructure. We import lazily and
+  // tolerate any failure (module missing, runtime error, network error).
+  // We route the module specifier through a `string` local so TypeScript
+  // does not statically resolve the path (the file may not exist in this
+  // checkout; the .catch() below ensures runtime tolerance regardless).
+  const mcpModuleSpec: string = "../../mcp/client.js";
+  try {
+    mod = (await import(mcpModuleSpec).catch(() => undefined)) as McpClient | undefined;
+  } catch {
+    result.errorsEncountered += 1;
+    return result;
+  }
+
+  if (!mod || typeof mod.listProviders !== "function") {
+    // No MCP client available — empty result, no error counted.
+    return result;
+  }
+
+  let list: unknown;
+  try {
+    list = await mod.listProviders();
+  } catch {
+    result.errorsEncountered += 1;
+    return result;
+  }
+
+  if (!Array.isArray(list)) return result;
+  for (const entry of list) {
+    if (!isProviderShape(entry)) continue;
+    const fields = pickProviderShapeFields(entry);
+    result.providers.push({
+      ...fields,
+      source: "mcp",
+      discoveredAt,
+      metadata: { ...entry },
+    });
+  }
+  return result;
+}
+
+function matchesVendorFilter(
+  provider: DiscoveredProvider,
+  vendorFilter: string | undefined,
+): boolean {
+  if (!vendorFilter) return true;
+  const needle = vendorFilter.trim().toLowerCase();
+  if (!needle) return true;
+  return (
+    provider.vendor.toLowerCase().includes(needle) ||
+    provider.id.toLowerCase().includes(needle)
+  );
+}
+
+function buildStats(providers: DiscoveredProvider[]): ProviderDiscoveryOutput["stats"] {
+  const bySource: Record<string, number> = {};
+  const byVendor: Record<string, number> = {};
+  for (const p of providers) {
+    bySource[p.source] = (bySource[p.source] ?? 0) + 1;
+    byVendor[p.vendor] = (byVendor[p.vendor] ?? 0) + 1;
+  }
+  return { total: providers.length, bySource, byVendor };
+}
+
+function extractInputs(metadata: Record<string, unknown> | undefined): DiscoveryInputs {
+  if (!metadata) return {};
+  const sources = Array.isArray(metadata.sources)
+    ? (metadata.sources as unknown[]).filter(
+        (s): s is DiscoverySource =>
+          s === "env" || s === "config" || s === "filesystem" || s === "mcp",
+      )
+    : undefined;
+  const baseDir =
+    typeof metadata.baseDir === "string" && metadata.baseDir.trim() !== ""
+      ? metadata.baseDir.trim()
+      : undefined;
+  const vendor =
+    typeof metadata.vendor === "string" && metadata.vendor.trim() !== ""
+      ? metadata.vendor.trim()
+      : undefined;
+  const envSnapshot =
+    metadata.envSnapshot && typeof metadata.envSnapshot === "object"
+      ? Object.fromEntries(
+          Object.entries(metadata.envSnapshot as Record<string, unknown>).filter(
+            (e): e is [string, string] => typeof e[1] === "string",
+          ),
+        )
+      : undefined;
+  return { sources, baseDir, vendor, envSnapshot };
+}
+
 export async function executeProviderDiscovery(task: A2ATask): Promise<A2ASkillResult> {
-  // TODO: Implement provider discovery skill
+  const inputs = extractInputs(task.metadata);
+  const sources =
+    inputs.sources && inputs.sources.length > 0 ? inputs.sources : DEFAULT_SOURCES;
+  const baseDir = inputs.baseDir ?? defaultBaseDir();
+  const discoveredAt = nowIso();
+
+  const collected: DiscoveredProvider[] = [];
+  let filesScanned = 0;
+  let errorsEncountered = 0;
+  const sourcesScanned: DiscoverySource[] = [];
+
+  for (const src of sources) {
+    try {
+      if (src === "env") {
+        collected.push(...discoverFromEnv(inputs, discoveredAt));
+        sourcesScanned.push("env");
+      } else if (src === "config") {
+        const r = await discoverFromConfig(baseDir, discoveredAt);
+        collected.push(...r.providers);
+        filesScanned += r.filesScanned;
+        errorsEncountered += r.errorsEncountered;
+        sourcesScanned.push("config");
+      } else if (src === "filesystem") {
+        const r = await discoverFromFilesystem(baseDir, discoveredAt);
+        collected.push(...r.providers);
+        filesScanned += r.filesScanned;
+        errorsEncountered += r.errorsEncountered;
+        sourcesScanned.push("filesystem");
+      } else if (src === "mcp") {
+        const r = await discoverFromMcp(discoveredAt);
+        collected.push(...r.providers);
+        filesScanned += r.filesScanned;
+        errorsEncountered += r.errorsEncountered;
+        sourcesScanned.push("mcp");
+      }
+    } catch {
+      // A single source failure must never abort the whole discovery.
+      errorsEncountered += 1;
+    }
+  }
+
+  const filtered = collected.filter((p) => matchesVendorFilter(p, inputs.vendor));
+  const stats = buildStats(filtered);
+  const output: ProviderDiscoveryOutput = { providers: filtered, stats };
+
   return {
     artifacts: [
       {
         type: "text",
-        content: "Provider discovery skill not yet implemented",
+        content: JSON.stringify(output),
       },
     ],
+    metadata: {
+      generatedAt: discoveredAt,
+      sourcesScanned: sourcesScanned as string[],
+      filesScanned,
+      errorsEncountered,
+      totalDiscovered: filtered.length,
+    },
   };
 }

--- a/tests/unit/a2a-provider-discovery.test.ts
+++ b/tests/unit/a2a-provider-discovery.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Tests for the provider-discovery A2A skill.
+ *
+ * Verifies:
+ *   1. env-only — mocked `process.env` produces a single provider
+ *      with the right vendor and source.
+ *   2. config-only — a temp config.json with 2 providers produces 2 entries.
+ *   3. filesystem-only — 2 temp JSON files produce 2 entries.
+ *   4. mcp-unreachable — a throwing MCP client is tolerated and yields [].
+ *   5. vendor filter — `metadata.vendor` filters the catalog.
+ *   6. empty — nothing on disk or in env returns an empty catalog, no errors.
+ *   7. error tolerance — one malformed JSON file is counted, not fatal.
+ *   8. source filter — `metadata.sources = ['env']` skips fs entirely.
+ *   9. stats shape — `bySource` / `byVendor` reflect the catalog.
+ *  10. idempotent — two consecutive calls produce the same catalog.
+ *  11. large-file skip — a 2 MB JSON file is skipped and counted as an error.
+ *  12. symlink skip — a symlinked file is skipped (not followed).
+ *  13. prefix grouping — `OPENAI_API_KEY` + `OPENAI_BASE_URL` → one `openai` provider.
+ *  14. multi-source dedup — same vendor in env + config yields 2 entries (different sources).
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import { executeProviderDiscovery } from "@/lib/a2a/skills/providerDiscovery";
+import type {
+  DiscoveredProvider,
+  ProviderDiscoveryOutput,
+} from "@/lib/a2a/skills/providerDiscovery";
+import type { A2ATask } from "@/lib/a2a/taskManager";
+
+function makeTask(metadata: Record<string, unknown>): A2ATask {
+  return {
+    id: "test-task",
+    skill: "provider-discovery",
+    messages: [],
+    metadata,
+    state: "working",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+function parseArtifact(result: Awaited<ReturnType<typeof executeProviderDiscovery>>): ProviderDiscoveryOutput {
+  expect(result.artifacts).toHaveLength(1);
+  expect(result.artifacts[0].type).toBe("text");
+  return JSON.parse(result.artifacts[0].content);
+}
+
+async function mkTmpDir(prefix: string): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), `pd-${prefix}-`));
+}
+
+async function rmTmpDir(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+// Strip the non-deterministic fields so we can deep-equal the payload.
+function normalizeProviders(providers: DiscoveredProvider[]): Array<Omit<DiscoveredProvider, "discoveredAt">> {
+  return providers.map(({ discoveredAt: _da, ...rest }) => rest);
+}
+
+describe("providerDiscovery A2A skill", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTmpDir("discovery");
+  });
+
+  afterEach(async () => {
+    await rmTmpDir(tmpDir);
+  });
+
+  it("returns 1 provider from a mocked OPENAI_API_KEY env (env-only)", async () => {
+    const result = await executeProviderDiscovery(
+      makeTask({
+        sources: ["env"],
+        baseDir: tmpDir, // empty dir so config + filesystem find nothing
+        envSnapshot: { OPENAI_API_KEY: "sk-test", UNRELATED: "x" },
+      }),
+    );
+
+    const payload = parseArtifact(result);
+    expect(payload.providers).toHaveLength(1);
+    const [p] = payload.providers;
+    expect(p.vendor).toBe("openai");
+    expect(p.id).toBe("openai");
+    expect(p.source).toBe("env");
+    expect(p.hasApiKey).toBe(true);
+    expect(p.hasBaseUrl).toBe(false);
+    expect(payload.stats.total).toBe(1);
+    expect(payload.stats.bySource.env).toBe(1);
+  });
+
+  it("reads 2 providers from a temp config.json (config-only)", async () => {
+    const cfg = {
+      providers: [
+        { id: "openai", vendor: "openai", apiKey: "sk-x", baseUrl: "https://api.openai.com" },
+        { id: "anthropic", vendor: "anthropic", apiKey: "sk-y" },
+      ],
+    };
+    await fs.writeFile(path.join(tmpDir, "config.json"), JSON.stringify(cfg), "utf8");
+
+    const result = await executeProviderDiscovery(
+      makeTask({ sources: ["config"], baseDir: tmpDir, envSnapshot: {} }),
+    );
+    const payload = parseArtifact(result);
+
+    expect(payload.providers).toHaveLength(2);
+    expect(payload.providers.every((p) => p.source === "config")).toBe(true);
+    const ids = payload.providers.map((p) => p.id).sort();
+    expect(ids).toEqual(["anthropic", "openai"]);
+    expect(payload.stats.bySource.config).toBe(2);
+  });
+
+  it("scans 2 temp JSON files in providers/ (filesystem-only)", async () => {
+    await fs.mkdir(path.join(tmpDir, "providers"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, "credentials"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "providers", "openai.json"),
+      JSON.stringify({ id: "openai", vendor: "openai", apiKey: "sk-o" }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "credentials", "anthropic.json"),
+      JSON.stringify({ id: "anthropic", apiKey: "sk-a" }),
+      "utf8",
+    );
+
+    const result = await executeProviderDiscovery(
+      makeTask({ sources: ["filesystem"], baseDir: tmpDir, envSnapshot: {} }),
+    );
+    const payload = parseArtifact(result);
+
+    expect(payload.providers).toHaveLength(2);
+    expect(payload.providers.every((p) => p.source === "filesystem")).toBe(true);
+    expect(payload.stats.bySource.filesystem).toBe(2);
+  });
+
+  it("tolerates an unreachable MCP source (returns empty, does not fail)", async () => {
+    // The MCP source uses a dynamic import of `../../mcp/client.js`. In the
+    // test repo that module does not exist; the import resolves to undefined
+    // and we expect a clean empty catalog with no errors counted.
+    const result = await executeProviderDiscovery(
+      makeTask({
+        sources: ["mcp"],
+        baseDir: tmpDir,
+        envSnapshot: {},
+      }),
+    );
+
+    const payload = parseArtifact(result);
+    expect(payload.providers).toEqual([]);
+    expect(payload.stats.total).toBe(0);
+    // No module = no error counted (only thrown listProviders counts as error).
+    expect(result.metadata?.errorsEncountered).toBe(0);
+  });
+
+  it("filters by vendor substring", async () => {
+    const cfg = {
+      providers: [
+        { id: "openai", vendor: "openai" },
+        { id: "anthropic", vendor: "anthropic" },
+      ],
+    };
+    await fs.writeFile(path.join(tmpDir, "config.json"), JSON.stringify(cfg), "utf8");
+
+    const result = await executeProviderDiscovery(
+      makeTask({
+        sources: ["config", "env"],
+        baseDir: tmpDir,
+        vendor: "openai",
+        envSnapshot: { OPENAI_API_KEY: "sk-test" },
+      }),
+    );
+    const payload = parseArtifact(result);
+
+    expect(payload.providers.map((p) => p.id)).toEqual(["openai"]);
+  });
+
+  it("returns an empty catalog when nothing is on disk or in env", async () => {
+    const result = await executeProviderDiscovery(
+      makeTask({ baseDir: tmpDir, envSnapshot: {} }),
+    );
+    const payload = parseArtifact(result);
+
+    expect(payload.providers).toEqual([]);
+    expect(payload.stats.total).toBe(0);
+    expect(result.metadata?.errorsEncountered).toBe(0);
+    // sourcesScanned records env (always runs, even if it found nothing).
+    expect(result.metadata?.sourcesScanned).toContain("env");
+  });
+
+  it("counts a malformed JSON file as an error but does not fail", async () => {
+    await fs.mkdir(path.join(tmpDir, "providers"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "providers", "good.json"),
+      JSON.stringify({ id: "good", vendor: "good" }), "utf8");
+    await fs.writeFile(path.join(tmpDir, "providers", "bad.json"),
+      "{ this is not valid JSON", "utf8");
+
+    const result = await executeProviderDiscovery(
+      makeTask({ sources: ["filesystem"], baseDir: tmpDir, envSnapshot: {} }),
+    );
+    const payload = parseArtifact(result);
+
+    expect(payload.providers).toHaveLength(1);
+    expect(payload.providers[0].id).toBe("good");
+    expect(result.metadata?.errorsEncountered).toBeGreaterThanOrEqual(1);
+  });
+
+  it("respects source filter (sources=['env'] never touches the fs)", async () => {
+    // Make a loud config file. If we accidentally read it, the test fails.
+    await fs.writeFile(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({ providers: [{ id: "loud", vendor: "loud" }] }),
+      "utf8",
+    );
+    await fs.mkdir(path.join(tmpDir, "providers"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "providers", "loud.json"),
+      JSON.stringify({ id: "loud-fs", vendor: "loud-fs" }),
+      "utf8",
+    );
+
+    const result = await executeProviderDiscovery(
+      makeTask({
+        sources: ["env"],
+        baseDir: tmpDir,
+        envSnapshot: { ANTHROPIC_API_KEY: "sk-a" },
+      }),
+    );
+    const payload = parseArtifact(result);
+
+    expect(payload.providers.map((p) => p.id)).toEqual(["anthropic"]);
+    expect(payload.providers.every((p) => p.source === "env")).toBe(true);
+    expect(result.metadata?.sourcesScanned).toEqual(["env"]);
+    expect(result.metadata?.filesScanned).toBe(0);
+  });
+
+  it("computes stats.bySource and stats.byVendor correctly", async () => {
+    const cfg = {
+      providers: [
+        { id: "openai", vendor: "openai" },
+        { id: "openai-alt", vendor: "openai" }, // same vendor, different id
+      ],
+    };
+    await fs.writeFile(path.join(tmpDir, "config.json"), JSON.stringify(cfg), "utf8");
+
+    const result = await executeProviderDiscovery(
+      makeTask({
+        sources: ["config", "env"],
+        baseDir: tmpDir,
+        envSnapshot: { ANTHROPIC_TOKEN: "tok" },
+      }),
+    );
+    const payload = parseArtifact(result);
+
+    expect(payload.stats.total).toBe(3);
+    expect(payload.stats.bySource.config).toBe(2);
+    expect(payload.stats.bySource.env).toBe(1);
+    expect(payload.stats.byVendor.openai).toBe(2);
+    expect(payload.stats.byVendor.anthropic).toBe(1);
+  });
+
+  it("is idempotent — two calls with the same input produce the same catalog", async () => {
+    await fs.mkdir(path.join(tmpDir, "providers"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "providers", "openai.json"),
+      JSON.stringify({ id: "openai", vendor: "openai", apiKey: "sk-o" }),
+      "utf8",
+    );
+
+    const task = makeTask({
+      sources: ["env", "filesystem"],
+      baseDir: tmpDir,
+      envSnapshot: { ANTHROPIC_API_KEY: "sk-a" },
+    });
+    const first = parseArtifact(await executeProviderDiscovery(task));
+    const second = parseArtifact(await executeProviderDiscovery(task));
+
+    expect(normalizeProviders(first.providers)).toEqual(
+      normalizeProviders(second.providers),
+    );
+    expect(first.stats).toEqual(second.stats);
+  });
+
+  it("skips JSON files larger than 1 MB", async () => {
+    await fs.mkdir(path.join(tmpDir, "providers"), { recursive: true });
+    // 2 MB of repeated JSON in a recognizable provider shape.
+    const huge =
+      '{"id":"huge","vendor":"huge","filler":"' + "x".repeat(2 * 1024 * 1024 - 50) + '"}';
+    await fs.writeFile(path.join(tmpDir, "providers", "huge.json"), huge, "utf8");
+    await fs.writeFile(
+      path.join(tmpDir, "providers", "small.json"),
+      JSON.stringify({ id: "small", vendor: "small" }),
+      "utf8",
+    );
+
+    const result = await executeProviderDiscovery(
+      makeTask({ sources: ["filesystem"], baseDir: tmpDir, envSnapshot: {} }),
+    );
+    const payload = parseArtifact(result);
+
+    expect(payload.providers.map((p) => p.id).sort()).toEqual(["small"]);
+    expect(result.metadata?.errorsEncountered).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not follow symlinks in the providers/ directory", async () => {
+    await fs.mkdir(path.join(tmpDir, "providers"), { recursive: true });
+    // Real file outside the providers dir.
+    await fs.writeFile(
+      path.join(tmpDir, "real.json"),
+      JSON.stringify({ id: "real", vendor: "real" }),
+      "utf8",
+    );
+    // Symlink inside providers/ pointing at it.
+    await fs.symlink(
+      path.join(tmpDir, "real.json"),
+      path.join(tmpDir, "providers", "linked.json"),
+    );
+
+    const result = await executeProviderDiscovery(
+      makeTask({ sources: ["filesystem"], baseDir: tmpDir, envSnapshot: {} }),
+    );
+    const payload = parseArtifact(result);
+
+    // The symlink target is skipped because isSymbolicLink() is true.
+    expect(payload.providers).toEqual([]);
+  });
+
+  it("groups OPENAI_API_KEY and OPENAI_BASE_URL into a single 'openai' provider", async () => {
+    const result = await executeProviderDiscovery(
+      makeTask({
+        sources: ["env"],
+        baseDir: tmpDir,
+        envSnapshot: {
+          OPENAI_API_KEY: "sk-x",
+          OPENAI_BASE_URL: "https://api.openai.com/v1",
+          ANTHROPIC_TOKEN: "sk-a",
+        },
+      }),
+    );
+    const payload = parseArtifact(result);
+
+    expect(payload.providers).toHaveLength(2);
+    const openai = payload.providers.find((p) => p.vendor === "openai");
+    expect(openai).toBeDefined();
+    expect(openai!.id).toBe("openai");
+    expect(openai!.hasApiKey).toBe(true);
+    expect(openai!.hasBaseUrl).toBe(true);
+    expect((openai!.metadata.envKeys as string[]).sort()).toEqual([
+      "OPENAI_API_KEY",
+      "OPENAI_BASE_URL",
+    ]);
+  });
+
+  it("reports same vendor from env AND config as two separate providers", async () => {
+    const cfg = {
+      providers: [
+        { id: "openai", vendor: "openai", apiKey: "from-config" },
+      ],
+    };
+    await fs.writeFile(path.join(tmpDir, "config.json"), JSON.stringify(cfg), "utf8");
+
+    const result = await executeProviderDiscovery(
+      makeTask({
+        sources: ["env", "config"],
+        baseDir: tmpDir,
+        envSnapshot: { OPENAI_API_KEY: "from-env" },
+      }),
+    );
+    const payload = parseArtifact(result);
+
+    expect(payload.providers).toHaveLength(2);
+    const sources = payload.providers.map((p) => p.source).sort();
+    expect(sources).toEqual(["config", "env"]);
+    expect(payload.providers.every((p) => p.vendor === "openai")).toBe(true);
+    expect(payload.stats.byVendor.openai).toBe(2);
+    expect(payload.stats.bySource.env).toBe(1);
+    expect(payload.stats.bySource.config).toBe(1);
+  });
+});


### PR DESCRIPTION
## **User description**
see commit message + closes 1/9 of DEBT-006 in docs/TECH_DEBT.md


___

## **CodeAnt-AI Description**
**Discover provider settings from local sources**

### What Changed
- The provider discovery skill now returns a real catalog instead of a placeholder.
- It can find providers from environment variables, local config, provider files, credential files, and MCP when available.
- It filters results by vendor, skips large files and symlinks, and keeps going when one source is missing or invalid.
- The response now includes counts by source and vendor, plus tests covering the main discovery paths and error cases.

### Impact
`✅ Find configured providers without manual setup`
`✅ Fewer discovery failures from missing or broken local files`
`✅ Clearer visibility into where providers were found`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
