### PR TITLE
feat(a2a): implement healthReport skill (closes DEBT-006 partial)

### DIFF
--- a/src/lib/a2a/skills/healthReport.ts
+++ b/src/lib/a2a/skills/healthReport.ts
@@ -1,19 +1,718 @@
 /**
  * Health Report A2A Skill
- * Aggregates circuit breaker, cooldown, lockout state per provider
+ *
+ * Aggregates a fleet-wide health snapshot for the OmniRoute gateway. The
+ * report covers five subsystems that the A2A server depends on:
+ *
+ *   - a2a        — the A2A server itself (skill registry, transport)
+ *   - mcp        — the Model Context Protocol server (tools, scopes)
+ *   - db         — the SQLite database (migrations, modules, backups, integrity)
+ *   - providers  — the provider catalog (count, free-tier coverage, degraded)
+ *   - bifrost    — the Tier-1 router substrate (NOT YET DEPLOYED)
+ *
+ * Each section is shaped as
+ *   { status: 'healthy'|'degraded'|'offline'|'unknown',
+ *     details: { ... subsystem-specific fields ... },
+ *     warnings: string[] }
+ *
+ * The top-level report has an `overall` rollup computed as worst-of across
+ * the included sections (offline > degraded > unknown > healthy). When a
+ * subsystem does not exist in the repo (e.g. bifrost), it is reported as
+ * `unknown` with a single warning "subsystem not yet deployed".
+ *
+ * The skill is read-only: it never makes network calls, never mutates DB
+ * state, and never enqueues any LLM call. The default collectors read
+ * filesystem + module-level constants only.
+ *
+ * For testability, the five collectors and the metrics collector can be
+ * overridden via the optional `deps` argument. Tests inject deterministic
+ * snapshots so the rollup behaviour can be asserted without touching the
+ * real registry / provider catalog / db files.
+ *
+ * Inputs (via task.metadata):
+ *   - scope           (optional, 'all'|'a2a'|'mcp'|'db'|'providers'|'bifrost')
+ *                     Default: 'all'. Restricts the report to one subsystem.
+ *   - includeMetrics  (optional, boolean) Default: false. When true, appends
+ *                     latency p50/p95/p99 per section (synthetic from any
+ *                     available log; otherwise null).
+ *
+ * Output (A2ASkillResult.artifacts[0].content is JSON):
+ *   {
+ *     overall: 'healthy'|'degraded'|'offline',
+ *     generatedAt: ISO8601,
+ *     scope: 'all'|<one of the sections>,
+ *     sections: { a2a, mcp, db, providers, bifrost }   // filtered by scope
+ *     metrics?: { a2a?: {p50,p95,p99}|null, ... }
+ *   }
  */
 
+import fs from "fs";
+import path from "path";
 import { A2ATask } from "../taskManager";
 import { A2ASkillResult } from "../taskExecution";
+import { A2A_SKILL_HANDLERS } from "../taskExecution";
+import { MCP_TOOLS } from "../../../../open-sse/mcp-server/schemas/tools";
+import {
+  APIKEY_PROVIDERS,
+  NOAUTH_PROVIDERS,
+  OAUTH_PROVIDERS,
+  WEB_COOKIE_PROVIDERS,
+} from "../../../shared/constants/providers";
 
-export async function executeHealthReport(task: A2ATask): Promise<A2ASkillResult> {
-  // TODO: Implement health report skill
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type SectionStatus = "healthy" | "degraded" | "offline" | "unknown";
+export type OverallStatus = "healthy" | "degraded" | "offline";
+export type A2ATransportState = "online" | "degraded" | "offline";
+export type HealthReportScope =
+  | "all"
+  | "a2a"
+  | "mcp"
+  | "db"
+  | "providers"
+  | "bifrost";
+
+export interface A2ASectionDetails {
+  skillsCount: number;
+  registeredSkills: string[];
+  transport: A2ATransportState;
+}
+
+export interface MCPSectionDetails {
+  toolsCount: number;
+  scopesCount: number;
+  transports: string[];
+  scopes: string[];
+}
+
+export interface DBSectionDetails {
+  migrations: number;
+  modules: number;
+  lastBackup: string | null;
+  integrityCheck: "ok" | "failed" | "not_run" | "skipped";
+}
+
+export interface ProvidersSectionDetails {
+  total: number;
+  active: number;
+  degraded: number;
+  withFreeTier: number;
+  byFamily: {
+    apiKey: number;
+    oauth: number;
+    noAuth: number;
+    webCookie: number;
+  };
+}
+
+export interface BifrostSectionDetails {
+  baseUrl: string | null;
+  lastHealthCheck: string | null;
+  modelCount: number;
+}
+
+export interface LatencyMetrics {
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+  sampleSize: number;
+  source: "synthetic" | "log" | "none";
+}
+
+export type SectionMetrics = LatencyMetrics | null;
+
+export interface HealthReportSection<TDetails> {
+  status: SectionStatus;
+  details: TDetails;
+  warnings: string[];
+}
+
+export type HealthReportSectionKey = "a2a" | "mcp" | "db" | "providers" | "bifrost";
+
+export interface HealthReport {
+  overall: OverallStatus;
+  generatedAt: string;
+  scope: HealthReportScope;
+  sections: Partial<{
+    a2a: HealthReportSection<A2ASectionDetails>;
+    mcp: HealthReportSection<MCPSectionDetails>;
+    db: HealthReportSection<DBSectionDetails>;
+    providers: HealthReportSection<ProvidersSectionDetails>;
+    bifrost: HealthReportSection<BifrostSectionDetails>;
+  }>;
+  metrics?: Partial<{
+    a2a: SectionMetrics;
+    mcp: SectionMetrics;
+    db: SectionMetrics;
+    providers: SectionMetrics;
+    bifrost: SectionMetrics;
+  }>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Collector dependencies (injectable for tests)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface HealthReportDeps {
+  collectA2A?: () => Omit<HealthReportSection<A2ASectionDetails>, "status"> & {
+    /** Caller can pin a transport state to force a non-healthy status. */
+    forcedStatus?: SectionStatus;
+  };
+  collectMCP?: () => Omit<HealthReportSection<MCPSectionDetails>, "status"> & {
+    forcedStatus?: SectionStatus;
+  };
+  collectDB?: () => Omit<HealthReportSection<DBSectionDetails>, "status"> & {
+    forcedStatus?: SectionStatus;
+  };
+  collectProviders?: () => Omit<HealthReportSection<ProvidersSectionDetails>, "status"> & {
+    forcedStatus?: SectionStatus;
+  };
+  collectBifrost?: () => Omit<HealthReportSection<BifrostSectionDetails>, "status"> & {
+    forcedStatus?: SectionStatus;
+  };
+  /**
+   * Optional metrics collector. When includeMetrics=true and the caller did
+   * not inject metrics, we fall back to `collectDefaultMetrics` which
+   * returns null (no log source wired up in this stub).
+   */
+  collectMetrics?: () => Partial<Record<HealthReportSectionKey, SectionMetrics>>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module-level state for filesystem-based defaults
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the migrations directory path. Mirrors the logic in
+ * `migrationRunner.ts` but stops at the first hit so this skill can be called
+ * before the DB subsystem is initialized (i.e. during very early boot).
+ */
+function resolveMigrationsDir(): string | null {
+  const candidates = [
+    process.env["OMNIROUTE_MIGRATIONS_DIR"],
+    path.join(process.cwd(), "src", "lib", "db", "migrations"),
+    path.join(process.cwd(), "migrations"),
+  ].filter((c): c is string => typeof c === "string" && c.length > 0);
+
+  for (const candidate of candidates) {
+    try {
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+        return candidate;
+      }
+    } catch {
+      // ignore — try the next candidate
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the `db` modules directory (top-level .ts files in src/lib/db).
+ * Used for the "modules" count in the db section.
+ */
+function resolveDbModulesDir(): string | null {
+  const candidates = [
+    path.join(process.cwd(), "src", "lib", "db"),
+    path.join(process.cwd(), "app", "src", "lib", "db"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+        return candidate;
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the `db_backups` directory used for last-backup lookups. Tries a
+ * few conventional locations without importing `core.ts` (which would
+ * initialize a DB handle and break the "read-only" guarantee).
+ */
+function resolveBackupsDir(): string | null {
+  const candidates = [
+    process.env["DB_BACKUPS_DIR"],
+    path.join(process.cwd(), "data", "db_backups"),
+    path.join(process.cwd(), ".data", "db_backups"),
+    path.join(process.cwd(), "db_backups"),
+  ].filter((c): c is string => typeof c === "string" && c.length > 0);
+
+  for (const candidate of candidates) {
+    try {
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+        return candidate;
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Default collectors — read from real sources (no network, no DB writes)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function defaultCollectA2A(): Omit<HealthReportSection<A2ASectionDetails>, "status"> & {
+  forcedStatus?: SectionStatus;
+} {
+  const registeredSkills = Object.keys(A2A_SKILL_HANDLERS).sort();
+  const warnings: string[] = [];
+  let transport: A2ATransportState = "online";
+
+  if (registeredSkills.length === 0) {
+    warnings.push("A2A skill registry is empty — no skills are registered");
+    transport = "degraded";
+  }
+
+  return {
+    details: {
+      skillsCount: registeredSkills.length,
+      registeredSkills,
+      transport,
+    },
+    warnings,
+  };
+}
+
+function defaultCollectMCP(): Omit<HealthReportSection<MCPSectionDetails>, "status"> & {
+  forcedStatus?: SectionStatus;
+} {
+  const warnings: string[] = [];
+  const transports = new Set<string>();
+  const scopes = new Set<string>();
+
+  for (const tool of MCP_TOOLS) {
+    transports.add("http");
+    for (const scope of tool.scopes) {
+      scopes.add(scope);
+    }
+  }
+
+  // The MCP server is currently served via HTTP from /api/mcp/tools.
+  // stdio transport is exposed by the open-sse harness for IDE clients
+  // (VS Code, Cursor, Claude Desktop) — we mark it known-but-not-active
+  // unless the env var explicitly opts in.
+  if (process.env["OMNIROUTE_MCP_STDIO"] === "1") {
+    transports.add("stdio");
+  }
+
+  // NOTE: MCP_TOOLS is typed as a literal tuple in the schema, so the
+  // length-0 warning is statically unreachable. We keep an `else` branch
+  // for documentation but the warning only fires for the `scopes`
+  // empty-set case (a real misconfiguration).
+  if (scopes.size === 0) {
+    warnings.push("MCP tools declare no scopes — auth will reject all calls");
+  }
+
+  return {
+    details: {
+      toolsCount: MCP_TOOLS.length,
+      scopesCount: scopes.size,
+      transports: [...transports].sort(),
+      scopes: [...scopes].sort(),
+    },
+    warnings,
+  };
+}
+
+function defaultCollectDB(): Omit<HealthReportSection<DBSectionDetails>, "status"> & {
+  forcedStatus?: SectionStatus;
+} {
+  const warnings: string[] = [];
+  const migrationsDir = resolveMigrationsDir();
+  const modulesDir = resolveDbModulesDir();
+  const backupsDir = resolveBackupsDir();
+
+  let migrations = 0;
+  if (migrationsDir) {
+    try {
+      migrations = fs
+        .readdirSync(migrationsDir)
+        .filter((f) => f.endsWith(".sql")).length;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      warnings.push(`Failed to read migrations dir: ${message}`);
+    }
+  } else {
+    warnings.push("Migrations directory not found — db.migrations = 0");
+  }
+
+  let modules = 0;
+  if (modulesDir) {
+    try {
+      modules = fs
+        .readdirSync(modulesDir)
+        .filter((f) => f.endsWith(".ts") && !f.endsWith(".d.ts")).length;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      warnings.push(`Failed to read db modules dir: ${message}`);
+    }
+  } else {
+    warnings.push("db modules directory not found — db.modules = 0");
+  }
+
+  let lastBackup: string | null = null;
+  if (backupsDir) {
+    try {
+      const files = fs
+        .readdirSync(backupsDir)
+        .filter((f) => f.startsWith("db_") && f.endsWith(".sqlite"))
+        .map((f) => {
+          const full = path.join(backupsDir, f);
+          try {
+            return { name: f, mtimeMs: fs.statSync(full).mtimeMs };
+          } catch {
+            return null;
+          }
+        })
+        .filter((x): x is { name: string; mtimeMs: number } => x !== null)
+        .sort((a, b) => b.mtimeMs - a.mtimeMs);
+      if (files.length > 0) {
+        lastBackup = new Date(files[0]!.mtimeMs).toISOString();
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      warnings.push(`Failed to read backups dir: ${message}`);
+    }
+  }
+
+  // We deliberately do not open a DB connection here. The skill is a
+  // read-only snapshot; an integrity_check is an expensive PRAGMA and
+  // should be triggered explicitly by the caller via the dedicated
+  // /api/db/health MCP tool. We mark this as 'not_run' to be honest about
+  // what this report covers.
+  const integrityCheck: DBSectionDetails["integrityCheck"] = "not_run";
+
+  return {
+    details: {
+      migrations,
+      modules,
+      lastBackup,
+      integrityCheck,
+    },
+    warnings,
+  };
+}
+
+function defaultCollectProviders(): Omit<
+  HealthReportSection<ProvidersSectionDetails>,
+  "status"
+> & { forcedStatus?: SectionStatus } {
+  const warnings: string[] = [];
+  const byFamily = {
+    apiKey: Object.keys(APIKEY_PROVIDERS).length,
+    oauth: Object.keys(OAUTH_PROVIDERS).length,
+    noAuth: Object.keys(NOAUTH_PROVIDERS).length,
+    webCookie: Object.keys(WEB_COOKIE_PROVIDERS).length,
+  };
+  const total = byFamily.apiKey + byFamily.oauth + byFamily.noAuth + byFamily.webCookie;
+
+  // "active" = configured + reachable. We have no live circuit-breaker state
+  // in this stub; we treat all catalog entries as potentially active and
+  // leave the `degraded` field at 0. Callers that want real-time degradation
+  // should query /api/resilience or the per-provider metrics tool. This is
+  // surfaced as a warning so operators know the catalog snapshot is not
+  // equivalent to a live health check.
+  const active = total;
+  const degraded = 0;
+
+  // The four provider maps have heterogeneous value types (some have
+  // `hasFree`, some have `subscriptionRisk`, some have `alias`); we widen
+  // to `unknown[]` and narrow per-element when reading `hasFree`.
+  const allProviders: unknown[] = [
+    ...Object.values(APIKEY_PROVIDERS),
+    ...Object.values(OAUTH_PROVIDERS),
+    ...Object.values(NOAUTH_PROVIDERS),
+    ...Object.values(WEB_COOKIE_PROVIDERS),
+  ];
+  const withFreeTier = allProviders.filter(
+    (p) => (p as { hasFree?: boolean } | null)?.hasFree === true,
+  ).length;
+
+  if (total === 0) {
+    warnings.push("Provider catalog is empty");
+  }
+  if (withFreeTier === 0) {
+    warnings.push("No providers advertise a free tier — every request will incur cost");
+  }
+  warnings.push(
+    "Provider active/degraded counts reflect catalog size; live circuit-breaker " +
+      "state is not consulted by this skill — use the resilience API for that.",
+  );
+
+  return {
+    details: {
+      total,
+      active,
+      degraded,
+      withFreeTier,
+      byFamily,
+    },
+    warnings,
+  };
+}
+
+function defaultCollectBifrost(): Omit<
+  HealthReportSection<BifrostSectionDetails>,
+  "status"
+> & { forcedStatus?: SectionStatus } {
+  // Bifrost is the Tier-1 router substrate (KooshaPari/bifrost). It is
+  // wired into OmniRoute via BifrostAdapter but is NOT YET DEPLOYED in
+  // production. The catalog model cache (L5-111) is staged in a feature
+  // branch and not merged. Until then we report 'unknown' with the
+  // standard "subsystem not yet deployed" warning.
+  return {
+    details: {
+      baseUrl: null,
+      lastHealthCheck: null,
+      modelCount: 0,
+    },
+    warnings: ["subsystem not yet deployed"],
+    forcedStatus: "unknown",
+  };
+}
+
+function defaultCollectMetrics(): Partial<Record<HealthReportSectionKey, SectionMetrics>> {
+  // No log source wired into this skill. We deliberately return null for
+  // every section rather than fabricate numbers. The includeMetrics=true
+  // path is a forward-compat hook for when /api/observability exposes
+  // rolling p50/p95/p99 windows.
+  return {
+    a2a: null,
+    mcp: null,
+    db: null,
+    providers: null,
+    bifrost: null,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Status derivation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Derive the status of a section from its collected details + warnings.
+ * Collectors may explicitly override status via `forcedStatus` (used by
+ * tests and by the bifrost stub).
+ */
+function deriveStatus<K extends HealthReportSectionKey>(
+  key: K,
+  collected: Omit<HealthReportSection<unknown>, "status"> & {
+    forcedStatus?: SectionStatus;
+  },
+): SectionStatus {
+  if (collected.forcedStatus) return collected.forcedStatus;
+
+  const warningCount = collected.warnings.length;
+  const details = collected.details as Record<string, unknown>;
+
+  // Subsystem-specific offline checks first.
+  switch (key) {
+    case "a2a": {
+      const a2aDetails = details as unknown as A2ASectionDetails;
+      if (a2aDetails.transport === "offline") return "offline";
+      if (a2aDetails.skillsCount === 0) return "offline";
+      if (a2aDetails.transport === "degraded" || warningCount > 0) return "degraded";
+      return "healthy";
+    }
+    case "mcp": {
+      const mcpDetails = details as unknown as MCPSectionDetails;
+      if (mcpDetails.toolsCount === 0) return "offline";
+      if (mcpDetails.scopesCount === 0 || warningCount > 0) return "degraded";
+      return "healthy";
+    }
+    case "db": {
+      const dbDetails = details as unknown as DBSectionDetails;
+      if (dbDetails.integrityCheck === "failed") return "offline";
+      if (dbDetails.migrations === 0 || dbDetails.modules === 0) return "degraded";
+      if (dbDetails.integrityCheck === "not_run" || warningCount > 0) return "degraded";
+      return "healthy";
+    }
+    case "providers": {
+      const pDetails = details as unknown as ProvidersSectionDetails;
+      if (pDetails.total === 0) return "offline";
+      const degradedRatio = pDetails.degraded / Math.max(1, pDetails.total);
+      if (degradedRatio > 0.5) return "degraded";
+      if (degradedRatio > 0 || warningCount > 1) return "degraded";
+      return "healthy";
+    }
+    case "bifrost": {
+      const bDetails = details as unknown as BifrostSectionDetails;
+      if (bDetails.baseUrl === null) return "unknown";
+      if (bDetails.modelCount === 0) return "degraded";
+      return "healthy";
+    }
+    default:
+      return warningCount > 0 ? "degraded" : "healthy";
+  }
+}
+
+/**
+ * Roll up multiple section statuses into one overall status using
+ * worst-of semantics. Ordering:
+ *   offline  > degraded > unknown  > healthy
+ *
+ * `unknown` is treated as "could not be verified" and contributes as a
+ * soft degraded signal — the overall never goes `healthy` if any section
+ * is unknown, but it does not escalate to `offline` purely because of an
+ * unknown subsystem.
+ */
+const STATUS_SEVERITY: Record<SectionStatus, number> = {
+  healthy: 0,
+  unknown: 1,
+  degraded: 2,
+  offline: 3,
+};
+
+function rollup(statuses: SectionStatus[]): OverallStatus {
+  let worst: OverallStatus = "healthy";
+  for (const s of statuses) {
+    if (STATUS_SEVERITY[s] > STATUS_SEVERITY[worst]) {
+      // Map unknown → degraded for the rollup (so unknown does not
+      // accidentally look healthy), but do not promote to offline.
+      if (s === "unknown") {
+        if (worst === "healthy") worst = "degraded";
+      } else {
+        worst = s as OverallStatus;
+      }
+    }
+  }
+  return worst;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scope parsing
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SCOPES: readonly HealthReportScope[] = [
+  "all",
+  "a2a",
+  "mcp",
+  "db",
+  "providers",
+  "bifrost",
+] as const;
+
+function parseScope(raw: unknown): HealthReportScope {
+  if (typeof raw === "string" && (SCOPES as readonly string[]).includes(raw)) {
+    return raw as HealthReportScope;
+  }
+  return "all";
+}
+
+function parseIncludeMetrics(raw: unknown): boolean {
+  return raw === true || raw === "true" || raw === 1 || raw === "1";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main skill
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Execute the `health-report` A2A skill.
+ *
+ * The returned `A2ASkillResult.artifacts[0].content` is a JSON-encoded
+ * `HealthReport`. The `metadata` field carries the same JSON as
+ * `content` for clients that prefer typed metadata.
+ */
+export async function executeHealthReport(
+  task: A2ATask,
+  deps: HealthReportDeps = {},
+): Promise<A2ASkillResult> {
+  const metadata = task.metadata ?? {};
+  const scope = parseScope(metadata["scope"]);
+  const includeMetrics = parseIncludeMetrics(metadata["includeMetrics"]);
+
+  // Collect each requested section. We always run all five collectors (they
+  // are cheap and isolated to filesystem + module-level constants); the
+  // scope filter happens after rollup.
+  const a2aRaw = (deps.collectA2A ?? defaultCollectA2A)();
+  const mcpRaw = (deps.collectMCP ?? defaultCollectMCP)();
+  const dbRaw = (deps.collectDB ?? defaultCollectDB)();
+  const providersRaw = (deps.collectProviders ?? defaultCollectProviders)();
+  const bifrostRaw = (deps.collectBifrost ?? defaultCollectBifrost)();
+
+  const a2aSection: HealthReportSection<A2ASectionDetails> = {
+    status: deriveStatus("a2a", a2aRaw),
+    details: a2aRaw.details as A2ASectionDetails,
+    warnings: a2aRaw.warnings,
+  };
+  const mcpSection: HealthReportSection<MCPSectionDetails> = {
+    status: deriveStatus("mcp", mcpRaw),
+    details: mcpRaw.details as MCPSectionDetails,
+    warnings: mcpRaw.warnings,
+  };
+  const dbSection: HealthReportSection<DBSectionDetails> = {
+    status: deriveStatus("db", dbRaw),
+    details: dbRaw.details as DBSectionDetails,
+    warnings: dbRaw.warnings,
+  };
+  const providersSection: HealthReportSection<ProvidersSectionDetails> = {
+    status: deriveStatus("providers", providersRaw),
+    details: providersRaw.details as ProvidersSectionDetails,
+    warnings: providersRaw.warnings,
+  };
+  const bifrostSection: HealthReportSection<BifrostSectionDetails> = {
+    status: deriveStatus("bifrost", bifrostRaw),
+    details: bifrostRaw.details as BifrostSectionDetails,
+    warnings: bifrostRaw.warnings,
+  };
+
+  const allSections = {
+    a2a: a2aSection,
+    mcp: mcpSection,
+    db: dbSection,
+    providers: providersSection,
+    bifrost: bifrostSection,
+  } as const;
+
+  // Apply scope filter.
+  let includedSections: Partial<typeof allSections> = allSections;
+  if (scope !== "all") {
+    includedSections = {
+      [scope]: allSections[scope],
+    } as Partial<typeof allSections>;
+  }
+
+  // Roll up overall from the included sections only.
+  const includedStatuses = Object.values(includedSections).map((s) => s.status);
+  const overall = rollup(includedStatuses);
+
+  const report: HealthReport = {
+    overall,
+    generatedAt: new Date().toISOString(),
+    scope,
+    sections: includedSections,
+  };
+
+  if (includeMetrics) {
+    const metricsCollector = deps.collectMetrics ?? defaultCollectMetrics;
+    const metrics = metricsCollector();
+    // Only attach metrics for sections actually included in the report.
+    const filtered: Partial<Record<HealthReportSectionKey, SectionMetrics>> = {};
+    for (const key of Object.keys(includedSections) as HealthReportSectionKey[]) {
+      if (metrics[key] !== undefined) filtered[key] = metrics[key] ?? null;
+    }
+    report.metrics = filtered;
+  }
+
   return {
     artifacts: [
       {
         type: "text",
-        content: "Health report skill not yet implemented",
+        content: JSON.stringify(report),
       },
     ],
+    metadata: {
+      health_report: report,
+      scope,
+      overall,
+    },
   };
 }

--- a/tests/unit/a2a-health-report.test.ts
+++ b/tests/unit/a2a-health-report.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Tests for the health-report A2A skill.
+ *
+ * Verifies:
+ *  - Default scope ('all') returns all 5 sections and the correct rollup.
+ *  - Scope filter (a2a, mcp, db, providers, bifrost) returns ONLY the
+ *    requested section and the rollup reflects only that section.
+ *  - Degraded-state synthesis: when a collector override pushes one
+ *    subsystem to a worse status, the overall rollup follows.
+ *  - includeMetrics=true appends a metrics block; includeMetrics=false omits
+ *    it.
+ *  - Overall rollup is worst-of: healthy+degraded=degraded;
+ *    healthy+offline=offline; healthy+unknown=degraded; degraded+offline=offline.
+ *  - Bifrost section reports status='unknown' with a single warning
+ *    "subsystem not yet deployed" when no collector override is supplied.
+ *  - Default collectors return the documented shape (5 keys in sections,
+ *    ISO8601 generatedAt).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  executeHealthReport,
+  type A2ASectionDetails,
+  type BifrostSectionDetails,
+  type DBSectionDetails,
+  type HealthReport,
+  type HealthReportDeps,
+  type HealthReportSection,
+  type MCPSectionDetails,
+  type ProvidersSectionDetails,
+} from "@/lib/a2a/skills/healthReport";
+import type { A2ATask } from "@/lib/a2a/taskManager";
+
+function makeTask(metadata: Record<string, unknown> | undefined = {}): A2ATask {
+  return {
+    id: "test-health-task",
+    skill: "health-report",
+    messages: [],
+    metadata,
+    state: "working",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+function parseReport(result: Awaited<ReturnType<typeof executeHealthReport>>): HealthReport {
+  expect(result.artifacts).toHaveLength(1);
+  expect(result.artifacts[0].type).toBe("text");
+  return JSON.parse(result.artifacts[0].content) as HealthReport;
+}
+
+// Deterministic snapshot builders for the five sections. Each returns a
+// section with a known status so the rollup tests can be controlled.
+function healthyA2A(): Omit<HealthReportSection<A2ASectionDetails>, "status"> {
+  return {
+    details: {
+      skillsCount: 10,
+      registeredSkills: ["s1", "s2"],
+      transport: "online",
+    },
+    warnings: [],
+  };
+}
+function healthyMCP(): Omit<HealthReportSection<MCPSectionDetails>, "status"> {
+  return {
+    details: { toolsCount: 87, scopesCount: 4, transports: ["http"], scopes: ["read"] },
+    warnings: [],
+  };
+}
+function healthyDB(): Omit<HealthReportSection<DBSectionDetails>, "status"> {
+  return {
+    details: {
+      migrations: 97,
+      modules: 83,
+      lastBackup: "2026-06-17T00:00:00.000Z",
+      integrityCheck: "ok",
+    },
+    warnings: [],
+  };
+}
+function healthyProviders(): Omit<HealthReportSection<ProvidersSectionDetails>, "status"> {
+  return {
+    details: {
+      total: 232,
+      active: 232,
+      degraded: 0,
+      withFreeTier: 12,
+      byFamily: { apiKey: 100, oauth: 50, noAuth: 50, webCookie: 32 },
+    },
+    warnings: [],
+  };
+}
+function healthyBifrost(): Omit<HealthReportSection<BifrostSectionDetails>, "status"> {
+  return {
+    details: { baseUrl: "https://bifrost.example", lastHealthCheck: "2026-06-18T00:00:00.000Z", modelCount: 50 },
+    warnings: [],
+  };
+}
+
+describe("healthReport A2A skill", () => {
+  it("default scope returns all 5 sections with overall=healthy when all subsystems are healthy", async () => {
+    const deps: HealthReportDeps = {
+      collectA2A: healthyA2A,
+      collectMCP: healthyMCP,
+      collectDB: healthyDB,
+      collectProviders: healthyProviders,
+      collectBifrost: healthyBifrost,
+    };
+    const report = parseReport(await executeHealthReport(makeTask(), deps));
+
+    expect(report.overall).toBe("healthy");
+    expect(report.scope).toBe("all");
+    expect(Object.keys(report.sections).sort()).toEqual(
+      ["a2a", "bifrost", "db", "mcp", "providers"].sort(),
+    );
+    expect(report.sections.a2a?.status).toBe("healthy");
+    expect(report.sections.mcp?.status).toBe("healthy");
+    expect(report.sections.db?.status).toBe("healthy");
+    expect(report.sections.providers?.status).toBe("healthy");
+    expect(report.sections.bifrost?.status).toBe("healthy");
+    // generatedAt is a valid ISO8601 string
+    expect(new Date(report.generatedAt).toString()).not.toBe("Invalid Date");
+  });
+
+  it("scope='a2a' returns ONLY the a2a section", async () => {
+    const deps: HealthReportDeps = {
+      collectA2A: healthyA2A,
+      collectMCP: healthyMCP,
+      collectDB: healthyDB,
+      collectProviders: healthyProviders,
+      collectBifrost: healthyBifrost,
+    };
+    const report = parseReport(
+      await executeHealthReport(makeTask({ scope: "a2a" }), deps),
+    );
+
+    expect(report.scope).toBe("a2a");
+    expect(Object.keys(report.sections)).toEqual(["a2a"]);
+    expect(report.sections.a2a?.details.skillsCount).toBe(10);
+    expect(report.overall).toBe("healthy");
+  });
+
+  it("scope='mcp' returns ONLY the mcp section", async () => {
+    const deps: HealthReportDeps = {
+      collectA2A: healthyA2A,
+      collectMCP: healthyMCP,
+      collectDB: healthyDB,
+      collectProviders: healthyProviders,
+      collectBifrost: healthyBifrost,
+    };
+    const report = parseReport(
+      await executeHealthReport(makeTask({ scope: "mcp" }), deps),
+    );
+
+    expect(report.scope).toBe("mcp");
+    expect(Object.keys(report.sections)).toEqual(["mcp"]);
+    expect(report.sections.mcp?.details.toolsCount).toBe(87);
+    expect(report.overall).toBe("healthy");
+  });
+
+  it("scope='db' returns ONLY the db section", async () => {
+    const deps: HealthReportDeps = {
+      collectA2A: healthyA2A,
+      collectMCP: healthyMCP,
+      collectDB: healthyDB,
+      collectProviders: healthyProviders,
+      collectBifrost: healthyBifrost,
+    };
+    const report = parseReport(
+      await executeHealthReport(makeTask({ scope: "db" }), deps),
+    );
+
+    expect(report.scope).toBe("db");
+    expect(Object.keys(report.sections)).toEqual(["db"]);
+    expect(report.sections.db?.details.migrations).toBe(97);
+    expect(report.overall).toBe("healthy");
+  });
+
+  it("scope='providers' returns ONLY the providers section", async () => {
+    const deps: HealthReportDeps = {
+      collectA2A: healthyA2A,
+      collectMCP: healthyMCP,
+      collectDB: healthyDB,
+      collectProviders: healthyProviders,
+      collectBifrost: healthyBifrost,
+    };
+    const report = parseReport(
+      await executeHealthReport(makeTask({ scope: "providers" }), deps),
+    );
+
+    expect(report.scope).toBe("providers");
+    expect(Object.keys(report.sections)).toEqual(["providers"]);
+    expect(report.sections.providers?.details.total).toBe(232);
+    expect(report.overall).toBe("healthy");
+  });
+
+  it("degraded state synthesis: a forced offline in mcp makes overall=offline", async () => {
+    const deps: HealthReportDeps = {
+      collectA2A: healthyA2A,
+      collectMCP: () => ({
+        details: { toolsCount: 0, scopesCount: 0, transports: [], scopes: [] },
+        warnings: ["MCP tool registry is empty"],
+        forcedStatus: "offline",
+      }),
+      collectDB: healthyDB,
+      collectProviders: healthyProviders,
+      collectBifrost: healthyBifrost,
+    };
+    const report = parseReport(await executeHealthReport(makeTask(), deps));
+
+    expect(report.sections.mcp?.status).toBe("offline");
+    expect(report.sections.a2a?.status).toBe("healthy");
+    expect(report.overall).toBe("offline");
+  });
+
+  it("overall rollup is worst-of: healthy+degraded → degraded, healthy+offline → offline", async () => {
+    const deps: HealthReportDeps = {
+      collectA2A: healthyA2A,
+      collectMCP: () => ({
+        details: { toolsCount: 87, scopesCount: 0, transports: ["http"], scopes: [] },
+        warnings: ["no scopes"],
+        forcedStatus: "degraded",
+      }),
+      collectDB: healthyDB,
+      collectProviders: healthyProviders,
+      collectBifrost: healthyBifrost,
+    };
+    const degradedReport = parseReport(await executeHealthReport(makeTask(), deps));
+    expect(degradedReport.overall).toBe("degraded");
+
+    // Now make providers offline, expect offline.
+    const deps2: HealthReportDeps = {
+      ...deps,
+      collectProviders: () => ({
+        details: {
+          total: 0,
+          active: 0,
+          degraded: 0,
+          withFreeTier: 0,
+          byFamily: { apiKey: 0, oauth: 0, noAuth: 0, webCookie: 0 },
+        },
+        warnings: ["Provider catalog is empty"],
+        forcedStatus: "offline",
+      }),
+    };
+    const offlineReport = parseReport(await executeHealthReport(makeTask(), deps2));
+    expect(offlineReport.overall).toBe("offline");
+  });
+
+  it("overall rollup: a single 'unknown' section makes overall=degraded (not healthy, not offline)", async () => {
+    // Bifrost is the only section we want to count; others healthy.
+    const deps: HealthReportDeps = {
+      collectA2A: healthyA2A,
+      collectMCP: healthyMCP,
+      collectDB: healthyDB,
+      collectProviders: healthyProviders,
+      collectBifrost: () => ({
+        details: { baseUrl: null, lastHealthCheck: null, modelCount: 0 },
+        warnings: ["subsystem not yet deployed"],
+        forcedStatus: "unknown",
+      }),
+    };
+    const report = parseReport(
+      await executeHealthReport(makeTask({ scope: "bifrost" }), deps),
+    );
+    expect(report.sections.bifrost?.status).toBe("unknown");
+    expect(report.overall).toBe("degraded");
+  });
+
+  it("default bifrost collector reports status='unknown' with 'subsystem not yet deployed' warning", async () => {
+    // No deps override — we exercise the real defaultCollectBifrost path.
+    // This test deliberately does NOT mock the other collectors either so
+    // it covers the real file/migration/provider paths too. We only
+    // assert on the bifrost section + the overall rollup behaviour.
+    const report = parseReport(
+      await executeHealthReport(makeTask({ scope: "bifrost" })),
+    );
+    expect(report.sections.bifrost?.status).toBe("unknown");
+    expect(report.sections.bifrost?.warnings).toContain("subsystem not yet deployed");
+    expect(report.sections.bifrost?.details.baseUrl).toBeNull();
+    expect(report.sections.bifrost?.details.modelCount).toBe(0);
+  });
+
+  it("includeMetrics=true appends a metrics block with the same keys as sections", async () => {
+    const deps: HealthReportDeps = {
+      collectA2A: healthyA2A,
+      collectMCP: healthyMCP,
+      collectDB: healthyDB,
+      collectProviders: healthyProviders,
+      collectBifrost: healthyBifrost,
+      collectMetrics: () => ({
+        a2a: { p50: 10, p95: 50, p99: 100, sampleSize: 200, source: "synthetic" },
+        mcp: { p50: 5, p95: 20, p99: 80, sampleSize: 200, source: "synthetic" },
+        db: { p50: 1, p95: 5, p99: 10, sampleSize: 200, source: "synthetic" },
+        providers: { p50: 8, p95: 30, p99: 90, sampleSize: 200, source: "synthetic" },
+        bifrost: { p50: null, p95: null, p99: null, sampleSize: 0, source: "none" },
+      }),
+    };
+    const report = parseReport(
+      await executeHealthReport(makeTask({ scope: "a2a", includeMetrics: true }), deps),
+    );
+    expect(report.metrics).toBeDefined();
+    expect(report.metrics?.a2a?.p50).toBe(10);
+    expect(report.metrics?.a2a?.p95).toBe(50);
+    expect(report.metrics?.a2a?.p99).toBe(100);
+    // Only the scoped section gets a metrics entry.
+    expect(Object.keys(report.metrics ?? {})).toEqual(["a2a"]);
+  });
+
+  it("includeMetrics=false (default) omits the metrics block", async () => {
+    const deps: HealthReportDeps = {
+      collectA2A: healthyA2A,
+      collectMCP: healthyMCP,
+      collectDB: healthyDB,
+      collectProviders: healthyProviders,
+      collectBifrost: healthyBifrost,
+    };
+    const report = parseReport(await executeHealthReport(makeTask(), deps));
+    expect(report.metrics).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Replaces the 19-line stub at `src/lib/a2a/skills/healthReport.ts` with a real implementation that produces a structured 5-section health report covering the A2A server, MCP server, SQLite database, provider catalog, and Bifrost Tier-1 router substrate.

Closes **1/6** remaining a2a skill stubs (DEBT-006).

## Report shape

```ts
{
  overall: 'healthy' | 'degraded' | 'offline',
  generatedAt: ISO8601,
  scope: 'all' | 'a2a' | 'mcp' | 'db' | 'providers' | 'bifrost',
  sections: { a2a, mcp, db, providers, bifrost }   // filtered by scope
  metrics?: { a2a?: {p50,p95,p99} | null, ... }    // includeMetrics=true
}
```

Each section is shaped as `{ status, details, warnings }`. The `bifrost` section reports `status: 'unknown'` with a single warning "subsystem not yet deployed" when no collector override is supplied (L5-111 cache not yet merged).

Collectors are **read-only** — no network calls, no DB writes.

## Rollup algorithm (worst-of)

Severity ordering: **offline (3) > degraded (2) > unknown (1) > healthy (0)**.

The rollup takes the max severity across the *included* sections, with one twist: an `'unknown'` section never promotes the rollup to `'offline'` but does bump a `'healthy'` rollup to `'degraded'` (unknown = could not be verified, not 'all good'). This keeps the rollup honest: a single not-yet-deployed subsystem cannot mask an actual offline elsewhere, but it also cannot be silently ignored.

Rollup is computed over the **included** sections only, so `scope='a2a'` produces a rollup that reflects only the a2a subsystem.

## Testability

All five collectors and the metrics collector can be overridden via the optional `deps` argument to `executeHealthReport`. Tests inject deterministic snapshots so the rollup behaviour can be asserted without touching the real registry / provider catalog / db files.

## Test coverage

11 vitest cases in `tests/unit/a2a-health-report.test.ts`:

1. Default scope `'all'` returns all 5 sections with `overall=healthy`
2. `scope='a2a'` returns ONLY the a2a section
3. `scope='mcp'` returns ONLY the mcp section
4. `scope='db'` returns ONLY the db section
5. `scope='providers'` returns ONLY the providers section
6. Degraded synthesis: forced offline in mcp → `overall=offline`
7. Worst-of rollup: `healthy+degraded=degraded`, `healthy+offline=offline`
8. Rollup edge: a single `unknown` section makes `overall=degraded` (not healthy, not offline)
9. Default bifrost collector reports `unknown` with the standard warning
10. `includeMetrics=true` appends a metrics block with the same keys as sections
11. `includeMetrics=false` (default) omits the metrics block

## Verification

- `tsc --noEmit` (sandbox): zero new errors from new files (pre-existing infra errors unrelated)
- `npx vitest run`: **11/11 pass** in 21 ms

## Closes

- DEBT-006 (1/6 remaining a2a skill stubs)


___

## **CodeAnt-AI Description**
**Turn the A2A health report into a full multi-system status snapshot**

### What Changed
- Replaced the placeholder health report with a real report that summarizes the A2A server, MCP server, database, provider catalog, and Bifrost router status.
- The report now supports scope filtering so users can request one subsystem or the full snapshot, and the overall result reflects only the sections included.
- Added clearer section details and warnings, including a default “subsystem not yet deployed” result for Bifrost and a metrics block when requested.
- Added tests for the report shape, scope filtering, status rollup, Bifrost handling, and optional metrics output.

### Impact
`✅ Clearer server health checks`
`✅ Faster troubleshooting for subsystem-specific issues`
`✅ Fewer false “all clear” health results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
