### PR TITLE
feat(bifrost): virtual-key minting + cost tracking (B5 of v8.1 track, ADR-031)

### DIFF
--- a/docs/frameworks/VIRTUAL-KEYS.md
+++ b/docs/frameworks/VIRTUAL-KEYS.md
@@ -1,0 +1,192 @@
+---
+title: "Virtual Keys & Cost Tracking"
+version: 3.8.6
+lastUpdated: 2026-06-18
+---
+
+# Virtual Keys & Cost Tracking
+
+> **Source of truth:** `src/lib/db/virtualKeys.ts`, `src/lib/db/costTracking.ts`, `src/lib/a2a/skills/mintVirtualKey.ts`
+> **Last updated:** 2026-06-18 — v3.8.6 (B5 of v8.1 Bifrost track, ADR-031)
+
+A **virtual key** is a per-tenant scoped credential that OmniRoute mints, hands to the user, and resolves to a real upstream key at request time. The raw key is shown exactly once on creation; from that point on the server only retains a sha256 hex digest of the raw value, and every state-mutating path runs as a single SQL `UPDATE` with the cap baked into the `WHERE` clause.
+
+This document covers activation, lifecycle, cost-event ingestion, dashboard usage, and the security model. For the broader Bifrost Tier-1 router rollout, see [`docs/adr/0031-bifrost-tier1-router.md`](#) and `PLAN.md` § 2.5.2.
+
+---
+
+## Activation
+
+Virtual keys are enabled automatically on first start. The two new migrations run in order:
+
+- `102_virtual_keys.sql` — creates `virtual_keys` and its three indexes
+- `103_cost_events.sql` — creates the `cost_events` append-only ledger
+
+The migration runner is the existing one in `src/lib/db/migrationRunner.ts`; no new env vars are required. To verify a fresh deployment:
+
+```bash
+sqlite3 "$DATA_DIR/storage.sqlite" "SELECT version, name FROM _omniroute_migrations WHERE version IN ('102','103');"
+```
+
+Both rows should be present. If a deployment has been running an older build and the new columns / tables are already present, the migration runner is idempotent (it checks `sqlite_master` before applying).
+
+---
+
+## Lifecycle
+
+```
+   mint                    consume / resolve
+ ┌────────┐  POST /api/virtual-keys   ┌────────────────────────┐
+ │  user  │ ────────────────────────▶ │  virtual_keys row      │
+ └────────┘                           │  (rawKey shown ONCE)   │
+      ▲                               │                        │
+      │ rawKey                         │  id, hashed_key,       │
+      │ (copy now)                     │  max_cost_usd, max_rpd,│
+      │                                │  current_cost_usd,     │
+      │                                │  current_rpd,          │
+      │                                │  expires_at,           │
+      │                                │  revoked_at            │
+      │                                └────────────────────────┘
+      │                                          │
+      │  DELETE /api/virtual-keys/:id            │  recordVirtualKeyUsage
+      │ ─────────────────────────────────────────▶  (atomic budget debit)
+      │  +1 cost_event row in cost_events         │  + cost_events row
+      ▼                                          ▼
+  revoked                                    ledger grows
+```
+
+### States
+
+| State             | `revoked_at` | `expires_at` | What happens on resolve / recordUsage |
+| :---------------- | :----------- | :----------- | :-------------------------------------- |
+| **active**        | `NULL`       | future / `NULL` | counter bumps, request allowed        |
+| **expired**       | `NULL`       | past         | `resolveVirtualKey` returns `null`     |
+| **at-cap**        | `NULL`       | future / `NULL` | next `recordUsage` returns `over_budget` / `over_rpd` |
+| **revoked**       | set          | any          | `resolve` and `recordUsage` both reject |
+
+### Idempotency
+
+- `revokeVirtualKey(id)` returns `true` on the active → revoked transition and `false` on every subsequent call. There is no "un-revoke" path.
+- `mintVirtualKey` always returns a fresh row. Two mints in the same millisecond produce different raw keys (32 bytes of `crypto.randomBytes` is enough entropy for the lifetime of a deployment).
+
+---
+
+## Cost-event Ingestion
+
+Every successful `recordVirtualKeyUsage` writes one `cost_events` row with the same provider / model / token / cost fields. The write is best-effort — a failure is logged but does not roll back the budget counters, since the request was already allowed.
+
+If you need to backfill from upstream receipts, use `recordCostEvent` directly:
+
+```ts
+import { recordCostEvent } from "@/lib/db/costTracking";
+
+recordCostEvent({
+  virtualKeyId: "vkey-...",
+  tenantId: "tenant_...",
+  provider: "openai",
+  model: "gpt-4o",
+  promptTokens: 1234,
+  completionTokens: 567,
+  costUsd: 0.042,
+  occurredAt: new Date().toISOString(), // optional, defaults to now
+});
+```
+
+### Retention
+
+The `cost_events` table is append-only. There is no automatic prune; operators are expected to drop or archive rows older than their retention window. A simple example:
+
+```sql
+DELETE FROM cost_events WHERE occurred_at < datetime('now', '-180 days');
+```
+
+Tune the threshold to your reporting window. The dashboard defaults to a 30-day view; longer windows just need the index (`idx_cost_events_occurred_at`) which is already in place.
+
+---
+
+## Dashboard Usage
+
+The operator UI lives at `http://localhost:20128/dashboard/keys` (or your configured host). It uses three REST endpoints:
+
+| Verb + path                          | Purpose                                          |
+| :----------------------------------- | :----------------------------------------------- |
+| `POST /api/virtual-keys`             | Mint a key (returns `rawKey` ONCE)               |
+| `GET  /api/virtual-keys?tenantId=…`  | List keys for a tenant                           |
+| `DELETE /api/virtual-keys/:id`       | Revoke a key                                     |
+| `GET  /api/virtual-keys/:id/cost`    | Cost summary for a single key (last 30 days)     |
+
+The cost summary response includes `byDay`, `byProvider`, `byModel` series. The dashboard attaches them to a `data-cost-by-day` attribute on the chart placeholder so a follow-up chart-library PR can render without re-fetching.
+
+All routes use the existing `requireManagementAuth` middleware — the same gate as the legacy `/api/keys` CRUD.
+
+### A2A
+
+Equivalent capability is exposed via the `mint-virtual-key` A2A skill (gated by the `keys:write` scope). The skill is registered in `A2A_SKILL_HANDLERS` under that name; call it via JSON-RPC at `POST /a2a` with `skill: "mint-virtual-key"`.
+
+---
+
+## Security Model
+
+> **One line:** The raw key is a 32-byte random hex string shown exactly once on mint and stored as a sha256 hex digest thereafter; every state-mutating path is a single SQL `UPDATE` whose `WHERE` clause enforces the cap atomically.
+
+### Key generation
+
+- 32 bytes from `crypto.randomBytes` (Node built-in, no extra deps).
+- Encoded as lowercase hex and prefixed with `vk_` for log/UI identification.
+- The first 8 characters (`vk_xxxx`) are stored as `key_prefix` so operators can identify a key without exposing the secret.
+
+### Storage
+
+- `hashed_key` is `sha256(rawKey)` in lowercase hex (64 chars).
+- `UNIQUE` constraint on `hashed_key` — even if two mints collide on the 64-bit prefix, the digest collision space (2²⁵⁶) is unreachable in practice.
+- `rawKey` is **never** persisted. It is returned only in the `POST /api/virtual-keys` response and the `mint-virtual-key` A2A artifact, and the caller is responsible for surfacing it to the user.
+
+### Resolve path
+
+`resolveVirtualKey(rawKey)` hashes the argument and looks up the row by digest. If the row is missing, revoked, or expired, the function returns `null` and the request is treated as unauthenticated. As a best-effort side-effect, `last_used_at` is bumped on success — this is informational, not a security primitive.
+
+### Atomic budget enforcement
+
+```sql
+UPDATE virtual_keys
+   SET current_cost_usd = current_cost_usd + ?,
+       current_rpd      = CASE WHEN last_reset_day = ? THEN current_rpd + 1 ELSE 1 END,
+       last_used_at     = ?,
+       last_reset_day   = ?
+ WHERE id = ?
+   AND revoked_at IS NULL
+   AND (max_cost_usd IS NULL OR current_cost_usd + ? <= max_cost_usd)
+   AND (max_rpd      IS NULL OR last_reset_day <> ? OR current_rpd + 1 <= max_rpd)
+```
+
+The cap is in the `WHERE` clause, not in application code. SQLite serialises writes; the loser of a concurrent debit sees `changes() === 0` and is mapped to `over_budget` or `over_rpd` by the caller. There is no read-then-write window.
+
+### What an attacker can and cannot do
+
+| Threat                                                | Mitigation                                         |
+| :---------------------------------------------------- | :------------------------------------------------- |
+| Steal raw key from another tenant's `listVirtualKeysForTenant` | `list*` returns the metadata row only; `hashed_key` is never sent (the `/cost` route does not need it). |
+| Replay a raw key after revocation                     | `resolveVirtualKey` filters `revoked_at IS NULL`; revoked rows hash-lookup fails. |
+| Replay a raw key after expiry                         | `resolveVirtualKey` filters `(expires_at IS NULL OR expires_at > now)`. |
+| Race the budget cap                                   | Single-statement `UPDATE` with the cap in the `WHERE` clause; SQLite serialisation enforces ordering. |
+| Recover the raw key from a database dump              | The stored value is `sha256(rawKey)`; pre-image resistance + the rawKey entropy (2²⁵⁶) make brute force infeasible. |
+
+### Out of scope (for B5)
+
+- Rate limiting per IP / per session — handled at the edge / proxy layer.
+- Per-model `allowedModels` enforcement at request time — the field is stored and surfaced in the dashboard, but the request-pipeline integration is a follow-up. The `BifrostBackend` executor (PR #72) is the integration point.
+- Webhook on revocation — a follow-up PR can subscribe to the row state change in the existing `audit_log`.
+
+---
+
+## Cross-references
+
+- ADR-031 § 1.3 — virtual keys
+- ADR-031 § 2.3 — atomic guards
+- ADR-031 § 4 — cost tracking
+- `PLAN.md` § 2.5.2 — B5 description
+- `src/lib/a2a/skills/mintVirtualKey.ts` — A2A skill
+- `src/lib/db/virtualKeys.ts` — DB module
+- `src/lib/db/costTracking.ts` — ledger
+- `src/app/api/virtual-keys/route.ts` — REST surface
+- `src/app/(dashboard)/dashboard/keys/page.tsx` — operator UI

--- a/src/app/(dashboard)/dashboard/keys/page.tsx
+++ b/src/app/(dashboard)/dashboard/keys/page.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+/**
+ * Dashboard: Virtual Keys (B5 of v8.1 Bifrost track, ADR-031)
+ *
+ * Operator-facing page for:
+ *   - minting new per-tenant virtual keys (rawKey shown ONCE on create)
+ *   - listing all keys for a tenant (active + revoked)
+ *   - revoking keys
+ *   - per-key cost summary (chart placeholder — data is attached so a
+ *     follow-up PR can render without re-fetching)
+ *
+ * The raw key is shown exactly once (on mint) and never again — the server
+ * stores only the sha256 hash. Operators are expected to copy the raw key
+ * immediately and store it in their own secret manager.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { Button, Card, Input } from "@/shared/components";
+
+interface VirtualKey {
+  id: string;
+  tenantId: string;
+  keyPrefix: string;
+  label: string;
+  allowedModels: string[] | null;
+  maxCostUsd: number | null;
+  maxRpd: number | null;
+  currentCostUsd: number;
+  currentRpd: number;
+  expiresAt: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+}
+
+interface CostSummary {
+  sinceIso: string;
+  untilIso: string;
+  totalCostUsd: number;
+  totalPromptTokens: number;
+  totalCompletionTokens: number;
+  eventCount: number;
+  byProvider: Array<{ key: string; costUsd: number; eventCount: number }>;
+  byModel: Array<{ key: string; costUsd: number; eventCount: number }>;
+  byDay: Array<{ day: string; costUsd: number; eventCount: number }>;
+}
+
+interface MintResponse {
+  key: VirtualKey;
+  rawKey: string;
+}
+
+function formatUsd(n: number): string {
+  return `$${n.toFixed(4)}`;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function statusOf(k: VirtualKey): { label: string; tone: "ok" | "warn" | "off" } {
+  if (k.revokedAt) return { label: "revoked", tone: "off" };
+  if (k.expiresAt && new Date(k.expiresAt) < new Date()) return { label: "expired", tone: "off" };
+  if (k.maxCostUsd !== null && k.currentCostUsd >= k.maxCostUsd) {
+    return { label: "over budget", tone: "warn" };
+  }
+  if (k.maxRpd !== null && k.currentRpd >= k.maxRpd) {
+    return { label: "over RPD", tone: "warn" };
+  }
+  return { label: "active", tone: "ok" };
+}
+
+export default function VirtualKeysPage() {
+  const [tenantId, setTenantId] = useState("tenant_default");
+  const [keys, setKeys] = useState<VirtualKey[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [mintedRawKey, setMintedRawKey] = useState<string | null>(null);
+  const [mintedMeta, setMintedMeta] = useState<VirtualKey | null>(null);
+
+  // mint form
+  const [label, setLabel] = useState("");
+  const [maxCostUsd, setMaxCostUsd] = useState<string>("");
+  const [maxRpd, setMaxRpd] = useState<string>("");
+  const [expiresAt, setExpiresAt] = useState<string>("");
+  const [minting, setMinting] = useState(false);
+
+  // cost chart
+  const [selectedKeyId, setSelectedKeyId] = useState<string | null>(null);
+  const [costSummary, setCostSummary] = useState<CostSummary | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = new URL("/api/virtual-keys", window.location.origin);
+      url.searchParams.set("tenantId", tenantId);
+      const res = await fetch(url.toString());
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? `HTTP ${res.status}`);
+      }
+      const j = (await res.json()) as { keys: VirtualKey[] };
+      setKeys(j.keys);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [tenantId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleMint = useCallback(async () => {
+    setMinting(true);
+    setError(null);
+    setMintedRawKey(null);
+    setMintedMeta(null);
+    try {
+      const body: Record<string, unknown> = { tenantId, label };
+      if (maxCostUsd.trim().length > 0) body.maxCostUsd = Number(maxCostUsd);
+      if (maxRpd.trim().length > 0) body.maxRpd = Number(maxRpd);
+      if (expiresAt.trim().length > 0) body.expiresAt = new Date(expiresAt).toISOString();
+      const res = await fetch("/api/virtual-keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? `HTTP ${res.status}`);
+      }
+      const j = (await res.json()) as MintResponse;
+      setMintedRawKey(j.rawKey);
+      setMintedMeta(j.key);
+      setLabel("");
+      setMaxCostUsd("");
+      setMaxRpd("");
+      setExpiresAt("");
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setMinting(false);
+    }
+  }, [tenantId, label, maxCostUsd, maxRpd, expiresAt, refresh]);
+
+  const handleRevoke = useCallback(
+    async (id: string) => {
+      setError(null);
+      try {
+        const res = await fetch(`/api/virtual-keys/${encodeURIComponent(id)}`, {
+          method: "DELETE",
+        });
+        if (!res.ok) {
+          const j = (await res.json().catch(() => ({}))) as { error?: string };
+          throw new Error(j.error ?? `HTTP ${res.status}`);
+        }
+        await refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [refresh],
+  );
+
+  const loadCost = useCallback(async (id: string) => {
+    setSelectedKeyId(id);
+    setCostSummary(null);
+    try {
+      const res = await fetch(`/api/virtual-keys/${encodeURIComponent(id)}/cost`);
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? `HTTP ${res.status}`);
+      }
+      setCostSummary((await res.json()) as CostSummary);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Virtual Keys</h1>
+        <p className="text-sm text-gray-500">
+          Per-tenant scoped credentials. The raw key is shown once on creation and never again.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+
+      {mintedRawKey && mintedMeta && (
+        <Card title="Key minted — copy the raw key now">
+          <div className="flex flex-col gap-2 text-sm">
+            <div>
+              <span className="text-gray-500">Key ID:</span>{" "}
+              <code className="rounded bg-gray-100 px-1 py-0.5">{mintedMeta.id}</code>
+            </div>
+            <div>
+              <span className="text-gray-500">Tenant:</span>{" "}
+              <code className="rounded bg-gray-100 px-1 py-0.5">{mintedMeta.tenantId}</code>
+            </div>
+            <div>
+              <span className="text-gray-500">Raw key (shown once):</span>
+              <div className="mt-1 flex items-center gap-2">
+                <code className="block w-full select-all break-all rounded bg-yellow-50 px-2 py-1 font-mono text-xs">
+                  {mintedRawKey}
+                </code>
+                <Button
+                  type="button"
+                  onClick={() => {
+                    void navigator.clipboard.writeText(mintedRawKey);
+                  }}
+                >
+                  Copy
+                </Button>
+              </div>
+            </div>
+            <p className="text-xs text-gray-500">
+              Store this in your secret manager. The server only retains the sha256 hash.
+            </p>
+          </div>
+        </Card>
+      )}
+
+      <Card title="Mint a key">
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Tenant ID</span>
+            <Input value={tenantId} onChange={(e) => setTenantId(e.target.value)} />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Label (optional)</span>
+            <Input value={label} onChange={(e) => setLabel(e.target.value)} />
+          </label>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="flex flex-col gap-1 text-sm">
+              <span>Max cost (USD, optional)</span>
+              <Input
+                value={maxCostUsd}
+                onChange={(e) => setMaxCostUsd(e.target.value)}
+                inputMode="decimal"
+                placeholder="e.g. 10"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm">
+              <span>Max requests / day (optional)</span>
+              <Input
+                value={maxRpd}
+                onChange={(e) => setMaxRpd(e.target.value)}
+                inputMode="numeric"
+                placeholder="e.g. 1000"
+              />
+            </label>
+          </div>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Expires at (optional)</span>
+            <Input
+              type="datetime-local"
+              value={expiresAt}
+              onChange={(e) => setExpiresAt(e.target.value)}
+            />
+          </label>
+          <Button type="button" onClick={handleMint} disabled={minting || !tenantId}>
+            {minting ? "Minting…" : "Mint key"}
+          </Button>
+        </div>
+      </Card>
+
+      <Card title={`Keys for tenant: ${tenantId}`}>
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <span className="text-sm text-gray-500">
+            {loading ? "Loading…" : `${keys.length} key(s)`}
+          </span>
+          <Button type="button" onClick={refresh} disabled={loading}>
+            Refresh
+          </Button>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left">
+                <th className="py-1 pr-2">Prefix</th>
+                <th className="py-1 pr-2">Label</th>
+                <th className="py-1 pr-2">Caps</th>
+                <th className="py-1 pr-2">Usage</th>
+                <th className="py-1 pr-2">Status</th>
+                <th className="py-1 pr-2">Created</th>
+                <th className="py-1 pr-2">Last used</th>
+                <th className="py-1 pr-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => {
+                const status = statusOf(k);
+                const caps: string[] = [];
+                if (k.maxCostUsd !== null) caps.push(`$${k.maxCostUsd}`);
+                if (k.maxRpd !== null) caps.push(`${k.maxRpd}/day`);
+                if (k.allowedModels) caps.push(`${k.allowedModels.length} model(s)`);
+                if (k.expiresAt) caps.push(`exp ${formatDate(k.expiresAt)}`);
+                return (
+                  <tr key={k.id} className="border-b">
+                    <td className="py-1 pr-2 font-mono text-xs">{k.keyPrefix}…</td>
+                    <td className="py-1 pr-2">{k.label || "—"}</td>
+                    <td className="py-1 pr-2 text-xs text-gray-600">{caps.join(" · ") || "none"}</td>
+                    <td className="py-1 pr-2 text-xs">
+                      {formatUsd(k.currentCostUsd)} / {k.currentRpd} req
+                    </td>
+                    <td className="py-1 pr-2">
+                      <span
+                        className={
+                          status.tone === "ok"
+                            ? "text-green-700"
+                            : status.tone === "warn"
+                              ? "text-yellow-700"
+                              : "text-gray-500 line-through"
+                        }
+                      >
+                        {status.label}
+                      </span>
+                    </td>
+                    <td className="py-1 pr-2 text-xs">{formatDate(k.createdAt)}</td>
+                    <td className="py-1 pr-2 text-xs">{formatDate(k.lastUsedAt)}</td>
+                    <td className="py-1 pr-2">
+                      <div className="flex gap-1">
+                        <Button
+                          type="button"
+                          onClick={() => loadCost(k.id)}
+                          disabled={!!k.revokedAt}
+                        >
+                          Cost
+                        </Button>
+                        <Button
+                          type="button"
+                          onClick={() => handleRevoke(k.id)}
+                          disabled={!!k.revokedAt}
+                        >
+                          Revoke
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+              {!loading && keys.length === 0 && (
+                <tr>
+                  <td colSpan={8} className="py-3 text-center text-sm text-gray-500">
+                    No keys yet — mint one above.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+
+      {selectedKeyId && (
+        <Card title={`Cost summary — ${selectedKeyId}`}>
+          {costSummary ? (
+            <div className="flex flex-col gap-3" data-cost-chart-placeholder>
+              <div className="grid grid-cols-2 gap-2 text-sm md:grid-cols-4">
+                <div>
+                  <div className="text-gray-500">Total cost</div>
+                  <div className="font-mono">{formatUsd(costSummary.totalCostUsd)}</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Events</div>
+                  <div className="font-mono">{costSummary.eventCount}</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Prompt tokens</div>
+                  <div className="font-mono">{costSummary.totalPromptTokens}</div>
+                </div>
+                <div>
+                  <div className="text-gray-500">Completion tokens</div>
+                  <div className="font-mono">{costSummary.totalCompletionTokens}</div>
+                </div>
+              </div>
+              {/* Cost chart placeholder — no chart library dep per B5 constraint.
+                  Follow-up PR can render the byDay series. */}
+              <div
+                className="rounded border border-dashed border-gray-300 p-3 text-xs text-gray-500"
+                data-cost-by-day={JSON.stringify(costSummary.byDay)}
+              >
+                Cost chart placeholder — <code>byDay</code> series attached as
+                <code> data-cost-by-day</code> for a follow-up chart-library PR.
+              </div>
+              <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                <div>
+                  <div className="text-sm font-medium">By provider</div>
+                  <ul className="text-xs">
+                    {costSummary.byProvider.map((b) => (
+                      <li key={b.key} className="flex justify-between border-b py-0.5">
+                        <span>{b.key || "—"}</span>
+                        <span className="font-mono">{formatUsd(b.costUsd)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <div className="text-sm font-medium">By model</div>
+                  <ul className="text-xs">
+                    {costSummary.byModel.map((b) => (
+                      <li key={b.key} className="flex justify-between border-b py-0.5">
+                        <span>{b.key || "—"}</span>
+                        <span className="font-mono">{formatUsd(b.costUsd)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="text-sm text-gray-500">Loading…</div>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/virtual-keys/[id]/cost/route.ts
+++ b/src/app/api/virtual-keys/[id]/cost/route.ts
@@ -1,0 +1,36 @@
+/**
+ * REST: /api/virtual-keys/[id]/cost
+ *
+ * GET → cost summary for a single virtual key. Shape matches the
+ * dashboard's per-key cost chart binding (totalCostUsd + byDay + byProvider
+ * + byModel). The `since` query param accepts ISO 8601; if omitted,
+ * defaults to 30 days back.
+ */
+import { NextResponse } from "next/server";
+import { summarizeCostForKey } from "@/lib/db/costTracking";
+import { getVirtualKey } from "@/lib/db/virtualKeys";
+import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+import * as log from "@/sse/utils/logger";
+
+export async function GET(request: Request, ctx: { params: Promise<{ id: string }> }) {
+  const authError = await requireManagementAuth(request);
+  if (authError) return authError;
+
+  try {
+    const { id } = await ctx.params;
+    if (!id || typeof id !== "string") {
+      return NextResponse.json({ error: "id is required" }, { status: 400 });
+    }
+    const key = getVirtualKey(id);
+    if (!key) {
+      return NextResponse.json({ error: "Virtual key not found" }, { status: 404 });
+    }
+    const url = new URL(request.url);
+    const since = url.searchParams.get("since") ?? undefined;
+    const summary = summarizeCostForKey(id, since);
+    return NextResponse.json({ keyId: id, tenantId: key.tenantId, ...summary });
+  } catch (error) {
+    log.error("virtual-keys", "Error fetching cost summary", error);
+    return NextResponse.json({ error: "Failed to fetch cost summary" }, { status: 500 });
+  }
+}

--- a/src/app/api/virtual-keys/[id]/route.ts
+++ b/src/app/api/virtual-keys/[id]/route.ts
@@ -1,0 +1,38 @@
+/**
+ * REST: /api/virtual-keys/[id]
+ *
+ * DELETE → revoke a virtual key. Idempotent (returns 200 on already-revoked
+ * or unknown id, so clients can replay without error; full 404 is reserved
+ * for malformed ids so the caller can distinguish "this id was never valid"
+ * from "this id was already revoked").
+ */
+import { NextResponse } from "next/server";
+import { revokeVirtualKey, getVirtualKey } from "@/lib/db/virtualKeys";
+import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+import * as log from "@/sse/utils/logger";
+
+export async function DELETE(_request: Request, ctx: { params: Promise<{ id: string }> }) {
+  const authError = await requireManagementAuth(_request);
+  if (authError) return authError;
+
+  try {
+    const { id } = await ctx.params;
+    if (!id || typeof id !== "string") {
+      return NextResponse.json({ error: "id is required" }, { status: 400 });
+    }
+    // Distinguish "never existed" (404) from "already revoked" (200).
+    const existing = getVirtualKey(id);
+    if (!existing) {
+      return NextResponse.json({ error: "Virtual key not found" }, { status: 404 });
+    }
+    const revoked = revokeVirtualKey(id);
+    return NextResponse.json({
+      message: revoked ? "Virtual key revoked" : "Virtual key was already revoked",
+      id,
+      alreadyRevoked: !revoked,
+    });
+  } catch (error) {
+    log.error("virtual-keys", "Error revoking virtual key", error);
+    return NextResponse.json({ error: "Failed to revoke virtual key" }, { status: 500 });
+  }
+}

--- a/src/app/api/virtual-keys/route.ts
+++ b/src/app/api/virtual-keys/route.ts
@@ -1,0 +1,173 @@
+/**
+ * REST: /api/virtual-keys
+ *
+ * B5 of v8.1 Bifrost track (ADR-031). Endpoints:
+ *   - POST /api/virtual-keys          → mint a new key (returns rawKey ONCE)
+ *   - GET  /api/virtual-keys?tenantId=…  → list keys (optionally filtered)
+ *
+ * Auth: requireManagementAuth (same as the legacy /api/keys CRUD; the
+ * "keys:write" scope check is enforced in the A2A skill and at the
+ * BFF/proxy edge, not here — this is an admin-only management surface).
+ */
+import { NextResponse } from "next/server";
+import {
+  mintVirtualKey,
+  listVirtualKeysForTenant,
+  listAllVirtualKeys,
+} from "@/lib/db/virtualKeys";
+import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+import * as log from "@/sse/utils/logger";
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function asStringArrayOrUndefined(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) return undefined;
+  const filtered = value.filter((v): v is string => typeof v === "string");
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function asNumberOrNull(value: unknown): number | null {
+  if (value === null) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined as unknown as null;
+}
+
+// GET /api/virtual-keys?tenantId=X
+export async function GET(request: Request) {
+  const authError = await requireManagementAuth(request);
+  if (authError) return authError;
+
+  try {
+    const url = new URL(request.url);
+    const tenantId = url.searchParams.get("tenantId");
+    const keys = tenantId ? listVirtualKeysForTenant(tenantId) : listAllVirtualKeys();
+    // NOTE: never expose the hash. The raw key is also never returned by
+    // list / get; only mint (POST) returns it, and only on creation.
+    return NextResponse.json({
+      keys,
+      total: keys.length,
+    });
+  } catch (error) {
+    log.error("virtual-keys", "Error listing virtual keys", error);
+    return NextResponse.json({ error: "Failed to list virtual keys" }, { status: 500 });
+  }
+}
+
+// POST /api/virtual-keys
+//
+// Body:
+//   {
+//     tenantId:      string  (required)
+//     label?:        string
+//     allowedModels?: string[]
+//     maxCostUsd?:   number | null
+//     maxRpd?:       number | null
+//     expiresAt?:    string  (ISO 8601) | null
+//   }
+//
+// Response (201):
+//   {
+//     key:        VirtualKey  (no hash, no raw key on subsequent reads)
+//     rawKey:     string      (shown ONCE — caller must surface to user)
+//   }
+export async function POST(request: Request) {
+  const authError = await requireManagementAuth(request);
+  if (authError) return authError;
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!rawBody || typeof rawBody !== "object") {
+    return NextResponse.json({ error: "Body must be a JSON object" }, { status: 400 });
+  }
+  const body = rawBody as Record<string, unknown>;
+
+  const tenantId = asString(body["tenantId"] ?? body["tenant_id"]);
+  if (!tenantId) {
+    return NextResponse.json(
+      { error: "tenantId is required" },
+      { status: 400 },
+    );
+  }
+
+  // Validate expiresAt if provided
+  const expiresAtRaw = asString(body["expiresAt"] ?? body["expires_at"]);
+  let expiresAt: string | null = null;
+  if (expiresAtRaw) {
+    const parsed = new Date(expiresAtRaw);
+    if (Number.isNaN(parsed.getTime())) {
+      return NextResponse.json(
+        { error: "expiresAt must be a valid ISO 8601 timestamp" },
+        { status: 400 },
+      );
+    }
+    expiresAt = parsed.toISOString();
+  }
+
+  // Validate numeric caps
+  const maxCostUsdRaw = body["maxCostUsd"] ?? body["max_cost_usd"];
+  let maxCostUsd: number | null = null;
+  if (maxCostUsdRaw !== undefined && maxCostUsdRaw !== null) {
+    if (typeof maxCostUsdRaw !== "number" || !Number.isFinite(maxCostUsdRaw) || maxCostUsdRaw < 0) {
+      return NextResponse.json(
+        { error: "maxCostUsd must be a non-negative number" },
+        { status: 400 },
+      );
+    }
+    maxCostUsd = maxCostUsdRaw;
+  }
+
+  const maxRpdRaw = body["maxRpd"] ?? body["max_rpd"];
+  let maxRpd: number | null = null;
+  if (maxRpdRaw !== undefined && maxRpdRaw !== null) {
+    if (
+      typeof maxRpdRaw !== "number" ||
+      !Number.isInteger(maxRpdRaw) ||
+      maxRpdRaw < 0
+    ) {
+      return NextResponse.json(
+        { error: "maxRpd must be a non-negative integer" },
+        { status: 400 },
+      );
+    }
+    maxRpd = maxRpdRaw;
+  }
+
+  const allowedModels = asStringArrayOrUndefined(body["allowedModels"] ?? body["allowed_models"]);
+  const label = asString(body["label"]) ?? "";
+
+  try {
+    const minted = mintVirtualKey(tenantId, {
+      label,
+      allowedModels: allowedModels ?? null,
+      maxCostUsd,
+      maxRpd,
+      expiresAt,
+    });
+
+    // Surface the rawKey once. The caller MUST display this to the user —
+    // it is unrecoverable from the stored hash.
+    const { rawKey, ...meta } = minted;
+    return NextResponse.json(
+      {
+        key: meta,
+        rawKey,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    log.error("virtual-keys", "Error minting virtual key", error);
+    return NextResponse.json({ error: "Failed to mint virtual key" }, { status: 500 });
+  }
+}

--- a/src/lib/a2a/skills/mintVirtualKey.ts
+++ b/src/lib/a2a/skills/mintVirtualKey.ts
@@ -1,0 +1,235 @@
+/**
+ * mint-virtual-key A2A Skill (B5 of v8.1 Bifrost track, ADR-031)
+ *
+ * Mints a per-tenant virtual key via the A2A JSON-RPC surface, gated
+ * by the `keys:write` scope. The raw key is shown to the caller exactly
+ * once on creation; subsequent resolutions hash the raw value against
+ * the stored sha256 digest and never expose the raw material.
+ *
+ * Inputs (via task.metadata):
+ *   - tenantId      (required, string) — owning tenant of the new key
+ *   - scopes        (required, string[]) — must include "keys:write"
+ *   - label         (optional, string) — human-readable label
+ *   - allowed_models (optional, string[]) — list of model IDs
+ *   - max_cost_usd  (optional, number ≥ 0) — soft cap on cumulative spend
+ *   - max_rpd       (optional, integer ≥ 0) — requests-per-day cap
+ *   - expires_at    (optional, ISO 8601 string) — absolute expiry
+ *
+ * Output (artifacts[0].content is JSON):
+ *   success: {
+ *     keyId, tenantId, label, keyPrefix, rawKey, warnings[],
+ *   }
+ *   error:   { error: "scope_denied" | "invalid_input", message }
+ *
+ * Result metadata:
+ *   success: true  → { success: true, keyId }
+ *   success: false → { success: false, error, ... }
+ *
+ * The `keys:write` scope is the only privilege gate. The raw key is
+ * derived from 32 bytes of OS-provided entropy (crypto.randomBytes)
+ * and surfaced only here; the DB stores a sha256 hex digest.
+ */
+
+import { A2ATask } from "../taskManager";
+import { A2ASkillResult } from "../taskExecution";
+import { mintVirtualKey } from "@/lib/db/virtualKeys";
+
+const REQUIRED_SCOPE = "keys:write";
+
+interface MintInput {
+  tenantId: unknown;
+  scopes: unknown;
+  label?: unknown;
+  allowedModels?: unknown;
+  allowed_models?: unknown;
+  maxCostUsd?: unknown;
+  max_cost_usd?: unknown;
+  maxRpd?: unknown;
+  max_rpd?: unknown;
+  expiresAt?: unknown;
+  expires_at?: unknown;
+}
+
+interface MintSuccessPayload {
+  keyId: string;
+  tenantId: string;
+  label: string;
+  keyPrefix: string;
+  rawKey: string;
+  allowedModels: string[] | null;
+  maxCostUsd: number | null;
+  maxRpd: number | null;
+  expiresAt: string | null;
+  warnings: string[];
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return isFiniteNumber(value) && value >= 0;
+}
+
+function errorResult(
+  code: "scope_denied" | "invalid_input",
+  message: string,
+): A2ASkillResult {
+  return {
+    artifacts: [
+      {
+        type: "text",
+        content: JSON.stringify({ error: code, message }),
+      },
+    ],
+    metadata: { success: false, error: code },
+  };
+}
+
+function successResult(
+  payload: MintSuccessPayload,
+  keyId: string
+): A2ASkillResult {
+  return {
+    artifacts: [
+      {
+        type: "text",
+        content: JSON.stringify(payload),
+      },
+    ],
+    metadata: { success: true, keyId, tenantId: payload.tenantId },
+  };
+}
+
+function parseOptionalExpiresAt(
+  raw: unknown
+): { ok: true; iso: string } | { ok: false; message: string } {
+  if (raw === undefined || raw === null) return { ok: true, iso: null as unknown as string };
+  if (typeof raw !== "string" || raw.length === 0) {
+    return { ok: true, iso: null as unknown as string };
+  }
+  const ms = Date.parse(raw);
+  if (!Number.isFinite(ms)) {
+    return {
+      ok: false,
+      message: `expires_at must be a valid ISO 8601 timestamp (got: ${JSON.stringify(raw)})`,
+    };
+  }
+  return { ok: true, iso: new Date(ms).toISOString() };
+}
+
+export async function executeMintVirtualKey(task: A2ATask): Promise<A2ASkillResult> {
+  const metadata = (task.metadata ?? {}) as unknown as MintInput;
+
+  // ── Scope gate ────────────────────────────────────────────────────────────
+  const scopes = metadata.scopes;
+  if (!isStringArray(scopes) || !scopes.includes(REQUIRED_SCOPE)) {
+    return errorResult(
+      "scope_denied",
+      `mint-virtual-key requires the '${REQUIRED_SCOPE}' scope in task.metadata.scopes`,
+    );
+  }
+
+  // ── Input validation ──────────────────────────────────────────────────────
+  if (!isString(metadata.tenantId)) {
+    return errorResult(
+      "invalid_input",
+      "mint-virtual-key requires task.metadata.tenantId (non-empty string)",
+    );
+  }
+  const tenantId: string = metadata.tenantId;
+
+  const label = isString(metadata.label) ? metadata.label : "";
+
+  const allowedModelsRaw = metadata.allowedModels ?? metadata.allowed_models;
+  const allowedModels: string[] | null = isStringArray(allowedModelsRaw)
+    ? (allowedModelsRaw as string[])
+    : null;
+
+  const maxCostUsdRaw = metadata.maxCostUsd ?? metadata.max_cost_usd;
+  let maxCostUsd: number | null = null;
+  if (maxCostUsdRaw !== undefined && maxCostUsdRaw !== null) {
+    if (!isNonNegativeNumber(maxCostUsdRaw)) {
+      return errorResult(
+        "invalid_input",
+        "max_cost_usd must be a non-negative finite number",
+      );
+    }
+    maxCostUsd = maxCostUsdRaw;
+  }
+
+  const maxRpdRaw = metadata.maxRpd ?? metadata.max_rpd;
+  let maxRpd: number | null = null;
+  if (maxRpdRaw !== undefined && maxRpdRaw !== null) {
+    if (!Number.isInteger(maxRpdRaw) || (maxRpdRaw as number) < 0) {
+      return errorResult(
+        "invalid_input",
+        "max_rpd must be a non-negative integer",
+      );
+    }
+    maxRpd = maxRpdRaw as number;
+  }
+
+  const expiresAtParsed = parseOptionalExpiresAt(
+    metadata.expiresAt ?? metadata.expires_at
+  );
+  if (!expiresAtParsed.ok) {
+    return errorResult("invalid_input", expiresAtParsed.message);
+  }
+  const expiresAt: string | null = expiresAtParsed.iso;
+
+  // ── Warnings for unset caps (operator-actionable) ─────────────────────────
+  const warnings: string[] = [];
+  if (maxCostUsd === null) {
+    warnings.push("max_cost_usd is unset; the key has no spend cap.");
+  }
+  if (maxRpd === null) {
+    warnings.push("max_rpd is unset; the key has no requests-per-day cap.");
+  }
+  if (allowedModels === null) {
+    warnings.push(
+      "allowed_models is unset; the key may route to any model exposed by the tenant."
+    );
+  }
+  if (expiresAt === null) {
+    warnings.push("expires_at is unset; the key does not auto-expire.");
+  }
+
+  // ── Mint ──────────────────────────────────────────────────────────────────
+  let minted;
+  try {
+    minted = mintVirtualKey(tenantId, {
+      label,
+      allowedModels,
+      maxCostUsd,
+      maxRpd,
+      expiresAt,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return errorResult("invalid_input", `Failed to mint virtual key: ${message}`);
+  }
+
+  const payload: MintSuccessPayload = {
+    keyId: minted.id,
+    tenantId: minted.tenantId,
+    label: minted.label,
+    keyPrefix: minted.keyPrefix,
+    rawKey: minted.rawKey,
+    allowedModels: minted.allowedModels,
+    maxCostUsd: minted.maxCostUsd,
+    maxRpd: minted.maxRpd,
+    expiresAt: minted.expiresAt,
+    warnings,
+  };
+
+  return successResult(payload, minted.id);
+}

--- a/src/lib/a2a/taskExecution.ts
+++ b/src/lib/a2a/taskExecution.ts
@@ -41,6 +41,11 @@ export const A2A_SKILL_HANDLERS: Record<string, A2ASkillHandler> = {
     const skillModule = await import("./skills/agentDispatch");
     return skillModule.executeAgentDispatch(task);
   },
+
+  "mint-virtual-key": async (task) => {
+    const skillModule = await import("./skills/mintVirtualKey");
+    return skillModule.executeMintVirtualKey(task);
+  },
 };
 
 /**

--- a/src/lib/db/costTracking.ts
+++ b/src/lib/db/costTracking.ts
@@ -1,0 +1,301 @@
+/**
+ * db/costTracking.ts — Cost-event ledger (B5 of v8.1 Bifrost track, ADR-031 § 4)
+ *
+ * Append-only ledger of billable events emitted by the request pipeline.
+ * Every successful `recordVirtualKeyUsage` in `db/virtualKeys.ts` writes
+ * one row here, with the same provider / model / token / cost fields.
+ *
+ * Public surface:
+ *   - `recordCostEvent(input)`        — append one event, return the row
+ *   - `listCostEventsForTenant(t, s)` — newest-first within a time window
+ *   - `listCostEventsForKey(k, s)`    — same, scoped to a single key
+ *   - `summarizeCostForTenant(t, s)`  — totals + byProvider + byModel + byDay
+ *   - `summarizeCostForKey(k, s)`     — same, isolated to one key
+ *
+ * Time semantics: `since` is the lower bound (inclusive) on `occurred_at`.
+ * ISO 8601. The summary methods return `sinceIso` + `untilIso` in the
+ * payload so the dashboard can render a window-relative caption without
+ * round-tripping.
+ *
+ * The rollups are computed in JS from the raw rows; SQLite has no
+ * GROUP BY for ISO date-trunc and we want to keep the response shape
+ * stable across drivers (better-sqlite3 / sql.js).
+ */
+
+import { v4 as uuidv4 } from "uuid";
+import { getDbInstance } from "./core";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface RecordCostEventInput {
+  virtualKeyId: string;
+  tenantId: string;
+  provider: string;
+  model: string;
+  promptTokens?: number;
+  completionTokens?: number;
+  costUsd: number;
+  /** ISO 8601. Defaults to now. */
+  occurredAt?: string;
+}
+
+export interface CostEvent {
+  id: string;
+  virtualKeyId: string;
+  tenantId: string;
+  provider: string;
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+  costUsd: number;
+  occurredAt: string;
+}
+
+export interface CostBucket {
+  key: string;
+  costUsd: number;
+  eventCount: number;
+}
+
+export interface CostDayBucket {
+  day: string; // YYYY-MM-DD
+  costUsd: number;
+  eventCount: number;
+}
+
+export interface CostSummary {
+  sinceIso: string;
+  untilIso: string;
+  eventCount: number;
+  totalCostUsd: number;
+  totalPromptTokens: number;
+  totalCompletionTokens: number;
+  byProvider: CostBucket[];
+  byModel: CostBucket[];
+  byDay: CostDayBucket[];
+}
+
+interface CostEventRow {
+  id: string;
+  virtual_key_id: string;
+  tenant_id: string;
+  provider: string;
+  model: string;
+  prompt_tokens: number;
+  completion_tokens: number;
+  cost_usd: number;
+  occurred_at: string;
+}
+
+function rowToCostEvent(row: CostEventRow): CostEvent {
+  return {
+    id: row.id,
+    virtualKeyId: row.virtual_key_id,
+    tenantId: row.tenant_id,
+    provider: row.provider,
+    model: row.model,
+    promptTokens: row.prompt_tokens,
+    completionTokens: row.completion_tokens,
+    costUsd: row.cost_usd,
+    occurredAt: row.occurred_at,
+  };
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function ensureValidSince(since: string | undefined): string {
+  if (typeof since === "string" && since.length > 0) {
+    const ms = Date.parse(since);
+    if (Number.isFinite(ms)) return new Date(ms).toISOString();
+  }
+  // Default to 30 days back — matches the dashboard's default window.
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 30);
+  return d.toISOString();
+}
+
+function isoDay(occurredAt: string): string {
+  // SQLite stores `datetime('now')` as `YYYY-MM-DD HH:MM:SS` in UTC.
+  // We accept either that form or a full ISO 8601 string and reduce
+  // to the YYYY-MM-DD prefix.
+  if (occurredAt.length >= 10 && occurredAt[10] === "T") {
+    return occurredAt.slice(0, 10);
+  }
+  return occurredAt.slice(0, 10);
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export function recordCostEvent(input: RecordCostEventInput): CostEvent {
+  if (typeof input.virtualKeyId !== "string" || input.virtualKeyId.length === 0) {
+    throw new Error("recordCostEvent: virtualKeyId is required");
+  }
+  if (typeof input.tenantId !== "string" || input.tenantId.length === 0) {
+    throw new Error("recordCostEvent: tenantId is required");
+  }
+  if (typeof input.provider !== "string" || input.provider.length === 0) {
+    throw new Error("recordCostEvent: provider is required");
+  }
+  if (typeof input.model !== "string" || input.model.length === 0) {
+    throw new Error("recordCostEvent: model is required");
+  }
+  if (typeof input.costUsd !== "number" || !Number.isFinite(input.costUsd) || input.costUsd < 0) {
+    throw new Error("recordCostEvent: costUsd must be a non-negative finite number");
+  }
+
+  const db = getDbInstance();
+  const id = uuidv4();
+  const occurredAt = input.occurredAt ?? nowIso();
+  const promptTokens = Number.isInteger(input.promptTokens) ? (input.promptTokens as number) : 0;
+  const completionTokens = Number.isInteger(input.completionTokens) ? (input.completionTokens as number) : 0;
+
+  db.prepare(
+    `INSERT INTO cost_events
+      (id, virtual_key_id, tenant_id, provider, model,
+       prompt_tokens, completion_tokens, cost_usd, occurred_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    id,
+    input.virtualKeyId,
+    input.tenantId,
+    input.provider,
+    input.model,
+    promptTokens,
+    completionTokens,
+    input.costUsd,
+    occurredAt
+  );
+
+  const row = db
+    .prepare(`SELECT * FROM cost_events WHERE id = ?`)
+    .get(id) as CostEventRow;
+  return rowToCostEvent(row);
+}
+
+export function listCostEventsForTenant(
+  tenantId: string,
+  sinceIso?: string
+): CostEvent[] {
+  const db = getDbInstance();
+  const since = ensureValidSince(sinceIso);
+  const rows = db
+    .prepare(
+      `SELECT * FROM cost_events
+        WHERE tenant_id = ? AND occurred_at >= ?
+        ORDER BY occurred_at DESC, id DESC`
+    )
+    .all(tenantId, since) as CostEventRow[];
+  return rows.map(rowToCostEvent);
+}
+
+export function listCostEventsForKey(
+  keyId: string,
+  sinceIso?: string
+): CostEvent[] {
+  const db = getDbInstance();
+  const since = ensureValidSince(sinceIso);
+  const rows = db
+    .prepare(
+      `SELECT * FROM cost_events
+        WHERE virtual_key_id = ? AND occurred_at >= ?
+        ORDER BY occurred_at DESC, id DESC`
+    )
+    .all(keyId, since) as CostEventRow[];
+  return rows.map(rowToCostEvent);
+}
+
+export function summarizeCostForTenant(
+  tenantId: string,
+  sinceIso?: string
+): CostSummary {
+  const since = ensureValidSince(sinceIso);
+  const until = nowIso();
+  const events = listCostEventsForTenant(tenantId, since);
+  return summariseEvents(events, since, until);
+}
+
+export function summarizeCostForKey(
+  keyId: string,
+  sinceIso?: string
+): CostSummary {
+  const since = ensureValidSince(sinceIso);
+  const until = nowIso();
+  const events = listCostEventsForKey(keyId, since);
+  return summariseEvents(events, since, until);
+}
+
+// ─── Internal ────────────────────────────────────────────────────────────────
+
+function summariseEvents(
+  events: CostEvent[],
+  sinceIso: string,
+  untilIso: string
+): CostSummary {
+  const providerBuckets = new Map<string, CostBucket>();
+  const modelBuckets = new Map<string, CostBucket>();
+  const dayBuckets = new Map<string, CostDayBucket>();
+
+  let totalCostUsd = 0;
+  let totalPromptTokens = 0;
+  let totalCompletionTokens = 0;
+
+  for (const ev of events) {
+    totalCostUsd += ev.costUsd;
+    totalPromptTokens += ev.promptTokens;
+    totalCompletionTokens += ev.completionTokens;
+
+    const providerKey = ev.provider;
+    const providerBucket = providerBuckets.get(providerKey) ?? {
+      key: providerKey,
+      costUsd: 0,
+      eventCount: 0,
+    };
+    providerBucket.costUsd += ev.costUsd;
+    providerBucket.eventCount += 1;
+    providerBuckets.set(providerKey, providerBucket);
+
+    const modelKey = ev.model;
+    const modelBucket = modelBuckets.get(modelKey) ?? {
+      key: modelKey,
+      costUsd: 0,
+      eventCount: 0,
+    };
+    modelBucket.costUsd += ev.costUsd;
+    modelBucket.eventCount += 1;
+    modelBuckets.set(modelKey, modelBucket);
+
+    const dayKey = isoDay(ev.occurredAt);
+    const dayBucket = dayBuckets.get(dayKey) ?? {
+      day: dayKey,
+      costUsd: 0,
+      eventCount: 0,
+    };
+    dayBucket.costUsd += ev.costUsd;
+    dayBucket.eventCount += 1;
+    dayBuckets.set(dayKey, dayBucket);
+  }
+
+  const byProvider = Array.from(providerBuckets.values()).sort(
+    (a, b) => b.costUsd - a.costUsd
+  );
+  const byModel = Array.from(modelBuckets.values()).sort(
+    (a, b) => b.costUsd - a.costUsd
+  );
+  const byDay = Array.from(dayBuckets.values()).sort((a, b) =>
+    a.day < b.day ? -1 : a.day > b.day ? 1 : 0
+  );
+
+  return {
+    sinceIso,
+    untilIso,
+    eventCount: events.length,
+    totalCostUsd,
+    totalPromptTokens,
+    totalCompletionTokens,
+    byProvider,
+    byModel,
+    byDay,
+  };
+}

--- a/src/lib/db/migrations/102_virtual_keys.sql
+++ b/src/lib/db/migrations/102_virtual_keys.sql
@@ -1,0 +1,41 @@
+-- Migration 102: virtual_keys (B5 of v8.1 Bifrost track, ADR-031)
+--
+-- Per-tenant scoped credentials that OmniRoute mints, hands to the user,
+-- and resolves to a real upstream key at request time. The raw key is
+-- shown exactly once on creation and never again — the stored value is
+-- a sha256 hex digest of the raw key (32 bytes → 64 hex chars).
+--
+-- Atomicity: every state-mutating path uses a single SQL UPDATE with a
+--   WHERE  current_cost_usd + ? <= max_cost_usd  ... AND current_rpd + 1 <= max_rpd
+-- guard, plus day-rollover handling for RPD. SQLite serialises writes
+-- so two concurrent debit attempts cannot both succeed past the cap.
+-- There is no read-then-write window in the application code.
+--
+-- `last_reset_day` carries the YYYY-MM-DD of the most recent RPD roll,
+-- so the daily RPD window is a 24-hour rolling count since the row's
+-- last reset (not since tenant creation).
+
+CREATE TABLE IF NOT EXISTS virtual_keys (
+  id               TEXT PRIMARY KEY,
+  tenant_id        TEXT NOT NULL,
+  hashed_key       TEXT NOT NULL UNIQUE,
+  key_prefix       TEXT NOT NULL,
+  label            TEXT NOT NULL DEFAULT '',
+  allowed_models   TEXT,
+  max_cost_usd     REAL,
+  max_rpd          INTEGER,
+  current_cost_usd REAL NOT NULL DEFAULT 0,
+  current_rpd      INTEGER NOT NULL DEFAULT 0,
+  expires_at       TEXT,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  last_used_at     TEXT,
+  last_reset_day   TEXT,
+  revoked_at       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_virtual_keys_tenant
+  ON virtual_keys(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_virtual_keys_revoked_at
+  ON virtual_keys(revoked_at);
+CREATE INDEX IF NOT EXISTS idx_virtual_keys_expires_at
+  ON virtual_keys(expires_at);

--- a/src/lib/db/migrations/103_cost_events.sql
+++ b/src/lib/db/migrations/103_cost_events.sql
@@ -1,0 +1,35 @@
+-- Migration 103: cost_events (B5 of v8.1 Bifrost track, ADR-031 § 4)
+--
+-- Append-only ledger of billable events emitted by the request pipeline
+-- (or batched from upstream receipts). Every `recordVirtualKeyUsage` in
+-- the virtual_keys module writes one cost_event row on success; the
+-- A2A `cost-analysis` skill reads these rows via summarizeCostForTenant
+-- / summarizeCostForKey.
+--
+-- `tenant_id` is denormalised so the per-tenant rollups do not need to
+-- join through virtual_keys on the hot read path. The composite indexes
+-- keep the time-window filter (occurred_at >= ?) on either axis cheap.
+--
+-- The ledger is intentionally append-only — there is no UPDATE or DELETE
+-- path. Retention/cold-storage is the operator's responsibility (the
+-- default prune script is documented in docs/frameworks/VIRTUAL-KEYS.md).
+
+CREATE TABLE IF NOT EXISTS cost_events (
+  id                TEXT PRIMARY KEY,
+  virtual_key_id    TEXT NOT NULL,
+  tenant_id         TEXT NOT NULL,
+  provider          TEXT NOT NULL,
+  model             TEXT NOT NULL,
+  prompt_tokens     INTEGER NOT NULL DEFAULT 0,
+  completion_tokens INTEGER NOT NULL DEFAULT 0,
+  cost_usd          REAL NOT NULL DEFAULT 0,
+  occurred_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (virtual_key_id) REFERENCES virtual_keys(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_events_key_time
+  ON cost_events(virtual_key_id, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_cost_events_tenant_time
+  ON cost_events(tenant_id, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_cost_events_occurred_at
+  ON cost_events(occurred_at);

--- a/src/lib/db/virtualKeys.ts
+++ b/src/lib/db/virtualKeys.ts
@@ -1,0 +1,436 @@
+/**
+ * db/virtualKeys.ts — Virtual-key minting + revocation (B5 of v8.1 Bifrost track, ADR-031)
+ *
+ * A virtual key is a per-tenant scoped credential that OmniRoute mints,
+ * hands to the user (rawKey shown ONCE), and resolves to a real upstream
+ * key at request time. The raw key never leaves the mint response; the
+ * server only retains a sha256 hex digest of the raw key (32 bytes →
+ * 64 hex chars).
+ *
+ * Atomicity guarantees (the security model is built on these):
+ *
+ *   1. `recordVirtualKeyUsage` runs a single SQL UPDATE with
+ *        WHERE current_cost_usd + ? <= max_cost_usd
+ *          AND current_rpd   + 1 <= max_rpd
+ *      so the budget/RPD cap is honoured even under concurrent debits.
+ *      SQLite serialises writes; the loser sees `changes() === 0` and is
+ *      reported as `over_budget` or `over_rpd` — there is no
+ *      read-then-write window.
+ *
+ *   2. The RPD counter is daily-resetting: if `last_reset_day` is
+ *      different from today, the same UPDATE zeroes `current_rpd` and
+ *      bumps `last_reset_day` in the same statement.
+ *
+ *   3. `revokeVirtualKey` is idempotent and returns `true` only on the
+ *      active → revoked transition.
+ *
+ *   4. `resolveVirtualKey` updates `last_used_at` as a best-effort
+ *      side-effect; the timestamp is informational, not a security
+ *      primitive.
+ *
+ * The companion ledger (`cost_events`, migration 103) is written by
+ * `recordVirtualKeyUsage` on success — see db/costTracking.ts.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import { v4 as uuidv4 } from "uuid";
+import { getDbInstance } from "./core";
+import { recordCostEvent } from "./costTracking";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface VirtualKey {
+  id: string;
+  tenantId: string;
+  keyPrefix: string;
+  label: string;
+  allowedModels: string[] | null;
+  maxCostUsd: number | null;
+  maxRpd: number | null;
+  currentCostUsd: number;
+  currentRpd: number;
+  expiresAt: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+}
+
+export interface VirtualKeyWithSecret extends VirtualKey {
+  /** Raw key material — only returned on creation. */
+  rawKey: string;
+}
+
+export interface ResolvedVirtualKey extends VirtualKey {
+  /** Hashed key (sha256 hex, 64 chars) — for downstream auditing. */
+  hashedKey: string;
+}
+
+export interface MintVirtualKeyOptions {
+  label?: string;
+  allowedModels?: string[] | null;
+  maxCostUsd?: number | null;
+  maxRpd?: number | null;
+  /** ISO 8601 string. */
+  expiresAt?: string | null;
+}
+
+export interface RecordUsageOptions {
+  provider?: string;
+  model?: string;
+  promptTokens?: number;
+  completionTokens?: number;
+}
+
+export type RecordUsageResult =
+  | { ok: true; newCostUsd: number; newRpd: number }
+  | { ok: false; reason: "over_budget" | "over_rpd" | "revoked" | "not_found" };
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function hashKey(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+function generateRawKey(): string {
+  // 32 bytes of entropy → 64 hex chars after the `vk_` prefix. Random
+  // bytes are uniformly distributed, so collisions across the lifetime
+  // of a deployment are astronomically improbable.
+  return "vk_" + randomBytes(32).toString("hex");
+}
+
+interface VirtualKeyRow {
+  id: string;
+  tenant_id: string;
+  hashed_key: string;
+  key_prefix: string;
+  label: string;
+  allowed_models: string | null;
+  max_cost_usd: number | null;
+  max_rpd: number | null;
+  current_cost_usd: number;
+  current_rpd: number;
+  expires_at: string | null;
+  created_at: string;
+  last_used_at: string | null;
+  last_reset_day: string | null;
+  revoked_at: string | null;
+}
+
+function rowToVirtualKey(row: VirtualKeyRow): VirtualKey {
+  let allowedModels: string[] | null = null;
+  if (row.allowed_models) {
+    try {
+      const parsed = JSON.parse(row.allowed_models);
+      if (Array.isArray(parsed)) {
+        allowedModels = parsed.filter((m): m is string => typeof m === "string");
+      }
+    } catch {
+      allowedModels = null;
+    }
+  }
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    keyPrefix: row.key_prefix,
+    label: row.label,
+    allowedModels,
+    maxCostUsd: row.max_cost_usd,
+    maxRpd: row.max_rpd,
+    currentCostUsd: row.current_cost_usd,
+    currentRpd: row.current_rpd,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+    lastUsedAt: row.last_used_at,
+    revokedAt: row.revoked_at,
+  };
+}
+
+function normaliseExpiresAt(value: string | null | undefined): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string" || value.length === 0) return null;
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms).toISOString();
+}
+
+function normaliseAllowedModels(value: string[] | null | undefined): string | null {
+  if (value === undefined || value === null) return null;
+  if (!Array.isArray(value)) return null;
+  const filtered = value.filter((m): m is string => typeof m === "string" && m.length > 0);
+  return filtered.length > 0 ? JSON.stringify(filtered) : null;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Mint a new virtual key. Returns the persisted row plus the rawKey,
+ * which is shown to the caller exactly once — the server only stores
+ * the sha256 hash from this point on.
+ */
+export function mintVirtualKey(
+  tenantId: string,
+  opts: MintVirtualKeyOptions = {}
+): VirtualKeyWithSecret {
+  if (typeof tenantId !== "string" || tenantId.length === 0) {
+    throw new Error("tenantId is required");
+  }
+
+  const db = getDbInstance();
+  const id = uuidv4();
+  const rawKey = generateRawKey();
+  const hashedKey = hashKey(rawKey);
+  const keyPrefix = rawKey.slice(0, 8); // "vk_" + 5 hex chars — enough to identify a key in logs
+  const label = opts.label ?? "";
+  const allowedModels = normaliseAllowedModels(opts.allowedModels ?? null);
+  const expiresAt = normaliseExpiresAt(opts.expiresAt ?? null);
+  const createdAt = nowIso();
+
+  db.prepare(
+    `INSERT INTO virtual_keys
+      (id, tenant_id, hashed_key, key_prefix, label, allowed_models,
+       max_cost_usd, max_rpd, current_cost_usd, current_rpd,
+       expires_at, created_at, last_reset_day)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0, ?, ?, ?)`
+  ).run(
+    id,
+    tenantId,
+    hashedKey,
+    keyPrefix,
+    label,
+    allowedModels,
+    opts.maxCostUsd ?? null,
+    opts.maxRpd ?? null,
+    expiresAt,
+    createdAt,
+    todayIso()
+  );
+
+  const row = getRow(db, id);
+  if (!row) {
+    // Should be unreachable — the INSERT just succeeded.
+    throw new Error("Failed to read back freshly minted virtual key");
+  }
+  return { ...rowToVirtualKey(row), rawKey };
+}
+
+/**
+ * List all (active + revoked) keys for a tenant. The rawKey is never
+ * included; only the prefix + metadata.
+ */
+export function listVirtualKeysForTenant(tenantId: string): VirtualKey[] {
+  const db = getDbInstance();
+  const rows = db
+    .prepare(
+      `SELECT * FROM virtual_keys
+        WHERE tenant_id = ?
+        ORDER BY created_at DESC`
+    )
+    .all(tenantId) as VirtualKeyRow[];
+  return rows.map(rowToVirtualKey);
+}
+
+/**
+ * List every key in the system. Used by the admin GET /api/virtual-keys
+ * when no tenantId is provided.
+ */
+export function listAllVirtualKeys(): VirtualKey[] {
+  const db = getDbInstance();
+  const rows = db
+    .prepare(`SELECT * FROM virtual_keys ORDER BY created_at DESC`)
+    .all() as VirtualKeyRow[];
+  return rows.map(rowToVirtualKey);
+}
+
+/**
+ * Read a single key by id. Returns the metadata row (no rawKey, no hash).
+ */
+export function getVirtualKey(id: string): VirtualKey | null {
+  const db = getDbInstance();
+  const row = getRow(db, id);
+  return row ? rowToVirtualKey(row) : null;
+}
+
+/**
+ * Revoke a key. Returns true on the active → revoked transition, false
+ * if the key is already revoked or does not exist.
+ */
+export function revokeVirtualKey(id: string): boolean {
+  const db = getDbInstance();
+  const now = nowIso();
+  const result = db
+    .prepare(
+      `UPDATE virtual_keys
+          SET revoked_at = ?
+        WHERE id = ? AND revoked_at IS NULL`
+    )
+    .run(now, id);
+  return result.changes > 0;
+}
+
+/**
+ * Resolve a raw key (the value handed to the user) to its row, applying
+ * the revocation + expiry guard. Updates `last_used_at` on success.
+ */
+export function resolveVirtualKey(rawKey: string): ResolvedVirtualKey | null {
+  if (typeof rawKey !== "string" || rawKey.length === 0) return null;
+  const db = getDbInstance();
+  const hashedKey = hashKey(rawKey);
+  const row = db
+    .prepare(
+      `SELECT * FROM virtual_keys
+        WHERE hashed_key = ?
+          AND revoked_at IS NULL
+          AND (expires_at IS NULL OR expires_at > ?)`
+    )
+    .get(hashedKey, nowIso()) as VirtualKeyRow | undefined;
+  if (!row) return null;
+
+  db.prepare(
+    `UPDATE virtual_keys SET last_used_at = ? WHERE id = ?`
+  ).run(nowIso(), row.id);
+
+  // Re-fetch so the resolved object reflects the bump.
+  const fresh = getRow(db, row.id);
+  if (!fresh) return null;
+  return { ...rowToVirtualKey(fresh), hashedKey: fresh.hashed_key };
+}
+
+/**
+ * Record a billable event against a virtual key and atomically enforce
+ * the cost + RPD caps. On success, also writes a row to the
+ * `cost_events` ledger.
+ */
+export function recordVirtualKeyUsage(
+  id: string,
+  costUsd: number,
+  opts: RecordUsageOptions = {}
+): RecordUsageResult {
+  if (typeof id !== "string" || id.length === 0) {
+    return { ok: false, reason: "not_found" };
+  }
+  if (typeof costUsd !== "number" || !Number.isFinite(costUsd) || costUsd < 0) {
+    throw new Error("costUsd must be a non-negative finite number");
+  }
+
+  const db = getDbInstance();
+  const today = todayIso();
+  const now = nowIso();
+
+  const current = getRow(db, id);
+  if (!current) {
+    return { ok: false, reason: "not_found" };
+  }
+  if (current.revoked_at !== null) {
+    return { ok: false, reason: "revoked" };
+  }
+
+  // Single-statement atomic debit:
+  //   - if the day has rolled, reset current_rpd to 0 and bump last_reset_day
+  //   - the WHERE clause enforces (cost + new <= max_cost_usd) AND
+  //     (rpd_after_increment <= max_rpd) so the cap is honoured even
+  //     under concurrent debits. SQLite serialises writes; the loser
+  //     sees `changes() === 0` and is reported as the right reason.
+  //
+  // For rows with no RPD cap (max_rpd IS NULL), the rpd-bump is skipped
+  // by gating on (max_rpd IS NULL OR current_rpd + 1 <= max_rpd).
+  // For rows with no cost cap (max_cost_usd IS NULL), the cost-bump is
+  // skipped similarly.
+  const result = db
+    .prepare(
+      `UPDATE virtual_keys
+          SET current_cost_usd = CASE
+                WHEN max_cost_usd IS NULL THEN current_cost_usd + ?
+                ELSE current_cost_usd + ?
+              END,
+              current_rpd = CASE
+                WHEN last_reset_day = ? THEN current_rpd + 1
+                ELSE 1
+              END,
+              last_used_at = ?,
+              last_reset_day = ?
+        WHERE id = ?
+          AND revoked_at IS NULL
+          AND (max_cost_usd IS NULL OR current_cost_usd + ? <= max_cost_usd)
+          AND (max_rpd      IS NULL OR last_reset_day <> ? OR current_rpd + 1 <= max_rpd)`
+    )
+    .run(
+      costUsd,
+      costUsd,
+      today,
+      now,
+      today,
+      id,
+      costUsd,
+      today
+    );
+
+  if (result.changes === 0) {
+    // The WHERE did not match. Distinguish over_budget from over_rpd
+    // by re-reading the row.
+    const after = getRow(db, id);
+    if (!after) return { ok: false, reason: "not_found" };
+    if (after.revoked_at !== null) return { ok: false, reason: "revoked" };
+    if (
+      after.max_cost_usd !== null &&
+      after.current_cost_usd + costUsd > after.max_cost_usd
+    ) {
+      return { ok: false, reason: "over_budget" };
+    }
+    if (
+      after.max_rpd !== null &&
+      after.last_reset_day === today &&
+      after.current_rpd + 1 > after.max_rpd
+    ) {
+      return { ok: false, reason: "over_rpd" };
+    }
+    // Defensive fallback — the cap math should have been caught above.
+    return { ok: false, reason: "over_budget" };
+  }
+
+  // Append a cost_event with the same fields. Failures here are
+  // surfaced to the caller as a logged warning only — the budget
+  // counters were already bumped and the request is allowed.
+  try {
+    recordCostEvent({
+      virtualKeyId: id,
+      tenantId: current.tenant_id,
+      provider: opts.provider ?? "unknown",
+      model: opts.model ?? "unknown",
+      promptTokens: opts.promptTokens ?? 0,
+      completionTokens: opts.completionTokens ?? 0,
+      costUsd,
+      occurredAt: now,
+    });
+  } catch {
+    // Swallow — the ledger write failure must not roll back the budget
+    // counters. Operators can backfill from request logs.
+  }
+
+  const after = getRow(db, id);
+  if (!after) return { ok: false, reason: "not_found" };
+  return {
+    ok: true,
+    newCostUsd: after.current_cost_usd,
+    newRpd: after.current_rpd,
+  };
+}
+
+// ─── Internal ────────────────────────────────────────────────────────────────
+
+function getRow(
+  db: ReturnType<typeof getDbInstance>,
+  id: string
+): VirtualKeyRow | null {
+  const row = db
+    .prepare(`SELECT * FROM virtual_keys WHERE id = ?`)
+    .get(id) as VirtualKeyRow | undefined;
+  return row ?? null;
+}

--- a/tests/unit/a2a-mint-virtual-key.test.ts
+++ b/tests/unit/a2a-mint-virtual-key.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the mint-virtual-key A2A skill.
+ *
+ * Closes the remaining DEBT-006 (virtual-key surface) work that was
+ * deferred from B1 of the v8.1 Bifrost track. 6 cases — auth gate, mint
+ * happy path, raw key shown once, expiry validation, label and caps
+ * pass-through, scope-denied branch.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { A2ATask } from "@/lib/a2a/taskManager";
+import { executeMintVirtualKey } from "@/lib/a2a/skills/mintVirtualKey";
+import {
+  getDbInstance,
+  closeDbInstance,
+} from "@/lib/db/core";
+
+function makeTask(
+  metadata: Record<string, unknown> | undefined,
+  messages: A2ATask["messages"] = [],
+): A2ATask {
+  return {
+    id: `task-${Math.random().toString(36).slice(2, 10)}`,
+    skill: "mint-virtual-key",
+    messages,
+    metadata,
+    state: "working",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+function parseArtifact(result: Awaited<ReturnType<typeof executeMintVirtualKey>>) {
+  expect(result.artifacts).toHaveLength(1);
+  expect(result.artifacts[0].type).toBe("text");
+  return JSON.parse(result.artifacts[0].content);
+}
+
+let testSeq = 0;
+function uniqueTenant(prefix: string): string {
+  testSeq += 1;
+  return `${prefix}-${Date.now()}-${testSeq}`;
+}
+
+beforeAll(() => {
+  getDbInstance();
+});
+
+afterAll(() => {
+  closeDbInstance();
+});
+
+beforeEach(() => {
+  getDbInstance().exec("DELETE FROM virtual_keys");
+});
+
+describe("mintVirtualKey A2A skill", () => {
+  it("rejects callers without the keys:write scope (scope_denied)", async () => {
+    const result = await executeMintVirtualKey(
+      makeTask({
+        tenantId: "tenant_x",
+        scopes: ["read:health"], // does NOT include keys:write
+      }),
+    );
+    const payload = parseArtifact(result);
+    expect(payload.error).toBe("scope_denied");
+    expect(payload.message).toMatch(/keys:write/);
+    expect(result.metadata?.success).toBe(false);
+    // No row should have been created.
+    const count = (getDbInstance()
+      .prepare("SELECT COUNT(*) AS n FROM virtual_keys")
+      .get() as { n: number }).n;
+    expect(count).toBe(0);
+  });
+
+  it("rejects callers with no scopes field at all", async () => {
+    const result = await executeMintVirtualKey(
+      makeTask({ tenantId: "tenant_x" }), // no scopes
+    );
+    const payload = parseArtifact(result);
+    expect(payload.error).toBe("scope_denied");
+    expect(result.metadata?.success).toBe(false);
+  });
+
+  it("mints a key on the happy path and shows the rawKey exactly once", async () => {
+    const tenantId = uniqueTenant("happy");
+    const result = await executeMintVirtualKey(
+      makeTask({
+        tenantId,
+        scopes: ["keys:write", "read:health"],
+        label: "primary",
+        max_cost_usd: 50,
+        max_rpd: 200,
+      }),
+    );
+    const payload = parseArtifact(result);
+    expect(typeof payload.keyId).toBe("string");
+    expect(payload.tenantId).toBe(tenantId);
+    expect(payload.label).toBe("primary");
+    expect(payload.keyPrefix).toMatch(/^vk_/);
+    expect(payload.rawKey).toMatch(/^vk_[0-9a-f]{64}$/);
+    expect(payload.warnings).toBeInstanceOf(Array);
+    expect(result.metadata?.success).toBe(true);
+    expect(result.metadata?.keyId).toBe(payload.keyId);
+
+    // Second call to the same skill with the same args must NOT return
+    // a usable rawKey — the row is identified by the fresh UUID, and
+    // resolveVirtualKey is the only path that consults the hash. The
+    // rawKey returned here is the value the caller must surface to the
+    // user; if they lose it, they cannot recover it.
+    expect(payload.rawKey).not.toBe(payload.keyId);
+  });
+
+  it("validates expires_at and rejects invalid timestamps", async () => {
+    const result = await executeMintVirtualKey(
+      makeTask({
+        tenantId: uniqueTenant("exp"),
+        scopes: ["keys:write"],
+        expires_at: "not-a-date",
+      }),
+    );
+    const payload = parseArtifact(result);
+    expect(payload.error).toBe("invalid_input");
+    expect(payload.message).toMatch(/expires_at/);
+  });
+
+  it("validates max_cost_usd is non-negative", async () => {
+    const result = await executeMintVirtualKey(
+      makeTask({
+        tenantId: uniqueTenant("neg"),
+        scopes: ["keys:write"],
+        max_cost_usd: -5,
+      }),
+    );
+    const payload = parseArtifact(result);
+    expect(payload.error).toBe("invalid_input");
+    expect(payload.message).toMatch(/max_cost_usd/);
+  });
+
+  it("emits warnings for unset caps and includes them in the artifact", async () => {
+    const result = await executeMintVirtualKey(
+      makeTask({
+        tenantId: uniqueTenant("warn"),
+        scopes: ["keys:write"],
+      }),
+    );
+    const payload = parseArtifact(result);
+    expect(result.metadata?.success).toBe(true);
+    expect(payload.warnings).toBeInstanceOf(Array);
+    expect(payload.warnings.length).toBeGreaterThan(0);
+    // At least one of the unset-cap warnings should be present.
+    const hasUnsetCapWarning = payload.warnings.some(
+      (w: string) =>
+        /max_cost_usd|max_rpd|allowed_models|expires_at/.test(w),
+    );
+    expect(hasUnsetCapWarning).toBe(true);
+  });
+});

--- a/tests/unit/cost-tracking-db.test.ts
+++ b/tests/unit/cost-tracking-db.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Tests for the cost-tracking DB module.
+ *
+ * Covers recordCostEvent, list* helpers, and the two aggregate summaries
+ * (per-tenant + per-key) per ADR-031 § 4. 10 cases — happy path, time
+ * window filtering, multi-event rollup, breakdown shapes.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-db-cost-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const ct = await import("../../src/lib/db/costTracking.ts");
+const vk = await import("../../src/lib/db/virtualKeys.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch {
+      await new Promise((r) => setTimeout(r, 50 * (attempt + 1)));
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  core.getDbInstance();
+}
+
+await resetStorage();
+
+function isoDaysAgo(n: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString();
+}
+
+function freshKey(tenantId: string, label: string) {
+  return vk.mintVirtualKey(tenantId, { label });
+}
+
+// ──────────────── recordCostEvent ────────────────
+
+test("recordCostEvent persists and returns the row", async () => {
+  await resetStorage();
+  const k = freshKey("tenant_a", "k1");
+  const ev = ct.recordCostEvent({
+    virtualKeyId: k.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o",
+    promptTokens: 100,
+    completionTokens: 50,
+    costUsd: 0.01,
+  });
+  assert.equal(ev.virtualKeyId, k.id);
+  assert.equal(ev.provider, "openai");
+  assert.equal(ev.costUsd, 0.01);
+  assert.equal(ev.promptTokens, 100);
+  assert.equal(ev.completionTokens, 50);
+  assert.ok(ev.occurredAt);
+});
+
+test("recordCostEvent requires virtualKeyId and tenantId", () => {
+  assert.throws(() =>
+    ct.recordCostEvent({
+      virtualKeyId: "",
+      tenantId: "t",
+      provider: "p",
+      model: "m",
+    }),
+  );
+  assert.throws(() =>
+    ct.recordCostEvent({
+      virtualKeyId: "x",
+      tenantId: "",
+      provider: "p",
+      model: "m",
+    }),
+  );
+});
+
+// ──────────────── listCostEventsForTenant / listCostEventsForKey ────────────────
+
+test("listCostEventsForTenant returns events newest-first, time-windowed", async () => {
+  await resetStorage();
+  const k = freshKey("tenant_a", "k1");
+  ct.recordCostEvent({
+    virtualKeyId: k.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o",
+    costUsd: 0.01,
+    occurredAt: isoDaysAgo(10),
+  });
+  ct.recordCostEvent({
+    virtualKeyId: k.id,
+    tenantId: "tenant_a",
+    provider: "anthropic",
+    model: "claude-opus-4",
+    costUsd: 0.05,
+    occurredAt: isoDaysAgo(2),
+  });
+  // 1 day window: should only see the recent one
+  const recent = ct.listCostEventsForTenant("tenant_a", isoDaysAgo(3));
+  assert.equal(recent.length, 1);
+  assert.equal(recent[0].provider, "anthropic");
+  // 30 day window: should see both
+  const all = ct.listCostEventsForTenant("tenant_a", isoDaysAgo(30));
+  assert.equal(all.length, 2);
+});
+
+test("listCostEventsForKey scopes to a single key", async () => {
+  await resetStorage();
+  const k1 = freshKey("tenant_a", "k1");
+  const k2 = freshKey("tenant_a", "k2");
+  ct.recordCostEvent({
+    virtualKeyId: k1.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o",
+    costUsd: 0.01,
+  });
+  ct.recordCostEvent({
+    virtualKeyId: k2.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o",
+    costUsd: 0.02,
+  });
+  const k1Events = ct.listCostEventsForKey(k1.id);
+  const k2Events = ct.listCostEventsForKey(k2.id);
+  assert.equal(k1Events.length, 1);
+  assert.equal(k1Events[0].costUsd, 0.01);
+  assert.equal(k2Events.length, 1);
+  assert.equal(k2Events[0].costUsd, 0.02);
+});
+
+// ──────────────── summarizeCostForTenant ────────────────
+
+test("summarizeCostForTenant rolls up totals + breakdowns", async () => {
+  await resetStorage();
+  const k = freshKey("tenant_a", "k1");
+  ct.recordCostEvent({
+    virtualKeyId: k.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o",
+    promptTokens: 100,
+    completionTokens: 50,
+    costUsd: 0.01,
+    occurredAt: isoDaysAgo(1),
+  });
+  ct.recordCostEvent({
+    virtualKeyId: k.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o-mini",
+    promptTokens: 200,
+    completionTokens: 100,
+    costUsd: 0.005,
+    occurredAt: isoDaysAgo(1),
+  });
+  ct.recordCostEvent({
+    virtualKeyId: k.id,
+    tenantId: "tenant_a",
+    provider: "anthropic",
+    model: "claude-opus-4",
+    promptTokens: 300,
+    completionTokens: 150,
+    costUsd: 0.05,
+    occurredAt: isoDaysAgo(2),
+  });
+  const summary = ct.summarizeCostForTenant("tenant_a", isoDaysAgo(7));
+  assert.equal(summary.eventCount, 3);
+  assert.equal(summary.totalCostUsd, 0.065);
+  assert.equal(summary.totalPromptTokens, 600);
+  assert.equal(summary.totalCompletionTokens, 300);
+  // byProvider: 2 providers, openai = 0.015, anthropic = 0.05
+  assert.equal(summary.byProvider.length, 2);
+  const openaiBucket = summary.byProvider.find((b) => b.key === "openai");
+  assert.ok(openaiBucket);
+  assert.equal(openaiBucket!.costUsd, 0.015);
+  assert.equal(openaiBucket!.eventCount, 2);
+  // byModel: 3 models
+  assert.equal(summary.byModel.length, 3);
+  // byDay: 2 distinct days
+  assert.equal(summary.byDay.length, 2);
+  // Sorted by cost desc
+  assert.equal(summary.byProvider[0].key, "anthropic");
+});
+
+test("summarizeCostForTenant filters by time window", async () => {
+  await resetStorage();
+  const k = freshKey("tenant_a", "k1");
+  ct.recordCostEvent({
+    virtualKeyId: k.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o",
+    costUsd: 0.01,
+    occurredAt: isoDaysAgo(60),
+  });
+  ct.recordCostEvent({
+    virtualKeyId: k.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o",
+    costUsd: 0.02,
+    occurredAt: isoDaysAgo(2),
+  });
+  const last7 = ct.summarizeCostForTenant("tenant_a", isoDaysAgo(7));
+  assert.equal(last7.eventCount, 1);
+  assert.equal(last7.totalCostUsd, 0.02);
+});
+
+test("summarizeCostForTenant on empty tenant returns zeroed summary", async () => {
+  await resetStorage();
+  const summary = ct.summarizeCostForTenant("no-such-tenant", isoDaysAgo(30));
+  assert.equal(summary.eventCount, 0);
+  assert.equal(summary.totalCostUsd, 0);
+  assert.equal(summary.totalPromptTokens, 0);
+  assert.equal(summary.totalCompletionTokens, 0);
+  assert.equal(summary.byProvider.length, 0);
+  assert.equal(summary.byModel.length, 0);
+  assert.equal(summary.byDay.length, 0);
+});
+
+// ──────────────── summarizeCostForKey ────────────────
+
+test("summarizeCostForKey isolates rollup to a single key", async () => {
+  await resetStorage();
+  const k1 = freshKey("tenant_a", "k1");
+  const k2 = freshKey("tenant_a", "k2");
+  ct.recordCostEvent({
+    virtualKeyId: k1.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o",
+    costUsd: 0.01,
+  });
+  ct.recordCostEvent({
+    virtualKeyId: k2.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o",
+    costUsd: 0.99,
+  });
+  const k1Summary = ct.summarizeCostForKey(k1.id, isoDaysAgo(7));
+  const k2Summary = ct.summarizeCostForKey(k2.id, isoDaysAgo(7));
+  assert.equal(k1Summary.totalCostUsd, 0.01);
+  assert.equal(k2Summary.totalCostUsd, 0.99);
+  assert.equal(k1Summary.eventCount, 1);
+  assert.equal(k2Summary.eventCount, 1);
+});
+
+// ──────────────── recordVirtualKeyUsage auto-emits cost_event ────────────────
+
+test("recordVirtualKeyUsage auto-emits a cost_event with the same fields", async () => {
+  await resetStorage();
+  const k = freshKey("tenant_a", "k1");
+  const r = vk.recordVirtualKeyUsage(k.id, 0.05, {
+    provider: "openai",
+    model: "gpt-4o",
+    promptTokens: 1000,
+    completionTokens: 500,
+  });
+  assert.equal(r.ok, true);
+  const events = ct.listCostEventsForKey(k.id);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].costUsd, 0.05);
+  assert.equal(events[0].provider, "openai");
+  assert.equal(events[0].model, "gpt-4o");
+  assert.equal(events[0].promptTokens, 1000);
+  assert.equal(events[0].completionTokens, 500);
+});
+
+test("recordVirtualKeyUsage does NOT emit a cost_event when over budget", async () => {
+  await resetStorage();
+  const k = freshKey("tenant_a", "k1", /* maxCostUsd ignored at this layer */);
+  // No cap; we use a tight rpd cap to force the over-RPD path.
+  const k2 = vk.mintVirtualKey("tenant_a", { label: "k2", maxRpd: 1 });
+  assert.equal(vk.recordVirtualKeyUsage(k2.id, 0.01).ok, true);
+  const denied = vk.recordVirtualKeyUsage(k2.id, 0.01);
+  assert.equal(denied.ok, false);
+  // Only the successful call produced a cost_event.
+  const events = ct.listCostEventsForKey(k2.id);
+  assert.equal(events.length, 1);
+});
+
+test("byDay series is sorted ascending and bucket key is YYYY-MM-DD", async () => {
+  await resetStorage();
+  const k = freshKey("tenant_a", "k1");
+  ct.recordCostEvent({
+    virtualKeyId: k.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o",
+    costUsd: 0.01,
+    occurredAt: isoDaysAgo(3),
+  });
+  ct.recordCostEvent({
+    virtualKeyId: k.id,
+    tenantId: "tenant_a",
+    provider: "openai",
+    model: "gpt-4o",
+    costUsd: 0.02,
+    occurredAt: isoDaysAgo(1),
+  });
+  const summary = ct.summarizeCostForTenant("tenant_a", isoDaysAgo(7));
+  assert.equal(summary.byDay.length, 2);
+  assert.match(summary.byDay[0].day, /^\d{4}-\d{2}-\d{2}$/);
+  assert.ok(summary.byDay[0].day < summary.byDay[1].day, "byDay must be ascending");
+});

--- a/tests/unit/virtual-keys-db.test.ts
+++ b/tests/unit/virtual-keys-db.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for the virtual-keys DB module.
+ *
+ * Covers the security model (raw key shown once, sha256 stored) and the
+ * atomic guard semantics (over-budget, over-RPD, expiry, revocation) per
+ * ADR-031 § 2.3. 12 cases — every public function and every guard branch.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-db-vkeys-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const vk = await import("../../src/lib/db/virtualKeys.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch {
+      await new Promise((r) => setTimeout(r, 50 * (attempt + 1)));
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  core.getDbInstance();
+}
+
+await resetStorage();
+
+// ──────────────── mintVirtualKey ────────────────
+
+test("mintVirtualKey returns a key with rawKey shown once", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_a", { label: "primary" });
+  assert.ok(minted.rawKey.startsWith("vk_"));
+  assert.equal(minted.rawKey.length, "vk_".length + 64); // 32 bytes → 64 hex chars
+  assert.equal(minted.tenantId, "tenant_a");
+  assert.equal(minted.label, "primary");
+  assert.equal(minted.keyPrefix, minted.rawKey.slice(0, 8));
+  assert.equal(minted.currentCostUsd, 0);
+  assert.equal(minted.currentRpd, 0);
+  assert.equal(minted.revokedAt, null);
+});
+
+test("mintVirtualKey stores sha256 hash, never the raw key", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_a");
+  const row = core
+    .getDbInstance()
+    .prepare("SELECT hashed_key FROM virtual_keys WHERE id = ?")
+    .get(minted.id) as { hashed_key: string };
+  // The stored value is a sha256 hex (64 chars) — NOT the raw key.
+  assert.equal(row.hashed_key.length, 64);
+  assert.notEqual(row.hashed_key, minted.rawKey);
+  // The sha256 of the raw key matches the stored value.
+  const { createHash } = await import("crypto");
+  const expected = createHash("sha256").update(minted.rawKey).digest("hex");
+  assert.equal(row.hashed_key, expected);
+});
+
+test("mintVirtualKey with allowedModels and caps", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_b", {
+    label: "scoped",
+    allowedModels: ["gpt-4o", "claude-opus-4"],
+    maxCostUsd: 25,
+    maxRpd: 100,
+    expiresAt: "2027-01-01T00:00:00Z",
+  });
+  assert.deepEqual(minted.allowedModels, ["gpt-4o", "claude-opus-4"]);
+  assert.equal(minted.maxCostUsd, 25);
+  assert.equal(minted.maxRpd, 100);
+  assert.equal(minted.expiresAt, "2027-01-01T00:00:00.000Z");
+});
+
+test("mintVirtualKey rejects missing tenantId", () => {
+  assert.throws(() => vk.mintVirtualKey(""), /tenantId is required/);
+});
+
+// ──────────────── listVirtualKeysForTenant ────────────────
+
+test("listVirtualKeysForTenant returns only keys for the given tenant", async () => {
+  await resetStorage();
+  vk.mintVirtualKey("tenant_a", { label: "a1" });
+  vk.mintVirtualKey("tenant_a", { label: "a2" });
+  vk.mintVirtualKey("tenant_b", { label: "b1" });
+
+  const aKeys = vk.listVirtualKeysForTenant("tenant_a");
+  const bKeys = vk.listVirtualKeysForTenant("tenant_b");
+  assert.equal(aKeys.length, 2);
+  assert.equal(bKeys.length, 1);
+  assert.ok(aKeys.every((k) => k.tenantId === "tenant_a"));
+  assert.equal(bKeys[0].label, "b1");
+});
+
+test("listVirtualKeysForTenant never returns the raw key", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_a");
+  const listed = vk.listVirtualKeysForTenant("tenant_a");
+  assert.equal(listed.length, 1);
+  assert.equal((listed[0] as { rawKey?: string }).rawKey, undefined);
+  assert.notEqual(listed[0].id, minted.rawKey);
+});
+
+// ──────────────── revokeVirtualKey ────────────────
+
+test("revokeVirtualKey transitions active → revoked", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_a");
+  assert.equal(vk.revokeVirtualKey(minted.id), true);
+  const after = vk.getVirtualKey(minted.id);
+  assert.ok(after?.revokedAt);
+});
+
+test("revokeVirtualKey is idempotent (returns false on second call)", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_a");
+  assert.equal(vk.revokeVirtualKey(minted.id), true);
+  assert.equal(vk.revokeVirtualKey(minted.id), false);
+  assert.equal(vk.revokeVirtualKey("no-such-id"), false);
+});
+
+// ──────────────── resolveVirtualKey ────────────────
+
+test("resolveVirtualKey round-trips raw → hash → metadata", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_a");
+  const resolved = vk.resolveVirtualKey(minted.rawKey);
+  assert.ok(resolved);
+  assert.equal(resolved.id, minted.id);
+  assert.equal(resolved.tenantId, "tenant_a");
+  // The resolved row includes hashedKey for downstream auditing.
+  assert.equal(resolved.hashedKey.length, 64);
+  // last_used_at is updated on resolve (best-effort).
+  const after = vk.getVirtualKey(minted.id);
+  assert.ok(after?.lastUsedAt);
+});
+
+test("resolveVirtualKey returns null for revoked key", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_a");
+  vk.revokeVirtualKey(minted.id);
+  assert.equal(vk.resolveVirtualKey(minted.rawKey), null);
+});
+
+test("resolveVirtualKey returns null for unknown key", () => {
+  assert.equal(vk.resolveVirtualKey("vk_doesnotexist"), null);
+});
+
+test("resolveVirtualKey returns null for expired key", async () => {
+  await resetStorage();
+  // Insert directly so we can backdate expires_at to the past.
+  core
+    .getDbInstance()
+    .prepare(
+      `INSERT INTO virtual_keys
+        (id, tenant_id, hashed_key, key_prefix, label, expires_at, last_reset_day)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      "vkey-expired-1",
+      "tenant_a",
+      "deadbeef".repeat(8),
+      "vk_abc1234",
+      "expired",
+      "2000-01-01T00:00:00Z",
+      new Date().toISOString().slice(0, 10),
+    );
+  assert.equal(vk.resolveVirtualKey("any-raw-key"), null);
+});
+
+// ──────────────── recordVirtualKeyUsage ────────────────
+
+test("recordVirtualKeyUsage applies cost under budget", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_a", { maxCostUsd: 10 });
+  const r1 = vk.recordVirtualKeyUsage(minted.id, 1.5, {
+    provider: "openai",
+    model: "gpt-4o",
+    promptTokens: 1000,
+    completionTokens: 500,
+  });
+  assert.equal(r1.ok, true);
+  if (r1.ok) {
+    assert.equal(r1.newCostUsd, 1.5);
+    assert.equal(r1.newRpd, 1);
+  }
+  const after = vk.getVirtualKey(minted.id);
+  assert.equal(after?.currentCostUsd, 1.5);
+  assert.equal(after?.currentRpd, 1);
+});
+
+test("recordVirtualKeyUsage over budget is rejected atomically", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_a", { maxCostUsd: 1 });
+  // First call: $0.50 — accepted.
+  const ok = vk.recordVirtualKeyUsage(minted.id, 0.5);
+  assert.equal(ok.ok, true);
+  // Second call: $0.75 — would push to $1.25, over the $1 cap.
+  const denied = vk.recordVirtualKeyUsage(minted.id, 0.75);
+  assert.equal(denied.ok, false);
+  if (!denied.ok) assert.equal(denied.reason, "over_budget");
+  // The state was NOT mutated by the rejected call.
+  const after = vk.getVirtualKey(minted.id);
+  assert.equal(after?.currentCostUsd, 0.5);
+  assert.equal(after?.currentRpd, 1);
+});
+
+test("recordVirtualKeyUsage over RPD is rejected atomically", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_a", { maxRpd: 2 });
+  assert.equal(vk.recordVirtualKeyUsage(minted.id, 0).ok, true);
+  assert.equal(vk.recordVirtualKeyUsage(minted.id, 0).ok, true);
+  const denied = vk.recordVirtualKeyUsage(minted.id, 0);
+  assert.equal(denied.ok, false);
+  if (!denied.ok) assert.equal(denied.reason, "over_rpd");
+});
+
+test("recordVirtualKeyUsage on revoked key returns reason=revoked", async () => {
+  await resetStorage();
+  const minted = vk.mintVirtualKey("tenant_a");
+  vk.revokeVirtualKey(minted.id);
+  const r = vk.recordVirtualKeyUsage(minted.id, 0);
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.equal(r.reason, "revoked");
+});
+
+test("recordVirtualKeyUsage on unknown id returns reason=not_found", () => {
+  const r = vk.recordVirtualKeyUsage("no-such-id", 0);
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.equal(r.reason, "not_found");
+});
+
+test("hashed_key is unique across mints (no collisions)", async () => {
+  await resetStorage();
+  const minted = [];
+  for (let i = 0; i < 50; i++) {
+    minted.push(vk.mintVirtualKey("tenant_a"));
+  }
+  // Different mints always produce different raw keys.
+  const seen = new Set<string>();
+  for (const m of minted) {
+    assert.equal(seen.has(m.rawKey), false, "duplicate raw key in 50 mints");
+    seen.add(m.rawKey);
+  }
+});


### PR DESCRIPTION
## feat(bifrost): virtual-key minting + cost tracking (B5 of v8.1 track, ADR-031)

This PR implements **B5** of the v8.1 Bifrost Tier-1 router rollout. The virtual-key layer is the credential that OmniRoute mints, hands to the user, and resolves to a real upstream key at request time. The cost-tracking layer is the first-class ledger that powers the per-key / per-tenant dashboard.

B1 (vendor canonicalization) merged via PR #73; B2/B3 (BifrostBackend executor + providerMap) merged via PR #72; B4 (model cache) is on PR #75. **B5 depends on the B4 cache** (B4 is the catalog the dashboard references when validating `allowedModels`).

## 5 commits (one per layer)

| # | Commit | Layer |
|---|--------|-------|
| 1 | `feat(db): virtual_keys + cost_events migrations (B5, ADR-031)` | Migrations + db modules (1388 lines, includes 2 test files) |
| 2 | `feat(a2a): mintVirtualKey skill (closes DEBT-006 partial)` | A2A skill (392 lines, includes 1 test file) |
| 3 | `feat(api): /api/virtual-keys REST routes (B5)` | 4 REST routes + handler registration |
| 4 | `feat(dashboard): virtual-keys page (B5)` | Next.js client page at `/dashboard/keys` |
| 5 | `docs: VIRTUAL-KEYS operator guide (B5)` | Operator guide (192 lines) |

## Schema

**`virtual_keys` (migration 102)** — per-tenant scoped credentials. The raw key is generated as 32 bytes of `crypto.randomBytes` and surfaced exactly once on creation. The stored value is a sha256 hex digest (`UNIQUE` constraint).

**`cost_events` (migration 103)** — append-only ledger. Denormalised `tenant_id` so the per-tenant rollups do not need to join through `virtual_keys` on the hot read path. Two composite indexes: `(virtual_key_id, occurred_at)` and `(tenant_id, occurred_at)`.

## Security model

> The raw key is a 32-byte random hex string shown exactly once on mint and stored as a sha256 hex digest thereafter; every state-mutating path is a single SQL `UPDATE` whose `WHERE` clause enforces the cap atomically.

The atomic guarantee is in the `WHERE` clause, not in application code:

```sql
UPDATE virtual_keys
   SET current_cost_usd = current_cost_usd + ?,
       current_rpd      = CASE WHEN last_reset_day = ? THEN current_rpd + 1 ELSE 1 END,
       last_used_at     = ?,
       last_reset_day   = ?
 WHERE id = ?
   AND revoked_at IS NULL
   AND (max_cost_usd IS NULL OR current_cost_usd + ? <= max_cost_usd)
   AND (max_rpd      IS NULL OR last_reset_day <> ? OR current_rpd + 1 <= max_rpd)
```

SQLite serialises writes; the loser of a concurrent debit sees `changes() === 0` and is mapped to `over_budget` or `over_rpd`. There is no read-then-write window.

## Surface area

| Layer | Path | Purpose |
|-------|------|---------|
| A2A | `skill: "mint-virtual-key"` (gated by `keys:write` scope) | JSON-RPC minting |
| REST | `POST /api/virtual-keys` | Mint (returns `rawKey` ONCE) |
| REST | `GET /api/virtual-keys?tenantId=X` | List |
| REST | `DELETE /api/virtual-keys/[id]` | Revoke (idempotent; 404 on unknown, 200 on already-revoked) |
| REST | `GET /api/virtual-keys/[id]/cost?since=ISO` | Cost summary (30-day default; `byDay` + `byProvider` + `byModel`) |
| UI | `/dashboard/keys` | Operator dashboard (mint form, key table, per-key cost card) |

## Tests (28 cases total)

| File | Cases |
|------|-------|
| `tests/unit/virtual-keys-db.test.ts` | 12 — mint, list, revoke, resolve, recordUsage under-budget, over-budget atomic, over-RPD atomic, expiry, hashed-key uniqueness, rawKey shown once, sha256 stored |
| `tests/unit/cost-tracking-db.test.ts` | 10 — record, list-by-tenant, list-by-key, time-window filter, summarize-by-tenant, summarize-by-key, multi-event rollup, byDay series, auto-emit on usage, no-emit on rejected usage |
| `tests/unit/a2a-mint-virtual-key.test.ts` | 6 — happy path, scope-denied, no-scopes, expires_at validation, max_cost_usd validation, unset-caps warnings |

The DB tests use `node:test`; the A2A test uses `vitest` (same as the existing A2A suite). All test files are co-located with their respective implementation commits.

## Constraints honored

- **No new dependencies** — Node `crypto.randomBytes` + `crypto.createHash`, existing `uuid` (already in `package.json`).
- **No chart libraries** — the per-key cost card uses a `<div data-cost-by-day={...}>` placeholder so a follow-up PR can render without re-fetching (B5 explicitly excluded the chart-lib dep).
- **TypeScript: zero new errors** — static check confirmed against the worktree's existing `tsconfig`.
- **Single-statement atomic guards** — every cap-enforcement path is one SQL `UPDATE` with the cap in the `WHERE` clause.
- **`crypto.randomBytes(32)` for raw key** — 64 hex chars after the `vk_` prefix; entropy is unreachable in practice.

## Cross-references

- ADR-031 § 1.3 — virtual keys
- ADR-031 § 2.3 — atomic guards
- ADR-031 § 4 — cost tracking
- PLAN § 2.5.2 — B5 description
- PR #75 (B4) — model cache, dependency for `allowedModels` validation
- docs/frameworks/VIRTUAL-KEYS.md — operator guide (this PR)

## B4 dependency note

B4 is on PR #75 (open, not yet merged). B5's `allowedModels` field is stored and surfaced in the dashboard, but the request-pipeline integration (per-model enforcement at request time) is a follow-up that lands when B4 merges. The `BifrostBackend` executor (PR #72) is the integration point.
