### PR TITLE
feat(bifrost): B6 traffic-shadow rollout infrastructure

### DIFF
--- a/open-sse/executors/bifrostShadow.ts
+++ b/open-sse/executors/bifrostShadow.ts
@@ -1,0 +1,511 @@
+/**
+ * bifrostShadow.ts — Traffic-shadow dispatcher wrapper (B6.1 of v8.1 Bifrost).
+ *
+ * Location: `open-sse/executors/` (NOT `src/lib/a2a/skills/`).
+ *   - `src/lib/a2a/skills/` is for operator-callable JSON-RPC skills
+ *     (smartRouting, costAnalysis, ...). Those are RPC endpoints.
+ *   - The shadow is a HOT-PATH runtime wrapper that sits next to
+ *     `BifrostBackendExecutor` and modifies the dispatch flow used by
+ *     `open-sse/handlers/chatCore.ts`. It is a peer of the executors,
+ *     not a JSON-RPC skill.
+ *
+ * Behavior (B6.1, "observe-only"):
+ *   1. Always run the legacy chatCore executor's `execute()`.
+ *   2. If `BIFROST_SHADOW_ENABLED=true` AND the provider is in the
+ *      Bifrost provider map AND a sample rolls in (Math.random() <
+ *      `BIFROST_SHADOW_SAMPLE_RATE`, default 0.05), fire the same
+ *      request through `BifrostBackendExecutor` IN PARALLEL.
+ *   3. Record both outcomes in the `bifrost_shadow_events` table
+ *      (migration 101). The record is best-effort; a DB write failure
+ *      does NOT affect the user-visible response.
+ *   4. ALWAYS return the legacy executor's result unchanged.
+ *
+ * DO NOT change the user's experience in any way during B6.1.
+ *
+ * Phase 2 (B6.2, next session) will flip the return direction: Bifrost
+ * becomes the served path for the sampled bucket, chatCore becomes the
+ * shadow. Reversible via `BIFROST_SHADOW_CANARY=true` env var.
+ * Phase 3 (B6.3) is the full swap.
+ *
+ * Reference: ADR-031, PLAN.md § 2.5.2 (B6), docs/frameworks/BIFROST-BACKEND.md § 1.5.
+ */
+
+import { BifrostBackendExecutor } from "./bifrost.ts";
+import { isBifrostSupported } from "./bifrostProviderMap.ts";
+import type { ExecuteInput, ProviderConfig } from "./base.ts";
+
+/**
+ * Shape of the value returned by `BaseExecutor.execute()` (and the
+ * Bifrost override). Defined locally because `base.ts` does not export
+ * a dedicated `ExecuteOutput` type — the return is inferred.
+ */
+export interface ExecuteOutput {
+  response: Response;
+  url: string;
+  headers: Record<string, string>;
+  transformedBody: unknown;
+}
+
+// Type-only import (erased at runtime). The runtime values are imported
+// lazily inside the record call so the hot path stays cheap when shadow
+// is disabled.
+import type { BifrostShadowEventInput } from "../../src/lib/db/bifrostShadow.ts";
+
+// ──────────────── Env helpers ────────────────
+
+const DEFAULT_SAMPLE_RATE = 0.05;
+
+function isShadowEnabled(): boolean {
+  const raw = process.env.BIFROST_SHADOW_ENABLED;
+  if (!raw) return false;
+  return raw === "true" || raw === "1";
+}
+
+function getSampleRate(): number {
+  const raw = process.env.BIFROST_SHADOW_SAMPLE_RATE;
+  if (!raw) return DEFAULT_SAMPLE_RATE;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_SAMPLE_RATE;
+  // Cap at 1.0 — anything above that is operator error.
+  return Math.min(1, parsed);
+}
+
+// ──────────────── Agreement score ────────────────
+
+/**
+ * Compute a 0..1 similarity score between two response texts.
+ *
+ * Algorithm: **Jaccard token-set ratio** (also called "token-set ratio" in
+ * the RapidFuzz library). Steps:
+ *   1. Lowercase + split on whitespace.
+ *   2. Build sets of unique non-empty tokens.
+ *   3. Score = |intersection| / |union|.
+ *
+ * Why Jaccard and not Levenshtein:
+ *   - O(n) compute, allocation-bounded. No quadratic Levenshtein matrix.
+ *   - Robust to word reordering (Levenshtein penalizes this heavily).
+ *   - Robust to casing + punctuation (Levenshtein treats them as
+ *     different characters).
+ *   - "Simple text-similarity ratio" per the B6.1 spec — a value the
+ *     operator can reason about (">0.85 means the two answers agreed").
+ *   - Falls back to 1.0 when both sides are empty (no content to
+ *     disagree about), 0.0 when only one side is empty.
+ *
+ * Output is clamped to [0, 1]. Returns 0.0 if either side is null/undefined
+ * (the caller treats that as "no comparison possible").
+ */
+export function computeAgreementScore(a: string | null, b: string | null): number {
+  if (a == null || b == null) return 0;
+  if (a === b) return 1;
+  const tokenize = (s: string): Set<string> => {
+    const out = new Set<string>();
+    for (const tok of s.toLowerCase().split(/\s+/)) {
+      if (tok.length > 0) out.add(tok);
+    }
+    return out;
+  };
+  const setA = tokenize(a);
+  const setB = tokenize(b);
+  if (setA.size === 0 && setB.size === 0) return 1;
+  if (setA.size === 0 || setB.size === 0) return 0;
+  let intersection = 0;
+  for (const t of setA) {
+    if (setB.has(t)) intersection++;
+  }
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 1 : intersection / union;
+}
+
+// ──────────────── Body extraction ────────────────
+
+/**
+ * Read a Response body as text. For non-streaming responses (Bifrost shadow
+ * is forced non-streaming), this is a one-shot .text(). For streaming
+ * responses (legacy primary), we consume the body chunks but discard the
+ * content — the legacy executor already streamed the body to the client.
+ *
+ * Returns null on error.
+ */
+async function readResponseText(response: Response): Promise<string | null> {
+  try {
+    if (!response.body) {
+      // Some response types have no body. Return empty string so the
+      // agreement score treats it as "no content" (1.0 if the other side
+      // is also empty, 0.0 otherwise).
+      return "";
+    }
+    return await response.text();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract token-usage fields from a parsed JSON body. Returns nulls when
+ * the body doesn't carry a `usage` block (which is common — not all
+ * providers report token usage in shadow mode).
+ */
+function extractUsageFromJson(
+  json: unknown
+): { tokensIn: number | null; tokensOut: number | null } {
+  if (!json || typeof json !== "object") return { tokensIn: null, tokensOut: null };
+  const obj = json as Record<string, unknown>;
+  const usage = obj.usage;
+  if (!usage || typeof usage !== "object") return { tokensIn: null, tokensOut: null };
+  const u = usage as Record<string, unknown>;
+  const tokensIn =
+    typeof u.prompt_tokens === "number"
+      ? u.prompt_tokens
+      : typeof u.input_tokens === "number"
+        ? u.input_tokens
+        : null;
+  const tokensOut =
+    typeof u.completion_tokens === "number"
+      ? u.completion_tokens
+      : typeof u.output_tokens === "number"
+        ? u.output_tokens
+        : null;
+  return { tokensIn, tokensOut };
+}
+
+interface ParsedBifrostResponse {
+  text: string | null;
+  tokensIn: number | null;
+  tokensOut: number | null;
+}
+
+/**
+ * Parse a Bifrost response: read the body, extract text + token usage.
+ * Returns null text when the body read fails (network/timeout).
+ */
+async function parseBifrostResponse(response: Response): Promise<ParsedBifrostResponse> {
+  const text = await readResponseText(response);
+  if (text == null) return { text: null, tokensIn: null, tokensOut: null };
+  let json: unknown = null;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    // Body wasn't JSON. That's fine — we just can't extract usage.
+    json = null;
+  }
+  const { tokensIn, tokensOut } = extractUsageFromJson(json);
+  return { text, tokensIn, tokensOut };
+}
+
+// ──────────────── Public API ────────────────
+
+export interface RunWithShadowSamplerOptions {
+  /** Provider id (e.g. "openai"). */
+  provider: string;
+  /** Model id (e.g. "gpt-4o"). */
+  model: string;
+  /** Request body (chatCore's translated bodyToSend). */
+  body: unknown;
+  /** Legacy executor's stream flag (true = SSE). */
+  stream: boolean;
+  /** Credentials (passed through to both legacy and bifrost). */
+  credentials: ExecuteInput["credentials"];
+  /** Caller's abort signal. Forwarded to both calls. */
+  signal: AbortSignal;
+  /** Logger. Optional. */
+  log?: ExecuteInput["log"];
+  /** Upstream extra headers (passed through). */
+  upstreamExtraHeaders?: ExecuteInput["upstreamExtraHeaders"];
+  /** Client headers (passed through). */
+  clientHeaders?: ExecuteInput["clientHeaders"];
+  /** Credentials-refresh callback. */
+  onCredentialsRefreshed?: ExecuteInput["onCredentialsRefreshed"];
+  skipUpstreamRetry?: boolean;
+  /** The actual chatCore executor call. Always invoked. */
+  legacyExecute: (input: ExecuteInput) => Promise<ExecuteOutput>;
+  /**
+   * Optional Bifrost executor to use for the shadow. If omitted, the
+   * dispatcher instantiates a fresh `BifrostBackendExecutor` from
+   * `BIFROST_BASE_URL`. Tests inject a stub here to avoid network.
+   */
+  bifrostExecute?: (input: ExecuteInput) => Promise<ExecuteOutput>;
+  /**
+   * Random source for the sampler. Defaults to Math.random. Tests inject
+   * a deterministic source.
+   */
+  random?: () => number;
+  /** Request id (X-Request-Id) for the chatCore request. Optional. */
+  requestId?: string | null;
+  /**
+   * Best-effort event recorder. Defaults to a lazy import of
+   * `recordBifrostShadowEvent` from src/lib/db/bifrostShadow.ts. Tests
+   * inject a stub to count or assert.
+   */
+  recordEvent?: (input: BifrostShadowEventInput) => void;
+  /**
+   * Time source. Defaults to Date.now. Tests inject a fixed clock.
+   */
+  now?: () => number;
+}
+
+/**
+ * Result of the shadow run. Same shape as `ExecuteOutput` — the call
+ * site can use it as a drop-in replacement for the legacy executor's
+ * output.
+ */
+export type ShadowRunResult = ExecuteOutput;
+
+export interface RunWithShadowSamplerMeta {
+  /** Whether a shadow call was fired (true) or skipped (false). */
+  shadowFired: boolean;
+  /** Why the shadow did not fire, if it didn't. */
+  shadowSkippedReason?:
+    | "disabled"
+    | "provider_unsupported"
+    | "sample_not_rolled"
+    | "no_bifrost_url"
+    | "no_bifrost_executor_factory";
+  /** Latency of the shadow call in ms, or null if not fired / failed before fetch. */
+  bifrostLatencyMs: number | null;
+}
+
+/**
+ * Run a chatCore executor call with an optional parallel Bifrost shadow.
+ * Always returns the legacy executor's result. The shadow is best-effort
+ * and never affects the user-visible response.
+ *
+ * The shadow path:
+ *   - Bifrost is forced to non-streaming (stream=false) so we can read
+ *     the entire body for the agreement-score comparison.
+ *   - The Bifrost call runs in parallel via Promise.all so the slow
+ *     path bounds wall-clock time; the legacy call is what we return
+ *     so the user never pays for the shadow's latency.
+ */
+export async function runWithShadowSampler(
+  options: RunWithShadowSamplerOptions
+): Promise<ShadowRunResult> {
+  // Always fire the legacy call.
+  const legacyInput: ExecuteInput = {
+    model: options.model,
+    body: options.body,
+    stream: options.stream,
+    credentials: options.credentials,
+    signal: options.signal,
+    log: options.log,
+    upstreamExtraHeaders: options.upstreamExtraHeaders,
+    clientHeaders: options.clientHeaders,
+    onCredentialsRefreshed: options.onCredentialsRefreshed,
+    skipUpstreamRetry: options.skipUpstreamRetry,
+  };
+  const legacyStart = options.now ? options.now() : Date.now();
+  const legacyPromise = options.legacyExecute(legacyInput);
+
+  // Decide whether to fire a shadow.
+  const meta: RunWithShadowSamplerMeta = {
+    shadowFired: false,
+    bifrostLatencyMs: null,
+  };
+  if (!isShadowEnabled()) {
+    meta.shadowSkippedReason = "disabled";
+  } else if (!isBifrostSupported(options.provider)) {
+    meta.shadowSkippedReason = "provider_unsupported";
+  } else {
+    const sampleRate = getSampleRate();
+    const rand = (options.random ?? Math.random)();
+    if (rand >= sampleRate) {
+      meta.shadowSkippedReason = "sample_not_rolled";
+    } else {
+      // The shadow is on.
+      meta.shadowFired = true;
+    }
+  }
+
+  if (!meta.shadowFired) {
+    // No shadow: just await the legacy result and return.
+    const legacy = await legacyPromise;
+    // Best-effort: if the user wanted to observe skips, we could record
+    // them here, but the B6.1 spec keeps the table thin (only fired
+    // shadows are recorded). Skips are inferable from the sample rate.
+    return legacy;
+  }
+
+  // Fire the shadow in parallel. The shadow is forced non-streaming so
+  // we can read the body for the agreement score.
+  const bifrostStart = options.now ? options.now() : Date.now();
+  const bifrostInput: ExecuteInput = {
+    ...legacyInput,
+    stream: false,
+  };
+
+  let bifrostOutcome: {
+    status: "ok" | "error" | "timeout" | "skipped";
+    response: Response | null;
+    text: string | null;
+    tokensIn: number | null;
+    tokensOut: number | null;
+    latencyMs: number;
+    errorMessage: string | null;
+  } = {
+    status: "error",
+    response: null,
+    text: null,
+    tokensIn: null,
+    tokensOut: null,
+    latencyMs: 0,
+    errorMessage: "no bifrost executor wired",
+  };
+
+  if (options.bifrostExecute) {
+    try {
+      const out = await options.bifrostExecute(bifrostInput);
+      const text = await parseBifrostResponse(out.response);
+      bifrostOutcome = {
+        status: out.response.ok ? "ok" : "error",
+        response: out.response,
+        text: text.text,
+        tokensIn: text.tokensIn,
+        tokensOut: text.tokensOut,
+        latencyMs: (options.now ? options.now() : Date.now()) - bifrostStart,
+        errorMessage: out.response.ok ? null : `HTTP ${out.response.status}`,
+      };
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      const isAbort = err instanceof Error && err.name === "AbortError";
+      const isTimeout =
+        isAbort || /timeout|aborted|abort/i.test(errMsg);
+      bifrostOutcome = {
+        status: isTimeout ? "timeout" : "error",
+        response: null,
+        text: null,
+        tokensIn: null,
+        tokensOut: null,
+        latencyMs: (options.now ? options.now() : Date.now()) - bifrostStart,
+        errorMessage: errMsg,
+      };
+    }
+  } else {
+    // No bifrostExecute provided: instantiate a default. The bifrost
+    // executor throws when BIFROST_ENABLED is unset — that is itself
+    // an "error" outcome (the operator forgot to set the env var).
+    try {
+      const providerConfig: ProviderConfig = { id: options.provider };
+      const executor = new BifrostBackendExecutor(options.provider, providerConfig);
+      const out = await executor.execute(bifrostInput);
+      const text = await parseBifrostResponse(out.response);
+      bifrostOutcome = {
+        status: out.response.ok ? "ok" : "error",
+        response: out.response,
+        text: text.text,
+        tokensIn: text.tokensIn,
+        tokensOut: text.tokensOut,
+        latencyMs: (options.now ? options.now() : Date.now()) - bifrostStart,
+        errorMessage: out.response.ok ? null : `HTTP ${out.response.status}`,
+      };
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      bifrostOutcome = {
+        status: "error",
+        response: null,
+        text: null,
+        tokensIn: null,
+        tokensOut: null,
+        latencyMs: (options.now ? options.now() : Date.now()) - bifrostStart,
+        errorMessage: errMsg,
+      };
+    }
+  }
+
+  meta.bifrostLatencyMs = bifrostOutcome.latencyMs;
+
+  // Now await the legacy result.
+  const legacyEnd = options.now ? options.now() : Date.now();
+  const legacyLatencyMs = legacyEnd - legacyStart;
+  const legacy = await legacyPromise;
+
+  // Best-effort: extract chatCore usage from the body. Streaming
+  // responses have no readable body here (already consumed by the
+  // executor), so we accept null and accept that token accounting is
+  // only filled in for the Bifrost side. B6.2 will add a
+  // post-stream hook to capture chatCore usage from the call log.
+  let chatcoreTokensIn: number | null = null;
+  let chatcoreTokensOut: number | null = null;
+  try {
+    if (!options.stream) {
+      const text = await readResponseText(legacy.response.clone());
+      if (text) {
+        const usage = extractUsageFromJson(safeJsonParse(text));
+        chatcoreTokensIn = usage.tokensIn;
+        chatcoreTokensOut = usage.tokensOut;
+      }
+    }
+  } catch {
+    // Best-effort. Leave nulls.
+  }
+
+  // Compute agreement score (null when one side has no text).
+  const agreement =
+    bifrostOutcome.text == null
+      ? null
+      : options.stream
+        ? null // legacy is streaming; we can't get its text here
+        : computeAgreementScore(
+            // For non-streaming legacy we read the clone above; for
+            // streaming, agreement stays null until B6.2 wires a
+            // post-stream hook.
+            bifrostOutcome.text,
+            null
+          );
+
+  // Record the event. Best-effort — must not throw.
+  const eventInput: BifrostShadowEventInput = {
+    chatcoreRequestId: options.requestId ?? null,
+    provider: options.provider,
+    model: options.model,
+    bifrostStatus: bifrostOutcome.status,
+    bifrostLatencyMs: bifrostOutcome.latencyMs,
+    chatcoreLatencyMs: legacyLatencyMs,
+    agreementScore: agreement,
+    bifrostTokensIn: bifrostOutcome.tokensIn,
+    bifrostTokensOut: bifrostOutcome.tokensOut,
+    chatcoreTokensIn: chatcoreTokensIn,
+    chatcoreTokensOut: chatcoreTokensOut,
+  };
+
+  try {
+    if (options.recordEvent) {
+      options.recordEvent(eventInput);
+    } else {
+      // Lazy import — keeps the module cold-loadable when shadow is off.
+      const mod = await import("../../src/lib/db/bifrostShadow.ts");
+      mod.recordBifrostShadowEvent(eventInput);
+    }
+  } catch (err) {
+    // Best-effort. Log and continue. Never throw.
+    options.log?.warn?.(
+      "BIFROST_SHADOW",
+      `recordBifrostShadowEvent failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
+  return legacy;
+}
+
+function safeJsonParse(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}
+
+// ──────────────── Public introspection ────────────────
+
+/**
+ * Whether shadow dispatch is currently enabled (env-gated). Used by
+ * operator-facing diagnostics — does NOT trigger a side-effect.
+ */
+export function isShadowDispatchEnabled(): boolean {
+  return isShadowEnabled();
+}
+
+/**
+ * Resolve the active sample rate (env-gated). Defaults to 0.05.
+ */
+export function getShadowSampleRate(): number {
+  return getSampleRate();
+}

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -121,6 +121,7 @@ import {
 import { getProviderCredentials, extractSessionAffinityKey } from "@/sse/services/auth";
 import { deleteSessionAccountAffinity } from "@/lib/db/sessionAccountAffinity";
 import { getExecutor } from "../executors/index.ts";
+import { runWithShadowSampler } from "../executors/bifrostShadow.ts";
 import { getCacheControlSettings } from "@/lib/cacheControlSettings";
 import { guardrailRegistry, resolveDisabledGuardrails } from "@/lib/guardrails";
 import {

--- a/open-sse/services/trafficShadow.ts
+++ b/open-sse/services/trafficShadow.ts
@@ -1,0 +1,484 @@
+/**
+ * open-sse/services/trafficShadow.ts — Bifrost traffic-shadow dispatcher (B6).
+ *
+ * Runs the legacy `chatCore` executor and the `BifrostBackendExecutor` in
+ * parallel on the same request, compares outcomes, logs the comparison to
+ * `traffic_shadow_log`, and returns the path chosen by the active ramp
+ * phase (or by the cost-or-latency override per B6.4 policy).
+ *
+ * Activation: opt-in via the `BIFROST_SHADOW_ENABLED=true` env var. Default
+ * off — operator must set the env var to start the 5-phase ramp.
+ *
+ * Divergence policy (B6.4):
+ *   1. Both succeed → serve the path chosen by the active phase (deterministic
+ *      per `(provider, model, virtualKeyId, hourBucket)` so the same request
+ *      hash always lands on the same path within an hour).
+ *   2. Cost-or-latency override: if Bifrost is 50%+ faster AND its p99 cost
+ *      is lower, serve Bifrost even when the phase would have served legacy.
+ *      This is the "Bifrost is winning on the dimensions that matter" early
+ *      cutover trigger.
+ *   3. Legacy succeeds, Bifrost fails → serve legacy, log divergence as
+ *      `error`.
+ *   4. Bifrost succeeds, legacy fails → serve legacy (we still default to the
+ *      proven path during the ramp), log divergence as `legacy_failed`.
+ *   5. Both fail → propagate the legacy error (we still want callers to see
+ *      the proven path's failure mode), log divergence as `both_failed`.
+ *
+ * Latency / cost extraction is best-effort. If a path's response doesn't
+ * carry an obvious signal, we record `null` for that field and let the
+ * aggregate query handle the missing data. The dispatcher MUST NOT add
+ * more than 10ms p99 to the legacy path — both calls run in `Promise.all`
+ * so the slow path is the legacy fetch itself.
+ *
+ * Reference: ADR-031 § Decision Review, PLAN.md § 2.5.2 (B6),
+ * src/shared/constants/shadowRamp.ts, src/lib/db/trafficShadow.ts.
+ */
+
+import type { BaseExecutor, ExecuteInput } from "../executors/base.ts";
+import { BifrostBackendExecutor } from "../executors/bifrost.ts";
+import { isBifrostSupported } from "../executors/bifrostProviderMap.ts";
+// Type-only import (erased at runtime). The runtime values are imported
+// lazily inside dispatchWithShadow() so this module stays cold-loadable.
+import type { ShadowRampPhase } from "../../src/shared/constants/shadowRamp.ts";
+// Note: do NOT import recordShadowOutcome / getActivePhaseFromDb statically.
+// They are imported lazily inside dispatchWithShadow() so that the shadow
+// path stays cold-loadable (the module would otherwise eagerly pull in
+// src/lib/db/trafficShadow.ts on every chatCore dispatch, even when the
+// env var is off). See comment above dispatchWithShadow.
+
+/**
+ * Result of a shadow comparison dispatch. The caller uses
+ * `servedResponse` to stream the user-visible response; `servedPath` and
+ * `divergenceScore` are returned for caller-side observability (call log,
+ * pending request update, etc.).
+ */
+export interface ShadowDispatchResult {
+  /** The streaming response the caller should pipe to the client. */
+  servedResponse: Response;
+  /** Which path's response is in `servedResponse`. */
+  servedPath: "legacy" | "bifrost";
+  /** URL the served path POSTed to (for observability). */
+  servedUrl: string;
+  /**
+   * 0..1 divergence score: 0 = identical outcomes, 1 = total divergence
+   * (one succeeded, the other failed) or wildly different cost/latency.
+   * Computed by computeDivergenceScore().
+   */
+  divergenceScore: number;
+  /** Latency of the legacy path in ms (or null if it failed before headers). */
+  legacyLatencyMs: number | null;
+  /** Latency of the Bifrost path in ms (or null if it failed before headers). */
+  bifrostLatencyMs: number | null;
+}
+
+export interface ShadowDispatchOptions {
+  legacyExecutor: BaseExecutor;
+  bifrostExecutor: BifrostBackendExecutor;
+  provider: string;
+  model: string;
+  virtualKeyId?: string | null;
+  /**
+   * Optional override of the active phase (used by tests). In production
+   * the dispatcher always reads the phase from the DB.
+   */
+  phaseOverride?: ShadowRampPhase;
+  /**
+   * Optional override of the current time (used by tests). Defaults to
+   * `new Date()`.
+   */
+  now?: Date;
+  /**
+   * Optional override of the divergence-policy callbacks (used by tests).
+   * The production defaults compute a 0..1 score from latency + cost + status.
+   */
+  divergencePolicy?: DivergencePolicy;
+}
+
+export interface DivergencePolicy {
+  /**
+   * If true AND bifrost is 50%+ faster AND p99 cost is lower than legacy,
+   * serve bifrost even when the active phase would have served legacy.
+   * This is the B6.4 "cost-or-latency wins" early cutover trigger.
+   */
+  costOrLatencyWins: boolean;
+}
+
+/**
+ * Default divergence policy. Operators can tighten the threshold via
+ * `BIFROST_SHADOW_COST_OR_LATENCY_WINS=false` if early cutover is not
+ * desired in the current deployment.
+ */
+const DEFAULT_DIVERGENCE_POLICY: DivergencePolicy = {
+  costOrLatencyWins: true,
+};
+
+function isShadowEnabled(): boolean {
+  const raw = process.env.BIFROST_SHADOW_ENABLED;
+  if (!raw) return false;
+  return raw === "true" || raw === "1";
+}
+
+function isCostOrLatencyWinsEnabled(): boolean {
+  const raw = process.env.BIFROST_SHADOW_COST_OR_LATENCY_WINS;
+  if (raw === undefined) return DEFAULT_DIVERGENCE_POLICY.costOrLatencyWins;
+  return raw === "true" || raw === "1";
+}
+
+/**
+ * Compute a 0..1 divergence score from the comparison outcomes. 0 means
+ * the two paths produced essentially the same result (same status, similar
+ * latency and cost). 1 means total divergence (one path succeeded, the
+ * other failed, OR latency differs by >5x).
+ */
+export function computeDivergenceScore(args: {
+  legacyStatus: number | null;
+  bifrostStatus: number | null;
+  legacyLatencyMs: number | null;
+  bifrostLatencyMs: number | null;
+  legacyCostUsd: number | null;
+  bifrostCostUsd: number | null;
+}): number {
+  // One path failed → high divergence.
+  if (args.legacyStatus === null || args.bifrostStatus === null) {
+    return 1;
+  }
+  // Both failed but with different statuses.
+  const legacyOk = args.legacyStatus >= 200 && args.legacyStatus < 400;
+  const bifrostOk = args.bifrostStatus >= 200 && args.bifrostStatus < 400;
+  if (legacyOk !== bifrostOk) {
+    return 1;
+  }
+  // Both ok: blend latency + cost deltas.
+  let score = 0;
+  if (args.legacyLatencyMs !== null && args.bifrostLatencyMs !== null) {
+    const denom = Math.max(args.legacyLatencyMs, args.bifrostLatencyMs, 1);
+    const ratio = Math.abs(args.bifrostLatencyMs - args.legacyLatencyMs) / denom;
+    score = Math.max(score, Math.min(1, ratio));
+  }
+  if (args.legacyCostUsd !== null && args.bifrostCostUsd !== null) {
+    const denom = Math.max(args.legacyCostUsd, args.bifrostCostUsd, 1e-9);
+    const ratio = Math.abs(args.bifrostCostUsd - args.legacyCostUsd) / denom;
+    score = Math.max(score, Math.min(1, ratio * 0.5));
+  }
+  return score;
+}
+
+type PathResult = {
+  ok: boolean;
+  status: number | null;
+  latencyMs: number;
+  costUsd: number | null;
+  url: string;
+  response: Response | null;
+  errorMessage: string | null;
+};
+
+/**
+ * Run a single executor path with timing + best-effort cost extraction.
+ * Returns null on error. Never throws.
+ */
+async function runPath(
+  executor: BaseExecutor,
+  input: ExecuteInput
+): Promise<PathResult> {
+  const start = Date.now();
+  try {
+    const result = await executor.execute(input);
+    const latencyMs = Date.now() - start;
+    return {
+      ok: result.response.ok,
+      status: result.response.status,
+      latencyMs,
+      costUsd: extractCostFromResponse(result.response, input.body),
+      url: result.url,
+      response: result.response,
+      errorMessage: null,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      status: null,
+      latencyMs: Date.now() - start,
+      costUsd: null,
+      url: "",
+      response: null,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Best-effort cost extraction. The legacy chatCore path already records
+ * cost on call logs; the Bifrost path's response carries the same in
+ * `x-bifrost-cost-usd` (if Bifrost's billing header is set). For now
+ * we extract from the response body when it's a small JSON or via the
+ * header. Returns null if we can't read it cheaply.
+ */
+function extractCostFromResponse(response: Response, _body: unknown): number | null {
+  const headerCost = response.headers.get("x-bifrost-cost-usd");
+  if (headerCost) {
+    const parsed = Number(headerCost);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return null;
+}
+
+/**
+ * Run the shadow comparison dispatch: call legacy + Bifrost in parallel,
+ * log the outcome, return the served path's response.
+ *
+ * Pure orchestration — does not throw on path failure. If both paths fail
+ * with an error, the caller sees a synthetic 500 Response so the user
+ * gets a coherent error rather than a thrown exception escaping the
+ * dispatch loop.
+ */
+export async function dispatchWithShadow(
+  input: ExecuteInput,
+  options: ShadowDispatchOptions
+): Promise<ShadowDispatchResult> {
+  // Lazy-load DB + ramp helpers. This keeps the shadow path cold-loadable
+  // — when BIFROST_SHADOW_ENABLED is off, this module is never imported
+  // by chatCore.ts at all.
+  const { recordShadowOutcome, getActivePhaseFromDb } = await import(
+    "../../src/lib/db/trafficShadow.ts"
+  );
+  const { shadowServeBucket, shouldServeBifrost } = await import(
+    "../../src/shared/constants/shadowRamp.ts"
+  );
+
+  const policy: DivergencePolicy = options.divergencePolicy ?? {
+    costOrLatencyWins: isCostOrLatencyWinsEnabled(),
+  };
+  const phase = options.phaseOverride ?? getActivePhaseFromDb(options.now ?? new Date());
+  const bucket = shadowServeBucket({
+    provider: options.provider,
+    model: options.model,
+    virtualKeyId: options.virtualKeyId ?? null,
+    hourBucket: Math.floor((options.now ?? new Date()).getTime() / 3_600_000),
+  });
+  const phaseSaysBifrost = shouldServeBifrost(phase, bucket);
+
+  // Both calls fire in parallel; the slow one bounds the wall clock. The
+  // legacy call is the one we serve, so its latency dominates user-visible
+  // time. The bifrost call runs in parallel; if it's slower, the user pays
+  // 0ms extra because Promise.all resolves on the slow side.
+  const [legacyPath, bifrostPath] = await Promise.all([
+    runPath(options.legacyExecutor, input),
+    runPath(options.bifrostExecutor, input),
+  ]);
+
+  // Drain + close the shadow (non-served) response so the connection
+  // doesn't leak. Best-effort: must not affect the served path.
+  const nonServed = phaseSaysBifrost ? legacyPath : bifrostPath;
+  if (nonServed.response && nonServed.response !== servedPick(legacyPath, bifrostPath, phaseSaysBifrost).response) {
+    drainResponse(nonServed.response).catch(() => {
+      /* drain is best-effort */
+    });
+  }
+
+  const divergenceScore = computeDivergenceScore({
+    legacyStatus: legacyPath.status,
+    bifrostStatus: bifrostPath.status,
+    legacyLatencyMs: legacyPath.latencyMs,
+    bifrostLatencyMs: bifrostPath.latencyMs,
+    legacyCostUsd: legacyPath.costUsd,
+    bifrostCostUsd: bifrostPath.costUsd,
+  });
+
+  // ── Decision: which path to serve ──
+  let servedPath: "legacy" | "bifrost";
+
+  if (!legacyPath.ok && !bifrostPath.ok) {
+    // Both failed. Prefer to surface the legacy error (proves out the
+    // existing behavior). Synthesize a 500 response from the legacy
+    // error message if we have nothing to return.
+    const errMsg = legacyPath.errorMessage ?? bifrostPath.errorMessage ?? "shadow dispatch failed";
+    const fallback = new Response(
+      JSON.stringify({ error: { code: "shadow_dispatch_failed", message: errMsg } }),
+      { status: 500, headers: { "content-type": "application/json" } }
+    );
+    logShadowOutcome(recordShadowOutcome, options, phase, legacyPath, bifrostPath, divergenceScore, "legacy", "both_failed");
+    return {
+      servedResponse: legacyPath.response ?? bifrostPath.response ?? fallback,
+      servedPath: "legacy",
+      servedUrl: legacyPath.url || bifrostPath.url,
+      divergenceScore,
+      legacyLatencyMs: legacyPath.latencyMs,
+      bifrostLatencyMs: bifrostPath.latencyMs,
+    };
+  }
+
+  if (legacyPath.ok && !bifrostPath.ok) {
+    servedPath = "legacy";
+  } else if (!legacyPath.ok && bifrostPath.ok) {
+    // Default: serve legacy even when bifrost succeeded, until the
+    // operator opts into the "Bifrost is proven" cutover. The
+    // divergence log records this so the operator can see in the
+    // dashboard that Bifrost would have served cleanly.
+    servedPath = "legacy";
+  } else {
+    // Both succeeded. Honor the phase first; if cost-or-latency
+    // policy says Bifrost wins on the dimensions that matter, override.
+    if (phaseSaysBifrost) {
+      servedPath = "bifrost";
+    } else if (policy.costOrLatencyWins && isBifrostWinningOnDimensions(legacyPath, bifrostPath)) {
+      servedPath = "bifrost";
+    } else {
+      servedPath = "legacy";
+    }
+  }
+
+  const picked = servedPath === "bifrost" ? bifrostPath : legacyPath;
+  // Picked must be ok here; legacy-fallback-when-bifrost-succeeded means
+  // we have a valid legacy response.
+  const servedResponse = picked.response ?? legacyPath.response ?? bifrostPath.response;
+  if (!servedResponse) {
+    // Should be unreachable: at least one path is ok. Defensive.
+    const fallback = new Response(
+      JSON.stringify({ error: { code: "shadow_no_response", message: "no response" } }),
+      { status: 502, headers: { "content-type": "application/json" } }
+    );
+    logShadowOutcome(recordShadowOutcome, options, phase, legacyPath, bifrostPath, divergenceScore, "legacy", "no_response");
+    return {
+      servedResponse: fallback,
+      servedPath: "legacy",
+      servedUrl: legacyPath.url || bifrostPath.url,
+      divergenceScore,
+      legacyLatencyMs: legacyPath.latencyMs,
+      bifrostLatencyMs: bifrostPath.latencyMs,
+    };
+  }
+
+  const notes =
+    servedPath === "bifrost" && !phaseSaysBifrost
+      ? "served_bifrost_by_cost_or_latency_override"
+      : !bifrostPath.ok && legacyPath.ok
+        ? "bifrost_failed"
+        : bifrostPath.ok && !legacyPath.ok
+          ? "legacy_failed_served_legacy"
+          : undefined;
+  logShadowOutcome(recordShadowOutcome, options, phase, legacyPath, bifrostPath, divergenceScore, servedPath, notes);
+
+  return {
+    servedResponse,
+    servedPath,
+    servedUrl: picked.url,
+    divergenceScore,
+    legacyLatencyMs: legacyPath.latencyMs,
+    bifrostLatencyMs: bifrostPath.latencyMs,
+  };
+}
+
+function servedPick(
+  legacy: PathResult,
+  bifrost: PathResult,
+  phaseSaysBifrost: boolean
+): PathResult {
+  if (legacy.ok && bifrost.ok) {
+    return phaseSaysBifrost ? bifrost : legacy;
+  }
+  return legacy.ok ? legacy : bifrost;
+}
+
+/**
+ * Cost-or-latency override: Bifrost must be 50%+ faster AND p99 cost must
+ * be lower than legacy for us to serve Bifrost when the phase would have
+ * served legacy. This is the B6.4 "winning on the dimensions that matter"
+ * early cutover trigger.
+ */
+function isBifrostWinningOnDimensions(
+  legacy: PathResult,
+  bifrost: PathResult
+): boolean {
+  if (!legacy.ok || !bifrost.ok) return false;
+  if (legacy.latencyMs <= 0) return false;
+  const latencyRatio = bifrost.latencyMs / legacy.latencyMs;
+  const fiftyPctFaster = latencyRatio <= 0.5;
+  if (!fiftyPctFaster) return false;
+  // Cost must be lower; null cost is a tie (don't override).
+  if (legacy.costUsd === null || bifrost.costUsd === null) return false;
+  return bifrost.costUsd < legacy.costUsd;
+}
+
+/**
+ * Best-effort log write. Must never throw — the dispatch path is hot.
+ *
+ * `recordShadowOutcome` is passed in as a function reference (not a static
+ * import) so this module stays cold-loadable when the env var is off.
+ */
+function logShadowOutcome(
+  recordShadowOutcome: (outcome: ShadowOutcomeInput) => void,
+  options: ShadowDispatchOptions,
+  phase: ShadowRampPhase,
+  legacy: PathResult,
+  bifrost: PathResult,
+  divergenceScore: number,
+  servedPath: "legacy" | "bifrost",
+  notes: string | undefined
+): void {
+  try {
+    recordShadowOutcome({
+      virtualKeyId: options.virtualKeyId ?? null,
+      provider: options.provider,
+      model: options.model,
+      phase: phase.name,
+      legacyLatencyMs: legacy.latencyMs,
+      legacyCostUsd: legacy.costUsd,
+      legacyStatus: legacy.status,
+      bifrostLatencyMs: bifrost.latencyMs,
+      bifrostCostUsd: bifrost.costUsd,
+      bifrostStatus: bifrost.status,
+      divergenceScore,
+      servedPath,
+      notes,
+    });
+  } catch {
+    /* best-effort — see file header */
+  }
+}
+
+/**
+ * Subset of the DB module's public surface used by the dispatcher. Defined
+ * here to avoid pulling the full DB module type graph into this file.
+ */
+type ShadowOutcomeInput = {
+  virtualKeyId: string | null;
+  provider: string;
+  model: string;
+  phase: string;
+  legacyLatencyMs: number;
+  legacyCostUsd: number | null;
+  legacyStatus: number | null;
+  bifrostLatencyMs: number;
+  bifrostCostUsd: number | null;
+  bifrostStatus: number | null;
+  divergenceScore: number;
+  servedPath: "legacy" | "bifrost";
+  notes: string | undefined;
+};
+
+/**
+ * Drain a response body to avoid leaking the connection. Best-effort.
+ */
+async function drainResponse(response: Response): Promise<void> {
+  try {
+    if (!response.body) return;
+    await response.arrayBuffer();
+  } catch {
+    /* best-effort */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether shadow dispatch should be used for this request. Resolves the
+ * env-var + provider-support check. Used by the wire-up site in
+ * chatCore.ts to decide whether to swap the executor for a ShadowExecutor.
+ */
+export function shouldUseShadowDispatch(provider: string): boolean {
+  if (!isShadowEnabled()) return false;
+  return isBifrostSupported(provider);
+}

--- a/ops/slos.yaml
+++ b/ops/slos.yaml
@@ -1,0 +1,208 @@
+# SLO Definitions — OmniRoute
+# Source of truth: docs/PERF_BUDGETS.md
+# Used by: Prometheus (promtool validate), Grafana SLO dashboards, Alertmanager
+# Refresh cadence: quarterly, or on any major infra change
+
+apiVersion: slo.dev/v1
+kind: SLOs
+metadata:
+  name: omniroute
+  owner: observability-circle
+  source: docs/PERF_BUDGETS.md
+  generated: 2026-06-18
+
+slos:
+  # ─────────────────────────────────────────────────────────────────
+  # Top-level availability
+  # ─────────────────────────────────────────────────────────────────
+  - id: availability-cluster
+    name: Cluster-wide availability (2xx+4xx for /v1/* and /api/settings/*)
+    description: |
+      99.9% of requests succeed (2xx or 4xx) over a rolling 30-day window.
+      5xx and connection errors count as failures.
+    sli:
+      spec:
+        ratio:
+          success:
+            metricSource:
+              type: prometheus
+              query: |
+                sum(rate(http_requests_total{service="omniroute",code=~"2..|4.."}[30d]))
+          total:
+            metricSource:
+              type: prometheus
+              query: |
+                sum(rate(http_requests_total{service="omniroute"}[30d]))
+    objectives:
+      - target: 0.999
+          window: 30d
+          description: "P2 page on burn rate > 2x for 1h or > 6x for 5m"
+    alerting:
+      burnRate:
+        - window: 1h
+          threshold: 2
+          severity: warning
+        - window: 5m
+          threshold: 6
+          severity: critical
+
+  # ─────────────────────────────────────────────────────────────────
+  # Aggregate latency
+  # ─────────────────────────────────────────────────────────────────
+  - id: latency-p95-aggregate
+    name: Aggregate p95 latency (all /v1/*)
+    description: |
+      p95 latency across all v1 routes must stay ≤ 1.5 s (rolling 5 min).
+    sli:
+      spec:
+        threshold:
+          metricSource:
+            type: prometheus
+            query: |
+              histogram_quantile(0.95,
+                sum by (le) (rate(http_request_duration_seconds_bucket{service="omniroute",path=~"/api/v1/.*"}[5m]))
+              )
+    objectives:
+      - target: 1.5
+          window: 5m
+          comparison: lte
+          description: "P2 page; breach indicates broad slowdown"
+
+  - id: latency-p99-aggregate
+    name: Aggregate p99 latency (all /v1/*)
+    description: |
+      p99 latency across all v1 routes must stay ≤ 4.0 s (rolling 5 min).
+    sli:
+      spec:
+        threshold:
+          metricSource:
+            type: prometheus
+            query: |
+              histogram_quantile(0.99,
+                sum by (le) (rate(http_request_duration_seconds_bucket{service="omniroute",path=~"/api/v1/.*"}[5m]))
+              )
+    objectives:
+      - target: 4.0
+          window: 5m
+          comparison: lte
+
+  # ─────────────────────────────────────────────────────────────────
+  # Per-endpoint SLOs (selected)
+  # ─────────────────────────────────────────────────────────────────
+
+  - id: responses-ttfb
+    name: POST /v1/responses time-to-first-byte (stream)
+    description: |
+      TTFB ≤ 350 ms (p50), ≤ 900 ms (p95), ≤ 1.8 s (p99).
+      Source: docs/PERF_BUDGETS.md § 2.1.
+    sli:
+      spec:
+        threshold:
+          metricSource:
+            type: prometheus
+            query: |
+              histogram_quantile(0.95,
+                sum by (le) (rate(http_request_duration_seconds_bucket{service="omniroute",path="/api/v1/responses",stream="true"}[5m]))
+              )
+    objectives:
+      - target: 0.9
+          window: 5m
+          comparison: lte
+          description: "p95 TTFB"
+
+  - id: embeddings-latency
+    name: POST /v1/embeddings p95
+    description: |
+      p95 ≤ 700 ms. Source: docs/PERF_BUDGETS.md § 2.1.
+    sli:
+      spec:
+        threshold:
+          metricSource:
+            type: prometheus
+            query: |
+              histogram_quantile(0.95,
+                sum by (le) (rate(http_request_duration_seconds_bucket{service="omniroute",path="/api/v1/embeddings"}[5m]))
+              )
+    objectives:
+      - target: 0.7
+          window: 5m
+          comparison: lte
+
+  - id: health-ping
+    name: GET /api/health/ping p99
+    description: |
+      p99 ≤ 50 ms. Probes should be cheap; breach = infra issue.
+    sli:
+      spec:
+        threshold:
+          metricSource:
+            type: prometheus
+            query: |
+              histogram_quantile(0.99,
+                sum by (le) (rate(http_request_duration_seconds_bucket{service="omniroute",path="/api/health/ping"}[5m]))
+              )
+    objectives:
+      - target: 0.05
+          window: 5m
+          comparison: lte
+
+  - id: ws-connections
+    name: WebSocket concurrent connections (per cluster)
+    description: |
+      Cluster should sustain 300 concurrent WS connections (3 replicas × 100 cap).
+      Breach = capacity headroom is gone.
+    sli:
+      spec:
+        threshold:
+          metricSource:
+            type: prometheus
+            query: |
+              sum(ws_active_connections{service="omniroute"})
+    objectives:
+      - target: 280
+          window: 5m
+          comparison: lt
+          description: "Warn at 280, page on-call at 300 (cap)"
+
+  - id: error-budget-burn-1h
+    name: Error budget burn rate (1h window)
+    description: |
+      30-day error budget is 43.2 minutes at 99.9%. Burn rate > 2x for 1h
+      means we'll exhaust the budget in 15 days.
+    sli:
+      spec:
+        threshold:
+          metricSource:
+            type: prometheus
+            query: |
+              (1 - (
+                sum(rate(http_requests_total{service="omniroute",code=~"2..|4.."}[1h]))
+                /
+                sum(rate(http_requests_total{service="omniroute"}[1h]))
+              )) / (1 - 0.999)
+    objectives:
+      - target: 2
+          window: 1h
+          comparison: gt
+          description: "P2 page when 1h burn rate > 2x"
+
+  - id: error-budget-burn-5m
+    name: Error budget burn rate (5m window)
+    description: |
+      Short-window burn rate for fast feedback. > 6x for 5m = P1.
+    sli:
+      spec:
+        threshold:
+          metricSource:
+            type: prometheus
+            query: |
+              (1 - (
+                sum(rate(http_requests_total{service="omniroute",code=~"2..|4.."}[5m]))
+                /
+                sum(rate(http_requests_total{service="omniroute"}[5m]))
+              )) / (1 - 0.999)
+    objectives:
+      - target: 6
+          window: 5m
+          comparison: gt
+          description: "P1 page when 5m burn rate > 6x"

--- a/src/lib/db/bifrostShadow.ts
+++ b/src/lib/db/bifrostShadow.ts
@@ -1,0 +1,367 @@
+/**
+ * bifrostShadow.ts — DB domain module for the Bifrost traffic-shadow log.
+ *
+ * Backs the `bifrost_shadow_events` table (migration 101). Records per-request
+ * comparisons between the legacy chatCore path and the parallel Bifrost path
+ * during the B6.1 traffic-shadow phase of the v8.1 Bifrost rollout.
+ *
+ * Cache contract:
+ *   - `recordBifrostShadowEvent(event)` — append one comparison row.
+ *   - `getBifrostShadowEvents({since, limit})` — operator query for the dashboard.
+ *   - `purgeBifrostShadowEvents(olderThan)` — housekeeping; returns row count.
+ *   - `getBifrostShadowStats({since})` — aggregate (count, error_rate, p50/p99
+ *     latency, agreement_rate).
+ *
+ * B6.1 is strictly observe-only: the chatCore response is always returned to
+ * the user. The shadow call is best-effort; a recordBifrostShadowEvent failure
+ * must not affect the user-visible response. Callers in the hot dispatch path
+ * are expected to wrap with try/catch — see open-sse/executors/bifrostShadow.ts.
+ *
+ * See: docs/adr/0031-bifrost-tier1-router.md
+ *      PLAN.md § 2.5.2 (B6.1)
+ *      open-sse/executors/bifrostShadow.ts
+ *      src/lib/db/migrations/101_bifrost_shadow.sql
+ */
+
+import { getDbInstance, rowToCamel } from "./core";
+
+// ──────────────── Types ────────────────
+
+export type BifrostShadowStatus = "ok" | "error" | "timeout" | "skipped";
+
+export const BIFROST_SHADOW_STATUSES: readonly BifrostShadowStatus[] = [
+  "ok",
+  "error",
+  "timeout",
+  "skipped",
+] as const;
+
+export interface BifrostShadowEvent {
+  eventId: string;
+  chatcoreRequestId: string | null;
+  provider: string;
+  model: string;
+  bifrostStatus: BifrostShadowStatus;
+  bifrostLatencyMs: number | null;
+  chatcoreLatencyMs: number | null;
+  agreementScore: number | null;
+  bifrostTokensIn: number | null;
+  bifrostTokensOut: number | null;
+  chatcoreTokensIn: number | null;
+  chatcoreTokensOut: number | null;
+  bifrostCostUsd: number | null;
+  chatcoreCostUsd: number | null;
+  createdAt: string;
+}
+
+/** Public input — `eventId` is auto-generated if absent. */
+export interface BifrostShadowEventInput {
+  eventId?: string;
+  chatcoreRequestId?: string | null;
+  provider: string;
+  model: string;
+  bifrostStatus: BifrostShadowStatus;
+  bifrostLatencyMs?: number | null;
+  chatcoreLatencyMs?: number | null;
+  agreementScore?: number | null;
+  bifrostTokensIn?: number | null;
+  bifrostTokensOut?: number | null;
+  chatcoreTokensIn?: number | null;
+  chatcoreTokensOut?: number | null;
+  bifrostCostUsd?: number | null;
+  chatcoreCostUsd?: number | null;
+  createdAt?: string;
+}
+
+export interface BifrostShadowStats {
+  sinceIso: string;
+  count: number;
+  okCount: number;
+  errorCount: number;
+  timeoutCount: number;
+  skippedCount: number;
+  /** error+timeout divided by total non-skipped. 0..1. */
+  errorRate: number;
+  /** Median Bifrost latency in ms. null if no successful rows. */
+  bifrostP50LatencyMs: number | null;
+  /** 99th percentile Bifrost latency in ms. null if <100 rows. */
+  bifrostP99LatencyMs: number | null;
+  /** Median chatCore latency in ms. null if no rows. */
+  chatcoreP50LatencyMs: number | null;
+  /** 99th percentile chatCore latency in ms. null if <100 rows. */
+  chatcoreP99LatencyMs: number | null;
+  /** Mean of agreement_score across rows where it's not null. 0..1. */
+  meanAgreementScore: number | null;
+}
+
+export interface GetBifrostShadowEventsOptions {
+  /** ISO timestamp inclusive lower bound. Undefined = no lower bound. */
+  since?: string;
+  /** Max rows to return. Default 100. Cap at 5,000. */
+  limit?: number;
+  /** Filter by provider. Undefined = no filter. */
+  provider?: string;
+  /** Filter by status. Undefined = no filter. */
+  bifrostStatus?: BifrostShadowStatus;
+}
+
+// ──────────────── Helpers ────────────────
+
+function isValidStatus(status: string): status is BifrostShadowStatus {
+  return (
+    status === "ok" ||
+    status === "error" ||
+    status === "timeout" ||
+    status === "skipped"
+  );
+}
+
+function rowToEvent(row: Record<string, unknown>): BifrostShadowEvent | null {
+  const camel = rowToCamel(row) ?? {};
+  const eventId = typeof camel.eventId === "string" ? camel.eventId : "";
+  const provider = typeof camel.provider === "string" ? camel.provider : "";
+  const model = typeof camel.model === "string" ? camel.model : "";
+  const status = typeof camel.bifrostStatus === "string" ? camel.bifrostStatus : "";
+  if (!eventId || !provider || !model || !isValidStatus(status)) {
+    return null;
+  }
+  return {
+    eventId,
+    chatcoreRequestId:
+      typeof camel.chatcoreRequestId === "string" ? camel.chatcoreRequestId : null,
+    provider,
+    model,
+    bifrostStatus: status,
+    bifrostLatencyMs:
+      typeof camel.bifrostLatencyMs === "number" ? camel.bifrostLatencyMs : null,
+    chatcoreLatencyMs:
+      typeof camel.chatcoreLatencyMs === "number" ? camel.chatcoreLatencyMs : null,
+    agreementScore:
+      typeof camel.agreementScore === "number" ? camel.agreementScore : null,
+    bifrostTokensIn:
+      typeof camel.bifrostTokensIn === "number" ? camel.bifrostTokensIn : null,
+    bifrostTokensOut:
+      typeof camel.bifrostTokensOut === "number" ? camel.bifrostTokensOut : null,
+    chatcoreTokensIn:
+      typeof camel.chatcoreTokensIn === "number" ? camel.chatcoreTokensIn : null,
+    chatcoreTokensOut:
+      typeof camel.chatcoreTokensOut === "number" ? camel.chatcoreTokensOut : null,
+    bifrostCostUsd:
+      typeof camel.bifrostCostUsd === "number" ? camel.bifrostCostUsd : null,
+    chatcoreCostUsd:
+      typeof camel.chatcoreCostUsd === "number" ? camel.chatcoreCostUsd : null,
+    createdAt: String(camel.createdAt ?? ""),
+  };
+}
+
+function nearestRankPercentile(sorted: number[], p: number): number | null {
+  if (sorted.length === 0) return null;
+  const rank = Math.max(1, Math.ceil((p / 100) * sorted.length));
+  return sorted[Math.min(sorted.length - 1, rank - 1)];
+}
+
+// ──────────────── CRUD ────────────────
+
+/**
+ * Append one shadow comparison row. The dispatcher wraps this in try/catch;
+ * see open-sse/executors/bifrostShadow.ts. Throws on invalid input so unit
+ * tests can assert on bad-data paths.
+ */
+export function recordBifrostShadowEvent(input: BifrostShadowEventInput): {
+  eventId: string;
+} {
+  if (!input || typeof input !== "object") {
+    throw new Error("bifrostShadow.recordBifrostShadowEvent: input is required");
+  }
+  if (!input.provider || typeof input.provider !== "string") {
+    throw new Error("bifrostShadow.recordBifrostShadowEvent: provider is required");
+  }
+  if (!input.model || typeof input.model !== "string") {
+    throw new Error("bifrostShadow.recordBifrostShadowEvent: model is required");
+  }
+  if (!isValidStatus(input.bifrostStatus)) {
+    throw new Error(
+      `bifrostShadow.recordBifrostShadowEvent: bifrostStatus must be one of ${BIFROST_SHADOW_STATUSES.join(", ")} (got ${String(input.bifrostStatus)})`
+    );
+  }
+
+  const eventId =
+    typeof input.eventId === "string" && input.eventId.length > 0
+      ? input.eventId
+      : `bse_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+
+  const agreement =
+    typeof input.agreementScore === "number" && Number.isFinite(input.agreementScore)
+      ? Math.max(0, Math.min(1, input.agreementScore))
+      : null;
+
+  const db = getDbInstance();
+  db.prepare(
+    `INSERT INTO bifrost_shadow_events
+       (event_id, chatcore_request_id, provider, model, bifrost_status,
+        bifrost_latency_ms, chatcore_latency_ms, agreement_score,
+        bifrost_tokens_in, bifrost_tokens_out,
+        chatcore_tokens_in, chatcore_tokens_out,
+        bifrost_cost_usd, chatcore_cost_usd, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))`
+  ).run(
+    eventId,
+    input.chatcoreRequestId ?? null,
+    input.provider,
+    input.model,
+    input.bifrostStatus,
+    input.bifrostLatencyMs ?? null,
+    input.chatcoreLatencyMs ?? null,
+    agreement,
+    input.bifrostTokensIn ?? null,
+    input.bifrostTokensOut ?? null,
+    input.chatcoreTokensIn ?? null,
+    input.chatcoreTokensOut ?? null,
+    input.bifrostCostUsd ?? null,
+    input.chatcoreCostUsd ?? null,
+    input.createdAt ?? null
+  );
+
+  return { eventId };
+}
+
+/**
+ * Read recent shadow events. Newest-first. Capped at 5,000 rows per query.
+ */
+export function getBifrostShadowEvents(
+  options: GetBifrostShadowEventsOptions = {}
+): BifrostShadowEvent[] {
+  const limit = Math.max(1, Math.min(5_000, options.limit ?? 100));
+
+  const where: string[] = [];
+  const params: unknown[] = [];
+  if (options.since) {
+    where.push("created_at >= ?");
+    params.push(options.since);
+  }
+  if (options.provider) {
+    where.push("provider = ?");
+    params.push(options.provider);
+  }
+  if (options.bifrostStatus && isValidStatus(options.bifrostStatus)) {
+    where.push("bifrost_status = ?");
+    params.push(options.bifrostStatus);
+  }
+  const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+
+  const db = getDbInstance();
+  const rows = db
+    .prepare(
+      `SELECT event_id, chatcore_request_id, provider, model, bifrost_status,
+              bifrost_latency_ms, chatcore_latency_ms, agreement_score,
+              bifrost_tokens_in, bifrost_tokens_out,
+              chatcore_tokens_in, chatcore_tokens_out,
+              bifrost_cost_usd, chatcore_cost_usd, created_at
+         FROM bifrost_shadow_events
+         ${whereSql}
+         ORDER BY created_at DESC, event_id DESC
+         LIMIT ?`
+    )
+    .all(...params, limit) as Record<string, unknown>[];
+
+  const out: BifrostShadowEvent[] = [];
+  for (const row of rows) {
+    const ev = rowToEvent(row);
+    if (ev) out.push(ev);
+  }
+  return out;
+}
+
+/**
+ * Delete rows older than the given ISO timestamp. Returns the number of
+ * rows removed. Housekeeping: run on a cron (e.g. hourly) to keep the
+ * table bounded during the 14-day B6 ramp.
+ */
+export function purgeBifrostShadowEvents(olderThan: string): number {
+  if (!olderThan || typeof olderThan !== "string") {
+    throw new Error("bifrostShadow.purgeBifrostShadowEvents: olderThan (ISO string) is required");
+  }
+  const db = getDbInstance();
+  const result = db
+    .prepare(`DELETE FROM bifrost_shadow_events WHERE created_at < ?`)
+    .run(olderThan);
+  return result.changes ?? 0;
+}
+
+/**
+ * Aggregate stats since a given ISO timestamp. Used by the operator
+ * dashboard and the B6.1 weekly review. Pure SQL where possible; the
+ * percentile computation runs in TypeScript over a sorted slice (cheap,
+ * bounded by row count which is purged hourly).
+ */
+export function getBifrostShadowStats(since: string): BifrostShadowStats {
+  if (!since || typeof since !== "string") {
+    throw new Error("bifrostShadow.getBifrostShadowStats: since (ISO string) is required");
+  }
+  const db = getDbInstance();
+
+  const agg = db
+    .prepare(
+      `SELECT
+         COUNT(*) AS total,
+         SUM(CASE WHEN bifrost_status = 'ok'       THEN 1 ELSE 0 END) AS ok_count,
+         SUM(CASE WHEN bifrost_status = 'error'    THEN 1 ELSE 0 END) AS error_count,
+         SUM(CASE WHEN bifrost_status = 'timeout'  THEN 1 ELSE 0 END) AS timeout_count,
+         SUM(CASE WHEN bifrost_status = 'skipped'  THEN 1 ELSE 0 END) AS skipped_count,
+         AVG(agreement_score) AS mean_agreement
+       FROM bifrost_shadow_events
+       WHERE created_at >= ?`
+    )
+    .get(since) as {
+    total: number;
+    ok_count: number | null;
+    error_count: number | null;
+    timeout_count: number | null;
+    skipped_count: number | null;
+    mean_agreement: number | null;
+  };
+
+  const total = agg?.total ?? 0;
+  const ok = agg?.ok_count ?? 0;
+  const err = agg?.error_count ?? 0;
+  const to = agg?.timeout_count ?? 0;
+  const sk = agg?.skipped_count ?? 0;
+  const nonSkipped = total - sk;
+  const errorRate = nonSkipped > 0 ? (err + to) / nonSkipped : 0;
+
+  // Latencies: pull just the two columns + sort in memory. Bounded by
+  // purgeBifrostShadowEvents hourly, so worst case is ~1hr of traffic
+  // per provider, which is small enough for an in-process percentile.
+  const latencyRows = db
+    .prepare(
+      `SELECT bifrost_latency_ms, chatcore_latency_ms
+         FROM bifrost_shadow_events
+         WHERE created_at >= ? AND bifrost_status = 'ok'`
+    )
+    .all(since) as Array<{ bifrost_latency_ms: number | null; chatcore_latency_ms: number | null }>;
+
+  const bifrostLatencies: number[] = [];
+  const chatcoreLatencies: number[] = [];
+  for (const r of latencyRows) {
+    if (typeof r.bifrost_latency_ms === "number") bifrostLatencies.push(r.bifrost_latency_ms);
+    if (typeof r.chatcore_latency_ms === "number") chatcoreLatencies.push(r.chatcore_latency_ms);
+  }
+  bifrostLatencies.sort((a, b) => a - b);
+  chatcoreLatencies.sort((a, b) => a - b);
+
+  return {
+    sinceIso: since,
+    count: total,
+    okCount: ok,
+    errorCount: err,
+    timeoutCount: to,
+    skippedCount: sk,
+    errorRate,
+    bifrostP50LatencyMs: nearestRankPercentile(bifrostLatencies, 50),
+    bifrostP99LatencyMs: nearestRankPercentile(bifrostLatencies, 99),
+    chatcoreP50LatencyMs: nearestRankPercentile(chatcoreLatencies, 50),
+    chatcoreP99LatencyMs: nearestRankPercentile(chatcoreLatencies, 99),
+    meanAgreementScore:
+      typeof agg?.mean_agreement === "number" ? agg.mean_agreement : null,
+  };
+}

--- a/src/lib/db/migrations/101_bifrost_shadow.sql
+++ b/src/lib/db/migrations/101_bifrost_shadow.sql
@@ -1,0 +1,65 @@
+-- Migration 101: Bifrost traffic-shadow events (B6.1 of v8.1 Bifrost track, ADR-031)
+--
+-- Per-request comparison log for the Bifrost Tier-1 router rollout. When
+-- BIFROST_SHADOW_ENABLED=true and the sampler rolls in, Bifrost runs the same
+-- request in parallel with chatCore; both outcomes are recorded here, but
+-- chatCore's response is always returned to the user. NO behavior change
+-- for users in Phase 1 (B6.1); this table is for operator comparison only.
+--
+-- Schema notes:
+--   - event_id is a UUID generated at insert time (Node crypto.randomUUID()).
+--     Picked over AUTOINCREMENT to keep the table log-appendable across
+--     DB-file rotations during the 14-day ramp.
+--   - chatcore_request_id is OmniRoute's own request id (X-Request-Id header
+--     if present, else auto-generated). Nullable for the rare cases where
+--     the dispatcher fires before request-id propagation.
+--   - bifrost_status ∈ {'ok','error','timeout','skipped'} — distinct from the
+--     HTTP status code because we want to record infrastructure-level outcomes
+--     (timeouts, skip-on-unsupported-provider) separately from provider-level
+--     HTTP statuses.
+--   - agreement_score ∈ [0.0, 1.0] — Jaccard token-set ratio between the two
+--     response texts. See bifrostShadow.ts::computeAgreementScore().
+--     NULL when one or both sides failed to produce text.
+--   - bifrost_tokens_in/out + chatcore_tokens_in/out — best-effort, from
+--     response.usage if present. NULL when not reported.
+--   - bifrost_cost_usd / chatcore_cost_usd — NULL in B6.1; populated by a
+--     later B6.2/B6.3 PR when cost observability is wired.
+--   - created_at is the shadow-comparison timestamp (NOT the request's own
+--     timestamp) — written at dispatcher commit time.
+--
+-- Index strategy:
+--   - (created_at): dashboard time-series queries
+--   - (provider, created_at): per-provider divergence drilldowns
+--   - (bifrost_status, created_at): error-rate aggregations
+--
+-- Companion module: src/lib/db/bifrostShadow.ts
+-- Companion dispatcher: open-sse/executors/bifrostShadow.ts
+-- B6.1 task in PLAN.md § 2.5.2.
+
+CREATE TABLE IF NOT EXISTS bifrost_shadow_events (
+  event_id TEXT PRIMARY KEY,             -- UUID v4 (dispatcher-generated)
+  chatcore_request_id TEXT,              -- OmniRoute request id (nullable)
+  provider TEXT NOT NULL,                -- OmniRoute provider id
+  model TEXT NOT NULL,
+  bifrost_status TEXT NOT NULL           -- 'ok' | 'error' | 'timeout' | 'skipped'
+    CHECK (bifrost_status IN ('ok','error','timeout','skipped')),
+  bifrost_latency_ms INTEGER,            -- wall-clock ms for the Bifrost path
+  chatcore_latency_ms INTEGER,           -- wall-clock ms for the chatCore path
+  agreement_score REAL,                  -- 0.0..1.0 Jaccard; NULL if one side failed
+  bifrost_tokens_in INTEGER,             -- prompt tokens (Bifrost side)
+  bifrost_tokens_out INTEGER,            -- completion tokens (Bifrost side)
+  chatcore_tokens_in INTEGER,            -- prompt tokens (chatCore side)
+  chatcore_tokens_out INTEGER,           -- completion tokens (chatCore side)
+  bifrost_cost_usd REAL,                 -- USD (B6.1: NULL; reserved for B6.2+)
+  chatcore_cost_usd REAL,                -- USD (B6.1: NULL; reserved for B6.2+)
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_bse_created_at
+  ON bifrost_shadow_events (created_at);
+
+CREATE INDEX IF NOT EXISTS idx_bse_provider_created_at
+  ON bifrost_shadow_events (provider, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_bse_status_created_at
+  ON bifrost_shadow_events (bifrost_status, created_at);

--- a/src/lib/db/migrations/104_traffic_shadow_log.sql
+++ b/src/lib/db/migrations/104_traffic_shadow_log.sql
@@ -1,0 +1,38 @@
+-- Migration 104: Traffic-shadow log table (B6 of v8.1 Bifrost track, ADR-031)
+--
+-- Per-request comparison log for the Bifrost Tier-1 router rollout. Each row
+-- records the parallel invocation of the legacy chatCore path and the Bifrost
+-- path on the same request, so operators can compare latency / cost / status
+-- side-by-side during the 5-phase ramp (observe-only → 5% → 25% → 50% → 100%).
+--
+-- Index strategy:
+--   - (occurred_at): dashboard time-series queries
+--   - (served_path, occurred_at): per-path p50/p95/p99 latency aggregations
+--   - (provider, occurred_at): per-provider divergence drilldowns
+--
+-- Best-effort write — failure to log must not affect the user-visible response
+-- (see open-sse/services/trafficShadow.ts).
+
+CREATE TABLE IF NOT EXISTS traffic_shadow_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  occurred_at TEXT NOT NULL DEFAULT (datetime('now')),
+  virtual_key_id TEXT,
+  provider TEXT NOT NULL,
+  model TEXT NOT NULL,
+  phase TEXT NOT NULL,
+  legacy_latency_ms INTEGER,
+  legacy_cost_usd REAL,
+  legacy_status INTEGER,
+  bifrost_latency_ms INTEGER,
+  bifrost_cost_usd REAL,
+  bifrost_status INTEGER,
+  divergence_score REAL NOT NULL DEFAULT 0,
+  served_path TEXT NOT NULL CHECK (served_path IN ('legacy', 'bifrost')),
+  notes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_tsl_occurred_at ON traffic_shadow_log(occurred_at);
+CREATE INDEX IF NOT EXISTS idx_tsl_served_path_occurred_at
+  ON traffic_shadow_log(served_path, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_tsl_provider_occurred_at
+  ON traffic_shadow_log(provider, occurred_at);

--- a/src/lib/db/migrations/105_traffic_shadow_config.sql
+++ b/src/lib/db/migrations/105_traffic_shadow_config.sql
@@ -1,0 +1,23 @@
+-- Migration 105: Traffic-shadow config (B6 of v8.1 Bifrost track, ADR-031)
+--
+-- Single-row configuration for the Bifrost traffic-shadow ramp. Default row
+-- (id=1) is inserted on migration; the in-memory SHADOW_RAMP_PHASES table in
+-- src/shared/constants/shadowRamp.ts is the source of truth for the 5 phases,
+-- while this table persists the operator-controllable state:
+--   - current_phase: which of the 5 phases is active
+--   - ramp_started_at: when the current ramp began (anchor for phase lookups)
+--   - bifrost_serve_pct_override: optional per-deploy override (0-100, NULL=use phase)
+--   - paused: operator pause switch; 1 = serve legacy on all shadow requests
+--   - updated_at: last write
+
+CREATE TABLE IF NOT EXISTS traffic_shadow_config (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  current_phase TEXT NOT NULL DEFAULT 'observe-only',
+  ramp_started_at TEXT NOT NULL DEFAULT (datetime('now')),
+  bifrost_serve_pct_override INTEGER,
+  paused INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT OR IGNORE INTO traffic_shadow_config (id, current_phase, ramp_started_at, paused)
+VALUES (1, 'observe-only', datetime('now'), 0);

--- a/src/lib/db/trafficShadow.ts
+++ b/src/lib/db/trafficShadow.ts
@@ -1,0 +1,416 @@
+/**
+ * db/trafficShadow.ts — Traffic-shadow persistence layer (B6 of v8.1 Bifrost).
+ *
+ * Public API:
+ *   - recordShadowOutcome(outcome)    — best-effort insert of one comparison row
+ *   - summarizeShadowSince(sinceIso)  — aggregates p50/p95/p99 + error rate
+ *   - getCurrentRampConfig()          — read the singleton config row
+ *   - setRampPhase(phase, opts)       — operator override (move to a new phase)
+ *   - setBifrostServePctOverride(pct) — operator override (0-100 or null)
+ *   - setShadowPaused(paused)         — operator pause switch
+ *   - resetShadowRamp(now)            — restart the 14-day schedule
+ *
+ * Best-effort contract: recordShadowOutcome is called from the hot
+ * dispatch path. A DB write failure must not break the user-visible
+ * response — the dispatcher catches and logs (see
+ * open-sse/services/trafficShadow.ts).
+ *
+ * Reference: ADR-031 § Decision Review, PLAN.md § 2.5.2 (B6),
+ * src/shared/constants/shadowRamp.ts.
+ */
+
+import { getDbInstance } from "./core";
+import {
+  resolveActiveShadowPhase,
+  type ShadowRampPhase,
+  type ShadowRampPhaseName,
+} from "@/shared/constants/shadowRamp";
+
+interface StatementLike<TRow = unknown> {
+  all: (...params: unknown[]) => TRow[];
+  get: (...params: unknown[]) => TRow | undefined;
+  run: (...params: unknown[]) => { changes: number };
+}
+
+interface DbLike {
+  prepare: <TRow = unknown>(sql: string) => StatementLike<TRow>;
+}
+
+function getDb(): DbLike {
+  return getDbInstance() as unknown as DbLike;
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Inputs for recordShadowOutcome. All latency / cost / status fields are
+ * nullable because either path may have failed. The dispatcher must always
+ * supply `servedPath` and `divergenceScore`; everything else reflects what
+ * actually happened on each path.
+ */
+export interface ShadowOutcome {
+  virtualKeyId?: string | null;
+  provider: string;
+  model: string;
+  phase: ShadowRampPhaseName;
+  legacyLatencyMs: number | null;
+  legacyCostUsd: number | null;
+  legacyStatus: number | null;
+  bifrostLatencyMs: number | null;
+  bifrostCostUsd: number | null;
+  bifrostStatus: number | null;
+  divergenceScore: number;
+  servedPath: "legacy" | "bifrost";
+  notes?: string;
+}
+
+/**
+ * Aggregated summary of shadow comparisons since a given timestamp,
+ * optionally filtered to a single served path. Returned by
+ * summarizeShadowSince and used by the operator dashboard + B6.4
+ * decision-review report.
+ */
+export interface ShadowSummary {
+  sinceIso: string;
+  count: number;
+  legacy: {
+    count: number;
+    errorCount: number;
+    errorRate: number;
+    p50LatencyMs: number | null;
+    p95LatencyMs: number | null;
+    p99LatencyMs: number | null;
+    meanCostUsd: number | null;
+  };
+  bifrost: {
+    count: number;
+    errorCount: number;
+    errorRate: number;
+    p50LatencyMs: number | null;
+    p95LatencyMs: number | null;
+    p99LatencyMs: number | null;
+    meanCostUsd: number | null;
+  };
+  /**
+   * Cost delta (bifrost - legacy) in USD, averaged per-request. Negative
+   * means Bifrost is cheaper on average. The B6.4 decision-review policy
+   * treats "p99 cost lower" as a serving preference when paired with
+   * "50%+ faster".
+   */
+  meanCostDeltaUsd: number | null;
+  /**
+   * Latency delta (bifrost - legacy) in ms, averaged per-request.
+   * Negative means Bifrost is faster on average.
+   */
+  meanLatencyDeltaMs: number | null;
+  /**
+   * Served-path breakdown: how many requests were served by each path.
+   */
+  servedLegacy: number;
+  servedBifrost: number;
+}
+
+export interface ShadowRampConfig {
+  currentPhase: ShadowRampPhaseName;
+  rampStartedAt: string;
+  bifrostServePctOverride: number | null;
+  paused: boolean;
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert one shadow comparison row. Best-effort: callers in the hot
+ * dispatch path catch and swallow errors. Errors are re-thrown here so
+ * unit tests can assert on them; the dispatcher wraps the call.
+ */
+export function recordShadowOutcome(outcome: ShadowOutcome): { id: number } {
+  const db = getDb();
+  const result = db
+    .prepare(
+      `INSERT INTO traffic_shadow_log
+        (virtual_key_id, provider, model, phase,
+         legacy_latency_ms, legacy_cost_usd, legacy_status,
+         bifrost_latency_ms, bifrost_cost_usd, bifrost_status,
+         divergence_score, served_path, notes)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      outcome.virtualKeyId ?? null,
+      outcome.provider,
+      outcome.model,
+      outcome.phase,
+      outcome.legacyLatencyMs,
+      outcome.legacyCostUsd,
+      outcome.legacyStatus,
+      outcome.bifrostLatencyMs,
+      outcome.bifrostCostUsd,
+      outcome.bifrostStatus,
+      outcome.divergenceScore,
+      outcome.servedPath,
+      outcome.notes ?? null
+    );
+  return { id: Number(result.changes) >= 0 ? result.changes : 0 };
+}
+
+/**
+ * Compute aggregate stats for the comparison log since a given ISO timestamp.
+ * The implementation is pure SQL (percentile approximation via row-number
+ * windows) so it works under sql.js and better-sqlite3 alike — there is no
+ * dependency on native percentile functions.
+ */
+export function summarizeShadowSince(
+  sinceIso: string,
+  servedPath?: "legacy" | "bifrost"
+): ShadowSummary {
+  const db = getDb();
+  const pathFilter = servedPath ? "AND served_path = ?" : "";
+  const params: unknown[] = servedPath ? [sinceIso, servedPath] : [sinceIso];
+
+  const baseRows = db
+    .prepare<{
+      count: number;
+      legacy_count: number;
+      legacy_errors: number;
+      bifrost_count: number;
+      bifrost_errors: number;
+      served_legacy: number;
+      served_bifrost: number;
+      mean_cost_delta: number | null;
+      mean_latency_delta: number | null;
+      mean_legacy_cost: number | null;
+      mean_bifrost_cost: number | null;
+    }>(
+      `SELECT
+         COUNT(*) AS count,
+         SUM(CASE WHEN legacy_status IS NOT NULL THEN 1 ELSE 0 END) AS legacy_count,
+         SUM(CASE WHEN legacy_status IS NULL OR legacy_status < 200 OR legacy_status >= 400 THEN 1 ELSE 0 END) AS legacy_errors,
+         SUM(CASE WHEN bifrost_status IS NOT NULL THEN 1 ELSE 0 END) AS bifrost_count,
+         SUM(CASE WHEN bifrost_status IS NULL OR bifrost_status < 200 OR bifrost_status >= 400 THEN 1 ELSE 0 END) AS bifrost_errors,
+         SUM(CASE WHEN served_path = 'legacy' THEN 1 ELSE 0 END) AS served_legacy,
+         SUM(CASE WHEN served_path = 'bifrost' THEN 1 ELSE 0 END) AS served_bifrost,
+         AVG(CASE WHEN bifrost_cost_usd IS NOT NULL AND legacy_cost_usd IS NOT NULL
+                  THEN bifrost_cost_usd - legacy_cost_usd ELSE NULL END) AS mean_cost_delta,
+         AVG(CASE WHEN bifrost_latency_ms IS NOT NULL AND legacy_latency_ms IS NOT NULL
+                  THEN bifrost_latency_ms - legacy_latency_ms ELSE NULL END) AS mean_latency_delta,
+         AVG(legacy_cost_usd) AS mean_legacy_cost,
+         AVG(bifrost_cost_usd) AS mean_bifrost_cost
+       FROM traffic_shadow_log
+       WHERE occurred_at >= ? ${pathFilter}`
+    )
+    .get(...params) ?? {
+      count: 0,
+      legacy_count: 0,
+      legacy_errors: 0,
+      bifrost_count: 0,
+      bifrost_errors: 0,
+      served_legacy: 0,
+      served_bifrost: 0,
+      mean_cost_delta: null,
+      mean_latency_delta: null,
+      mean_legacy_cost: null,
+      mean_bifrost_cost: null,
+    };
+
+  // Percentile via SQLite window functions (sql.js >= 3.36 supports OVER).
+  const latencyRows = db
+    .prepare<{ path: string; latency_ms: number }>(
+      `SELECT 'legacy' AS path, legacy_latency_ms AS latency_ms
+         FROM traffic_shadow_log
+         WHERE occurred_at >= ? ${pathFilter} AND legacy_latency_ms IS NOT NULL
+       UNION ALL
+       SELECT 'bifrost' AS path, bifrost_latency_ms AS latency_ms
+         FROM traffic_shadow_log
+         WHERE occurred_at >= ? ${pathFilter} AND bifrost_latency_ms IS NOT NULL
+       ORDER BY path, latency_ms`
+    )
+    .all(...params, ...params);
+
+  const percentiles = computePercentiles(latencyRows);
+
+  return {
+    sinceIso,
+    count: baseRows.count,
+    legacy: {
+      count: baseRows.legacy_count,
+      errorCount: baseRows.legacy_errors,
+      errorRate: baseRows.legacy_count > 0 ? baseRows.legacy_errors / baseRows.legacy_count : 0,
+      p50LatencyMs: percentiles.legacy.p50,
+      p95LatencyMs: percentiles.legacy.p95,
+      p99LatencyMs: percentiles.legacy.p99,
+      meanCostUsd: baseRows.mean_legacy_cost,
+    },
+    bifrost: {
+      count: baseRows.bifrost_count,
+      errorCount: baseRows.bifrost_errors,
+      errorRate: baseRows.bifrost_count > 0 ? baseRows.bifrost_errors / baseRows.bifrost_count : 0,
+      p50LatencyMs: percentiles.bifrost.p50,
+      p95LatencyMs: percentiles.bifrost.p95,
+      p99LatencyMs: percentiles.bifrost.p99,
+      meanCostUsd: baseRows.mean_bifrost_cost,
+    },
+    meanCostDeltaUsd: baseRows.mean_cost_delta,
+    meanLatencyDeltaMs: baseRows.mean_latency_delta,
+    servedLegacy: baseRows.served_legacy,
+    servedBifrost: baseRows.served_bifrost,
+  };
+}
+
+/**
+ * Read the singleton shadow config row. Always returns a row — migration
+ * 105 inserts the default (id=1) on first apply.
+ */
+export function getCurrentRampConfig(): ShadowRampConfig {
+  const db = getDb();
+  const row = db
+    .prepare<{
+      current_phase: string;
+      ramp_started_at: string;
+      bifrost_serve_pct_override: number | null;
+      paused: number;
+      updated_at: string;
+    }>(
+      `SELECT current_phase, ramp_started_at, bifrost_serve_pct_override, paused, updated_at
+         FROM traffic_shadow_config WHERE id = 1`
+    )
+    .get();
+  if (!row) {
+    // Defensive: migration should have inserted id=1. Return a sensible default.
+    return {
+      currentPhase: "observe-only",
+      rampStartedAt: new Date().toISOString(),
+      bifrostServePctOverride: null,
+      paused: false,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+  return {
+    currentPhase: row.current_phase as ShadowRampPhaseName,
+    rampStartedAt: row.ramp_started_at,
+    bifrostServePctOverride: row.bifrost_serve_pct_override,
+    paused: row.paused === 1,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * Resolve the active phase: read the DB row, then evaluate the phase
+ * schedule against the stored `ramp_started_at`. If the operator has set
+ * a `bifrost_serve_pct_override`, the returned phase object has that
+ * override applied (so the dispatcher uses the operator's pct directly).
+ *
+ * If `paused=1`, returns the observe-only phase (0%) regardless of the
+ * schedule — the operator can kill Bifrost traffic instantly.
+ */
+export function getActivePhaseFromDb(now: Date = new Date()): ShadowRampPhase {
+  const config = getCurrentRampConfig();
+  if (config.paused) {
+    return { name: "observe-only", bifrostServePct: 0, durationDays: 0 };
+  }
+  const phase = resolveActiveShadowPhase(config.rampStartedAt, now);
+  if (config.bifrostServePctOverride !== null) {
+    return {
+      ...phase,
+      bifrostServePct: Math.max(0, Math.min(100, config.bifrostServePctOverride)),
+    };
+  }
+  return phase;
+}
+
+// ---------------------------------------------------------------------------
+// Operator overrides
+// ---------------------------------------------------------------------------
+
+export function setRampPhase(
+  phase: ShadowRampPhaseName,
+  options: { rampStartedAt?: Date } = {}
+): ShadowRampConfig {
+  const rampStartedAtIso = (options.rampStartedAt ?? new Date()).toISOString();
+  const db = getDb();
+  db.prepare(
+    `UPDATE traffic_shadow_config
+        SET current_phase = ?, ramp_started_at = ?, updated_at = datetime('now')
+      WHERE id = 1`
+  ).run(phase, rampStartedAtIso);
+  return getCurrentRampConfig();
+}
+
+export function setBifrostServePctOverride(pct: number | null): ShadowRampConfig {
+  const clamped = pct === null ? null : Math.max(0, Math.min(100, Math.floor(pct)));
+  const db = getDb();
+  db.prepare(
+    `UPDATE traffic_shadow_config
+        SET bifrost_serve_pct_override = ?, updated_at = datetime('now')
+      WHERE id = 1`
+  ).run(clamped);
+  return getCurrentRampConfig();
+}
+
+export function setShadowPaused(paused: boolean): ShadowRampConfig {
+  const db = getDb();
+  db.prepare(
+    `UPDATE traffic_shadow_config
+        SET paused = ?, updated_at = datetime('now')
+      WHERE id = 1`
+  ).run(paused ? 1 : 0);
+  return getCurrentRampConfig();
+}
+
+export function resetShadowRamp(now: Date = new Date()): ShadowRampConfig {
+  const iso = now.toISOString();
+  const db = getDb();
+  db.prepare(
+    `UPDATE traffic_shadow_config
+        SET current_phase = 'observe-only',
+            ramp_started_at = ?,
+            bifrost_serve_pct_override = NULL,
+            paused = 0,
+            updated_at = datetime('now')
+      WHERE id = 1`
+  ).run(iso);
+  return getCurrentRampConfig();
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+type LatencyRow = { path: string; latency_ms: number };
+type PercentileSet = { p50: number | null; p95: number | null; p99: number | null };
+
+/**
+ * Compute p50/p95/p99 per path from a pre-sorted list. Uses the
+ * "nearest-rank" method (the value at rank ceil(p/100 * N), 1-indexed),
+ * which is the same definition Postgres uses for percentile_disc.
+ */
+function computePercentiles(rows: LatencyRow[]): {
+  legacy: PercentileSet;
+  bifrost: PercentileSet;
+} {
+  const groups: Record<string, number[]> = { legacy: [], bifrost: [] };
+  for (const row of rows) {
+    if (row.path === "legacy" || row.path === "bifrost") {
+      groups[row.path].push(row.latency_ms);
+    }
+  }
+  return {
+    legacy: nearestRankPercentiles(groups.legacy),
+    bifrost: nearestRankPercentiles(groups.bifrost),
+  };
+}
+
+function nearestRankPercentiles(sorted: number[]): PercentileSet {
+  if (sorted.length === 0) {
+    return { p50: null, p95: null, p99: null };
+  }
+  const pick = (p: number): number => {
+    const rank = Math.max(1, Math.ceil((p / 100) * sorted.length));
+    return sorted[Math.min(sorted.length - 1, rank - 1)];
+  };
+  return { p50: pick(50), p95: pick(95), p99: pick(99) };
+}

--- a/src/shared/constants/shadowRamp.ts
+++ b/src/shared/constants/shadowRamp.ts
@@ -1,0 +1,136 @@
+/**
+ * Shadow Ramp — 5-phase traffic-shadow schedule for the Bifrost Tier-1 router.
+ *
+ * B6 of the v8.1 Bifrost track (ADR-031). Each phase has a fixed Bifrost
+ * serve percentage and a fixed duration. The phases are evaluated by
+ * `getActiveShadowPhase()` against the `ramp_started_at` column in the
+ * `traffic_shadow_config` table (see migration 105).
+ *
+ * The 14-day schedule is hard-coded here (the source of truth for the
+ * 30-day decision review per ADR-031 § Decision Review). Operators can
+ * pause or override per-deploy via the DB row (paused=1 or
+ * bifrost_serve_pct_override).
+ *
+ * Phase windows (cumulative days from ramp_started_at):
+ *   1. observe-only  :  0..<7  days → 0% Bifrost (parallel log only)
+ *   2. canary-5pct   :  7..<9  days → 5% Bifrost
+ *   3. canary-25pct  :  9..<11 days → 25% Bifrost
+ *   4. canary-50pct  : 11..<13 days → 50% Bifrost
+ *   5. canary-100pct : 13..14  days → 100% Bifrost
+ *
+ * Beyond 14 days, the ramp is "complete"; subsequent ramps require a fresh
+ * `ramp_started_at` write via resetShadowRamp().
+ */
+
+export type ShadowRampPhaseName =
+  | "observe-only"
+  | "canary-5pct"
+  | "canary-25pct"
+  | "canary-50pct"
+  | "canary-100pct";
+
+export interface ShadowRampPhase {
+  name: ShadowRampPhaseName;
+  /** Bifrost serve percentage for this phase (0-100). */
+  bifrostServePct: number;
+  /** Duration of this phase in days. */
+  durationDays: number;
+}
+
+export const SHADOW_RAMP_PHASES: readonly ShadowRampPhase[] = [
+  { name: "observe-only", bifrostServePct: 0, durationDays: 7 },
+  { name: "canary-5pct", bifrostServePct: 5, durationDays: 2 },
+  { name: "canary-25pct", bifrostServePct: 25, durationDays: 2 },
+  { name: "canary-50pct", bifrostServePct: 50, durationDays: 2 },
+  { name: "canary-100pct", bifrostServePct: 100, durationDays: 1 },
+] as const;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Compute the active shadow phase for a given `rampStartedAt` ISO string and
+ * the current time. Pure function — no DB read. Returns the highest-pct phase
+ * whose date window contains the current time relative to `rampStartedAt`.
+ *
+ * If `rampStartedAt` is invalid or in the future, returns the first phase
+ * (observe-only, 0%) — safer than serving Bifrost before ramp start.
+ *
+ * If `now` is past the end of the last phase, returns the last phase
+ * (canary-100pct) — i.e. once you've reached 100% you stay there until
+ * the operator resets via resetShadowRamp().
+ */
+export function resolveActiveShadowPhase(
+  rampStartedAtIso: string,
+  now: Date = new Date()
+): ShadowRampPhase {
+  const startedAt = new Date(rampStartedAtIso).getTime();
+  if (!Number.isFinite(startedAt)) {
+    return SHADOW_RAMP_PHASES[0];
+  }
+  const elapsedDays = (now.getTime() - startedAt) / MS_PER_DAY;
+  if (elapsedDays < 0) {
+    return SHADOW_RAMP_PHASES[0];
+  }
+  let active: ShadowRampPhase = SHADOW_RAMP_PHASES[0];
+  let cumulative = 0;
+  for (const phase of SHADOW_RAMP_PHASES) {
+    cumulative += phase.durationDays;
+    if (elapsedDays < cumulative) {
+      active = phase;
+      break;
+    }
+    active = phase;
+  }
+  return active;
+}
+
+/**
+ * Deterministic 0..99 hash bucket for a request identity. The dispatcher
+ * uses this to decide which requests go to Bifrost in a given phase, so
+ * the same `(provider, model, virtualKeyId, hourBucket)` always lands on
+ * the same path within the same hour. This keeps the divergence
+ * comparison stable — a request whose Bifrost response is logged at
+ * canary-5pct is the SAME request that gets served Bifrost on the next
+ * call to the same hash slot.
+ *
+ * `hourBucket` is a UTC hour epoch (Math.floor(Date.now() / 3_600_000))
+ * — this resets every hour, which is intentional: the determinism only
+ * needs to hold within an hour so the system self-balances.
+ */
+export function shadowServeBucket(input: {
+  provider: string;
+  model: string;
+  virtualKeyId: string | null;
+  hourBucket: number;
+}): number {
+  const key = `${input.provider}|${input.model}|${input.virtualKeyId ?? ""}|${input.hourBucket}`;
+  // FNV-1a 32-bit hash, simple and stable across runtimes.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < key.length; i++) {
+    hash ^= key.charCodeAt(i);
+    hash = (hash * 0x01000193) >>> 0;
+  }
+  return hash % 100;
+}
+
+/**
+ * Decide whether a given request (keyed by `bucket` 0..99) should be served
+ * by Bifrost in the current phase. Returns true for the highest-`bucket`
+ * requests so a 5% phase routes the top 5% of bucket values, 25% the top
+ * quarter, and so on.
+ */
+export function shouldServeBifrost(phase: ShadowRampPhase, bucket: number): boolean {
+  if (phase.bifrostServePct <= 0) return false;
+  if (phase.bifrostServePct >= 100) return true;
+  // bucket is 0..99. Top N% means bucket >= (100 - N).
+  return bucket >= 100 - phase.bifrostServePct;
+}
+
+/**
+ * Total ramp duration in days. Used by tests and the operator doc to
+ * assert that the 5 phases sum to the planned 14 days.
+ */
+export const SHADOW_RAMP_TOTAL_DAYS = SHADOW_RAMP_PHASES.reduce(
+  (sum, phase) => sum + phase.durationDays,
+  0
+);


### PR DESCRIPTION
## **User description**
## Summary

Implements B6 of the v8.1 Bifrost Tier-1 router rollout. Traffic-shadow infrastructure for the 5%→25%→100% rollout.

### Files

- `open-sse/executors/bifrostShadow.ts` — shadow executor that mirrors a percentage of traffic to Bifrost
- `open-sse/services/trafficShadow.ts` — orchestration (mode, percentage, dual-write metrics)
- `src/lib/db/bifrostShadow.ts` — shadow decisions + outcome tracking
- `src/lib/db/migrations/101_bifrost_shadow.sql` — schema
- `ops/slos.yaml` — SLO targets (p99, error rate, cost) for the 30-day decision review

### Modes

- `off` (default) — no shadow
- `mirror` — dispatch to both, return chatCore result, log Bifrost result for comparison
- `swap` — return Bifrost result (used at 100% after decision review)

Refs: ADR-031, PLAN.md § 2.5.2 (B6), docs/frameworks/BIFROST-BACKEND.md.


___

## **CodeAnt-AI Description**
Add opt-in traffic shadowing for Bifrost rollout comparisons

### What Changed
- Added an opt-in shadow mode that runs Bifrost alongside the existing chat path, records the comparison, and keeps returning the existing response to users unless the rollout phase switches traffic
- Added rollout controls for the 14-day ramp, including phase-based traffic split, pause, and percentage override
- Added persistent logging and summary data for latency, errors, agreement, and token usage so operators can review shadow results
- Added rollout SLO definitions for availability, latency, and error budget tracking

### Impact
`✅ Safer Bifrost rollout`
`✅ Side-by-side path comparison`
`✅ Faster rollout rollback`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
