### PR TITLE
chore: fix pre-push hook (DEBT-002)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,12 +1,20 @@
-#!/usr/bin/env sh
-# .husky/pre-push — fast deterministic gates (<10s total)
-# Intentionally excludes test:unit (slow; covered by CI pre-push remote run).
-# Activated: 2026-06-13 (6A.12 — replaced commented-out test:unit stub)
-
-if ! command -v npm >/dev/null 2>&1; then
-  echo "⚠️  npm not found in PATH — skipping pre-push hooks"
-  echo "   Run 'npm run check:any-budget:t11 && npm run check:tracked-artifacts' manually before pushing."
-  exit 0
-fi
-
-npm run check:any-budget:t11 && npm run check:tracked-artifacts
+#!/bin/sh
+# .husky/pre-push — disabled per DEBT-002.
+#
+# The pre-push hook previously invoked npm scripts that referenced a
+# non-existent root package.json (originally `npm test`; later
+# `npm run check:any-budget:t11 && npm run check:tracked-artifacts`),
+# blocking every `git push` with an ENOENT / Missing-script abort and
+# forcing contributors to silence it via `core.hooksPath=/dev/null`.
+#
+# Real fix path (per docs/TECH_DEBT.md DEBT-002):
+#   1) Make the hook workspace-aware via npm/pnpm workspaces, OR
+#   2) Move to lefthook + `cargo make` at the repo root.
+#
+# Until that work lands, the hook is a no-op so commits land cleanly.
+# CI runs the full test matrix on the remote side (see
+# .github/workflows/audit-ratchet.yml).
+#
+# Re-enable when CI runs the full test matrix and root package.json
+# is restored (or the hook is ported to lefthook).
+exit 0


### PR DESCRIPTION
## **User description**
## Summary

Fixes DEBT-002 — the broken pre-push hook that ran `npm` scripts against a non-existent root `package.json`, blocking every `git push` with an `ENOENT` / `Missing script` abort.

### Findings on `main` (pre-fix state)

- `.husky/pre-push` invoked `npm run check:any-budget:t11 && npm run check:tracked-artifacts`. Neither script is defined in any `package.json` in the repo (verified via `grep -l`), so `git push` aborted with `npm error Missing script` — not the original `ENOENT` for `npm test` described in `docs/TECH_DEBT.md`, but the same class of failure.
- `lefthook.yml` does not exist at the root or anywhere in the repo (verified via `find`).
- Root `package.json` does not exist (verified via `find`); real manifests live in `@omniroute/opencode-plugin/`, `@omniroute/opencode-provider/`, `open-sse/`, `desktop-electrobun/`, `electron/`.

### Changes

- `.husky/pre-push` — replaced with a no-op shell script (`exit 0`) and a comment explaining the DEBT-002 background, the two real fix paths (workspace-aware npm/pnpm scripts OR port to lefthook + `cargo make`), and the re-enable trigger (CI runs the full test matrix and root `package.json` is restored).
- `lefthook.yml` — already absent on `main`; nothing to do.
- Root `package.json` — already absent on `main`; nothing to do.

### Verification

- `git push` no longer aborts with `npm error code ENOENT` / `Missing script`.
- Hook still exits cleanly with the no-op shell script.
- Pre-push hooks run from `.husky/pre-push` (set via `husky` install in `packageManager` field of sub-package.jsons).

### Related

- DEBT-002 in `docs/TECH_DEBT.md`
- PLAN.md § 4.1 (operational readiness)
- worklogs/2026-06-17-fleet-readiness.md (worklog entry — exact filename may differ; fleet worklog schema is `worklogs/<date>-<req-id>-<slug>.md`)

### Out of scope (not touched)

- The pre-existing `docs/intent/OmniRoute.md` working-tree modifications were left untouched (auto-save from a parallel process, not related to DEBT-002).
- The unrelated `feat(a2a): implement smartRouting skill` commit (`341fce795`, DEBT-006) that was on this branch from a prior session was left as-is — DEBT-002 fix is the additional `13a670057` commit on top.

---

**Branch**: `chore/l5-117-fix-pre-push-hook-2026-06-18`
**Base**: `main`
**Owner**: @KooshaPari/core
**Commits ahead of main**: 2 (1 unrelated `feat(a2a): implement smartRouting skill` + 1 `chore: fix pre-push hook (DEBT-002)`)


___

## **CodeAnt-AI Description**
**Stop pre-push from blocking git pushes**

### What Changed
- The pre-push hook now does nothing instead of running broken checks against a missing root `package.json`
- `git push` no longer fails with `ENOENT` or “Missing script” from this hook
- The hook now points contributors to the real fix path and notes that CI still runs the full test matrix

### Impact
`✅ Fewer push failures`
`✅ No more missing-script errors on pre-push`
`✅ Cleaner contributor workflow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
