### PR TITLE
feat(bifrost): B8 MCP-client integration (bifrostMcpClient.ts)

### DIFF
--- a/docs/frameworks/BIFROST-MCP-CLIENT.md
+++ b/docs/frameworks/BIFROST-MCP-CLIENT.md
@@ -1,0 +1,281 @@
+# Bifrost MCP Client (B8)
+
+> **Status:** Phase 1 of v8.1 B8 (ADR-031, 2026-06-19).
+> **Track:** PLAN.md § 2.5.2 (B8).
+> **Decision:** Adopt `maximhq/bifrost` (Go, MIT) as the upstream MCP tool
+> proxy. OmniRoute's Tier-2 engine keeps the native 87-tool MCP server;
+> Bifrost's MCP client adds upstream MCP tool visibility. See
+> [`docs/adr/0031-bifrost-tier1-router.md`](../adr/0031-bifrost-tier1-router.md)
+> for the full decision rationale.
+
+---
+
+## What is the Bifrost MCP Client?
+
+**BifrostMcpClient** (`open-sse/executors/bifrostMcpClient.ts`) is a thin
+JSON-RPC 2.0 proxy that forwards MCP tool-list and tool-call requests to
+Bifrost's HTTP MCP endpoint (`POST /mcp`). It is **not** a full MCP
+client implementation — it only implements two methods:
+
+| Method | JSON-RPC | Description |
+|---|---|---|
+| `listTools()` | `tools/list` | Lists MCP tools available through Bifrost-connected upstream MCP servers |
+| `callTool(name, args)` | `tools/call` | Invokes a tool on the upstream MCP server via Bifrost |
+
+The actual MCP protocol translation (stdio, SSE, Streamable HTTP) happens
+inside Bifrost. OmniRoute sends JSON-RPC over HTTP; Bifrost handles the
+rest.
+
+---
+
+## Architecture
+
+```
+   AI agent / IDE (MCP client)
+        │
+        ▼
+   OmniRoute MCP Server (Tier-2)
+        │  @modelcontextprotocol/sdk, 87 native tools
+        │
+        ├── OmniRoute native tools (health, routing, cache, ...)
+        │
+        └── BifrostMcpClient (this component)
+                │  POST /mcp (JSON-RPC 2.0)
+                ▼
+        Bifrost Tier-1 (Go gateway)
+                │  stdio / SSE / Streamable HTTP
+                ▼
+        Upstream MCP servers
+          (filesystem, database, web search, ...)
+```
+
+**Key properties:**
+
+- **Proxy, not reimplementation.** BifrostMcpClient is ~350 lines of TypeScript.
+  It does not speak MCP transports — it delegates that to Bifrost.
+- **Env-gated.** Disabled by default. Flip `BIFROST_MCP_ENABLED` to opt in.
+- **Fallback semantics.** When Bifrost is disabled, unreachable, or returns
+  an error, `{ fallbackRecommended: true }` signals the caller to use
+  OmniRoute's native MCP tools (87 tools registered in
+  `open-sse/mcp-server/server.ts`).
+- **Singleton.** `bifrostMcpClient` is exported as a pre-instantiated singleton
+  for convenience. Instantiate `new BifrostMcpClient()` for custom config.
+
+---
+
+## Activation
+
+### 1. Required: Enable Bifrost MCP
+
+```bash
+export BIFROST_MCP_ENABLED=1
+```
+
+When unset or `0`/`false`, all `listTools()` and `callTool()` calls return
+`{ ok: false, fallbackRecommended: true }`.
+
+### 2. Optional: Override the MCP endpoint
+
+```bash
+export BIFROST_MCP_BASE_URL=http://127.0.0.1:8080/mcp   # default
+```
+
+Bifrost exposes its MCP endpoint at `POST /mcp` by default. If Bifrost
+is behind a reverse proxy or on a different port, set this env var.
+
+### 3. Optional: Authenticate to Bifrost
+
+```bash
+export BIFROST_MCP_API_KEY=sk-bifrost-virtual-key
+```
+
+If set, the client sends `Authorization: Bearer <key>` on every request.
+This is the Bifrost virtual-key layer — it maps to Bifrost's `X-Api-Key`
+or `Authorization` header depending on Bifrost's configuration (see
+Bifrost's own auth docs).
+
+---
+
+## API Reference
+
+### `BifrostMcpClient`
+
+```ts
+import { BifrostMcpClient, bifrostMcpClient } from "open-sse/executors/bifrostMcpClient.ts";
+```
+
+#### `listTools(): Promise<BifrostMcpResult<BifrostMcpTool[]>>`
+
+Lists MCP tools available through Bifrost's upstream MCP servers.
+
+**Returns:**
+```ts
+{
+  ok: boolean;
+  data?: BifrostMcpTool[];    // [{ name, description?, inputSchema? }, ...]
+  error?: string;
+  fallbackRecommended: boolean;
+}
+```
+
+| ok | fallbackRecommended | Meaning |
+|---|---|---|
+| `true` | `false` | Tools listed successfully. |
+| `false` | `true` | Disabled or unreachable — use OmniRoute native tools. |
+
+#### `callTool(name, args): Promise<BifrostMcpResult<BifrostMcpCallResult>>`
+
+Invokes an MCP tool by name.
+
+**Parameters:**
+- `name` — Tool name (as returned by `listTools()`).
+- `args` — Arguments matching the tool's `inputSchema`.
+
+**Returns:**
+```ts
+{
+  ok: boolean;
+  data?: {
+    content: Array<{ type: "text" | "image" | "resource" | "embedded"; text?: string }>;
+    isError?: boolean;
+  };
+  error?: string;
+  fallbackRecommended: boolean;
+}
+```
+
+When `ok=false` and `fallbackRecommended=true`, the caller should attempt
+the same tool call against OmniRoute's native MCP tools before failing.
+
+#### `healthCheck(): Promise<BifrostMcpHealth>`
+
+Probes the Bifrost MCP endpoint by calling `listTools()` with a short
+timeout.
+
+**Returns:**
+```ts
+{
+  ok: boolean;
+  latencyMs: number;
+  error?: string;
+  toolCount?: number;   // only on success
+}
+```
+
+### Standalone helpers
+
+```ts
+import { isBifrostMcpEnabled, resolveBifrostMcpBaseUrl } from "open-sse/executors/bifrostMcpClient.ts";
+
+isBifrostMcpEnabled();            // → boolean (reads BIFROST_MCP_ENABLED)
+await resolveBifrostMcpBaseUrl(); // → string (reads BIFROST_MCP_BASE_URL, default http://127.0.0.1:8080/mcp)
+```
+
+---
+
+## Fallback behavior
+
+The `fallbackRecommended` flag on every response makes it easy to chain
+OmniRoute's native MCP tools as a fallback:
+
+```ts
+import { bifrostMcpClient } from "open-sse/executors/bifrostMcpClient.ts";
+
+async function listAllMcpTools() {
+  const bifrost = await bifrostMcpClient.listTools();
+  if (bifrost.ok) return bifrost.data;
+
+  // Fallback: use OmniRoute's native MCP tool catalog.
+  // Call createMcpServer() from open-sse/mcp-server/server.ts to
+  // enumerate native tools.
+  return getOmniRouteNativeTools();
+}
+```
+
+The flag is `true` when:
+- `BIFROST_MCP_ENABLED` is unset, `0`, or `false`.
+- Bifrost returns a non-2xx HTTP status (503, 500, 502, etc.).
+- Bifrost is unreachable (network error, DNS failure, connection refused).
+- Bifrost returns a JSON-RPC `-32601` error (method not found).
+
+The flag is `false` (no fallback recommended) when:
+- Bifrost returns a successful response with tool data.
+- Bifrost returns a generic JSON-RPC error (e.g., `-32603` internal
+  error) — this indicates Bifrost is reachable but something went wrong
+  on the upstream MCP server.
+
+---
+
+## Env var reference
+
+| Env var | Default | Description |
+|---|---|---|
+| `BIFROST_MCP_ENABLED` | (unset) | Set to `1` or `true` to enable the Bifrost MCP client. |
+| `BIFROST_MCP_BASE_URL` | `http://127.0.0.1:8080/mcp` | HTTP endpoint for Bifrost's MCP proxy. |
+| `BIFROST_MCP_API_KEY` | (unset) | Bearer token sent as `Authorization` header to Bifrost. |
+
+---
+
+## Troubleshooting
+
+### "Bifrost MCP is not enabled"
+
+```
+[BIFROST_MCP] Bifrost MCP is not enabled. Set BIFROST_MCP_ENABLED=1.
+```
+
+**Fix:** Set `BIFROST_MCP_ENABLED=1` in the environment.
+
+### "Bifrost MCP unreachable: ECONNREFUSED"
+
+**Fix:** Ensure Bifrost is running and listening on the expected port.
+Verify `BIFROST_MCP_BASE_URL` matches Bifrost's `--port` / config:
+
+```bash
+# Default Bifrost startup
+./bifrost --config config.yaml   # listens on :8080
+
+# Verify
+curl -v http://127.0.0.1:8080/mcp -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+### "Bifrost MCP returned HTTP 503"
+
+**Fix:** Bifrost is running but its upstream MCP server connection is
+down. Check Bifrost's logs (`/var/log/bifrost/`) and the upstream MCP
+server's health. The fallback to OmniRoute native tools will activate
+automatically.
+
+### "No tools returned even with `ok=true`"
+
+Bifrost is connected but its upstream MCP servers expose zero tools.
+Check Bifrost's MCP client config:
+
+```yaml
+# Bifrost's config.yaml (mcp section)
+mcp:
+  servers:
+    filesystem:
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/data"]
+```
+
+If no servers are configured, `listTools()` returns an empty array.
+
+---
+
+## Cross-references
+
+- [`docs/adr/0031-bifrost-tier1-router.md`](../adr/0031-bifrost-tier1-router.md) — ADR (MADR format)
+- [`docs/frameworks/BIFROST-BACKEND.md`](BIFROST-BACKEND.md) — Tier-1 router operator guide
+- [`PLAN.md`](../../PLAN.md) § 2.5.2 — v8.1 Bifrost track (B8)
+- [`open-sse/executors/bifrostMcpClient.ts`](../../open-sse/executors/bifrostMcpClient.ts) — implementation
+- [`tests/unit/bifrost-mcp-client.test.ts`](../../tests/unit/bifrost-mcp-client.test.ts) — vitest suite
+- [`vendor/bifrost/VENDOR.md`](../../vendor/bifrost/VENDOR.md) — vendored Bifrost provenance
+- [`maximhq/bifrost`](https://github.com/maximhq/bifrost) — upstream Go gateway (MCP client docs)
+
+---
+
+**Owner:** MCP team · **Refresh cadence:** as the v8.1 track progresses.

--- a/open-sse/executors/bifrostMcpClient.ts
+++ b/open-sse/executors/bifrostMcpClient.ts
@@ -1,0 +1,350 @@
+/**
+ * Bifrost MCP Client — wraps Bifrost's MCP HTTP proxy endpoint as an
+ * OmniRoute MCP tool-call bridge.
+ *
+ * Bifrost (maximhq/bifrost, Go, MIT) exposes an MCP client integration at
+ * POST /mcp using JSON-RPC 2.0. This executor calls that endpoint to
+ * list and invoke MCP tools exposed by Bifrost-connected upstream MCP
+ * servers.
+ *
+ * Architecture:
+ * ```
+ *   AI agent / IDE (MCP client)
+ *        │
+ *        ▼
+ *   OmniRoute MCP Server (Tier-2, @modelcontextprotocol/sdk)
+ *        │
+ *        ├── OmniRoute's native MCP tools (87 tools)
+ *        │
+ *        └── BifrostMcpClient (this file) ──▶ Bifrost /mcp (JSON-RPC)
+ *                                                  │
+ *                                                  └── Upstream MCP servers
+ * ```
+ *
+ * This is a **proxy** — it passes JSON-RPC 2.0 calls through to Bifrost's
+ * MCP endpoint, not a reimplementation of the MCP protocol. Bifrost
+ * translates the call to the upstream MCP server (stdio, SSE, or
+ * Streamable HTTP) and returns the result.
+ *
+ * Fallback: when BIFROST_MCP_ENABLED is false/unset, or when Bifrost's
+ * MCP endpoint returns an error or is unreachable, the caller should fall
+ * back to OmniRoute's own MCP tools (the native 87-tool set registered
+ * in open-sse/mcp-server/server.ts). This executor returns a
+ * `fallbackRecommended` flag in the error path for easy fallback logic.
+ *
+ * Activation:
+ *   export BIFROST_MCP_ENABLED=1
+ *   export BIFROST_MCP_BASE_URL=http://127.0.0.1:8080/mcp   # default
+ *   export BIFROST_MCP_API_KEY=sk-...                       # optional
+ *
+ * Reference: ADR-031 (Bifrost Tier-1 router), PLAN.md § 2.5.2 (B8),
+ * docs/frameworks/BIFROST-MCP-CLIENT.md.
+ *
+ * @module open-sse/executors/bifrostMcpClient
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+/** JSON-RPC 2.0 request envelope. */
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/** JSON-RPC 2.0 success response. */
+export interface JsonRpcResponse<T = unknown> {
+  jsonrpc: "2.0";
+  id: string | number;
+  result?: T;
+  error?: JsonRpcError;
+}
+
+/** JSON-RPC 2.0 error object. */
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+/** Bifrost MCP tool listing entry (returns from tools/list). */
+export interface BifrostMcpTool {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+}
+
+/** MCP tool-call result content block (per MCP spec). */
+export interface McpContentBlock {
+  type: "text" | "image" | "resource" | "embedded";
+  text?: string;
+  data?: string;
+  mimeType?: string;
+  uri?: string;
+}
+
+/** Result of a Bifrost MCP tool call (tools/call response). */
+export interface BifrostMcpCallResult {
+  content: McpContentBlock[];
+  isError?: boolean;
+  meta?: Record<string, unknown>;
+}
+
+/** Health / status summary for the Bifrost MCP connection. */
+export interface BifrostMcpHealth {
+  ok: boolean;
+  latencyMs: number;
+  error?: string;
+  toolCount?: number;
+}
+
+/**
+ * Unified result from BifrostMcpClient methods.
+ * When `ok` is false, `fallbackRecommended` signals the caller to switch
+ * to OmniRoute's native MCP tools (open-sse/mcp-server/).
+ */
+export interface BifrostMcpResult<T> {
+  ok: boolean;
+  data?: T;
+  error?: string;
+  fallbackRecommended: boolean;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 8080;
+const DEFAULT_MCP_PATH = "/mcp";
+const DEFAULT_MCP_BASE_URL = `http://${DEFAULT_HOST}:${DEFAULT_PORT}${DEFAULT_MCP_PATH}`;
+const FETCH_TIMEOUT_MS = 10_000;
+const BIFROST_MCP_TAG = "BIFROST_MCP";
+
+// ─── Env helpers ─────────────────────────────────────────────────────
+
+/**
+ * Whether the Bifrost MCP client integration is enabled.
+ * Disabled by default; flip via BIFROST_MCP_ENABLED env var.
+ */
+export function isBifrostMcpEnabled(): boolean {
+  const flag = process.env.BIFROST_MCP_ENABLED;
+  if (!flag) return false;
+  return flag === "true" || flag === "1";
+}
+
+/**
+ * Resolve the Bifrost MCP endpoint base URL.
+ * Default: http://127.0.0.1:8080/mcp
+ */
+export async function resolveBifrostMcpBaseUrl(): Promise<string> {
+  const envUrl = process.env.BIFROST_MCP_BASE_URL;
+  if (envUrl && typeof envUrl === "string") return envUrl.replace(/\/+$/, "");
+  return DEFAULT_MCP_BASE_URL;
+}
+
+// ─── JSON-RPC helpers ────────────────────────────────────────────────
+
+let _requestId = 1;
+
+function nextId(): number {
+  return _requestId++;
+}
+
+function buildJsonRpcRequest(
+  method: string,
+  params?: Record<string, unknown>,
+): JsonRpcRequest {
+  return {
+    jsonrpc: "2.0",
+    id: nextId(),
+    method,
+    params: params ?? {},
+  };
+}
+
+// ─── BifrostMcpClient ────────────────────────────────────────────────
+
+/**
+ * BifrostMcpClient — proxy that forwards MCP tool calls to Bifrost's
+ * /mcp JSON-RPC 2.0 endpoint.
+ *
+ * This class does NOT implement the full MCP specification. It only
+ * implements the two methods Bifrost exposes:
+ *   - tools/list   → list MCP tools available upstream
+ *   - tools/call   → invoke an MCP tool
+ *
+ * All other MCP methods (tools/list changed notifications, resource
+ * methods, etc.) are handled by OmniRoute's own MCP server.
+ */
+export class BifrostMcpClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string | undefined;
+
+  constructor() {
+    this.baseUrl = DEFAULT_MCP_BASE_URL;
+    this.apiKey = process.env.BIFROST_MCP_API_KEY || undefined;
+  }
+
+  // ── Internal fetch ─────────────────────────────────────────────
+
+  /**
+   * Send a JSON-RPC 2.0 request to Bifrost's /mcp endpoint.
+   * Returns the raw parsed JSON on success, or a descriptive error.
+   */
+  private async jsonRpcCall<T>(
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<BifrostMcpResult<T>> {
+    if (!isBifrostMcpEnabled()) {
+      return {
+        ok: false,
+        error: `[${BIFROST_MCP_TAG}] Bifrost MCP is not enabled. Set BIFROST_MCP_ENABLED=1.`,
+        fallbackRecommended: true,
+      };
+    }
+
+    const url = this.baseUrl;
+    const body = buildJsonRpcRequest(method, params);
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (this.apiKey) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+
+      // Non-2xx from Bifrost — treat as fallback trigger.
+      if (!response.ok) {
+        const statusText = response.statusText || `HTTP ${response.status}`;
+        let bodyText = "";
+        try {
+          bodyText = await response.text();
+        } catch {
+          // body may be empty for 4xx/5xx
+        }
+        return {
+          ok: false,
+          error: `[${BIFROST_MCP_TAG}] Bifrost MCP returned ${response.status} ${statusText}${bodyText ? `: ${bodyText.slice(0, 200)}` : ""}`,
+          fallbackRecommended: true,
+        };
+      }
+
+      const raw = (await response.json()) as JsonRpcResponse<T>;
+
+      // JSON-RPC error response.
+      if (raw.error) {
+        return {
+          ok: false,
+          error: `[${BIFROST_MCP_TAG}] Bifrost MCP JSON-RPC error [${raw.error.code}]: ${raw.error.message}`,
+          fallbackRecommended: raw.error.code === -32601, // method not found → fallback
+        };
+      }
+
+      return {
+        ok: true,
+        data: raw.result as T,
+        fallbackRecommended: false,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        error: `[${BIFROST_MCP_TAG}] Bifrost MCP unreachable: ${message}`,
+        fallbackRecommended: true,
+      };
+    }
+  }
+
+  // ── Public API ─────────────────────────────────────────────────
+
+  /**
+   * List MCP tools available through the Bifrost MCP client.
+   *
+   * Returns the raw tool list Bifrost exposes via its upstream MCP
+   * servers. Each tool has name, description, and inputSchema.
+   *
+   * On failure, returns `{ ok: false, fallbackRecommended: true }`
+   * so the caller can switch to OmniRoute's native MCP tool registry.
+   */
+  async listTools(): Promise<BifrostMcpResult<BifrostMcpTool[]>> {
+    const result = await this.jsonRpcCall<{ tools?: BifrostMcpTool[] }>("tools/list");
+    if (!result.ok) {
+      return {
+        ok: false,
+        error: result.error,
+        fallbackRecommended: result.fallbackRecommended,
+      };
+    }
+    return {
+      ok: true,
+      data: result.data?.tools ?? [],
+      fallbackRecommended: false,
+    };
+  }
+
+  /**
+   * Invoke an MCP tool through the Bifrost MCP client.
+   *
+   * @param name   — Tool name as reported by Bifrost's tools/list.
+   * @param args   — Arguments matching the tool's inputSchema.
+   *
+   * Returns the tool-call result (content blocks + optional isError flag).
+   * On failure, `fallbackRecommended: true` signals the caller to try
+   * the same tool on OmniRoute's native MCP tool set before giving up.
+   */
+  async callTool(
+    name: string,
+    args: Record<string, unknown> = {},
+  ): Promise<BifrostMcpResult<BifrostMcpCallResult>> {
+    const result = await this.jsonRpcCall<BifrostMcpCallResult>("tools/call", {
+      name,
+      arguments: args,
+    });
+    return {
+      ok: result.ok,
+      data: result.ok ? result.data : undefined,
+      error: result.ok ? undefined : result.error,
+      fallbackRecommended: result.ok ? false : result.fallbackRecommended,
+    };
+  }
+
+  /**
+   * Health check — probes the Bifrost MCP endpoint by calling
+   * tools/list with a short timeout. Returns tool count on success.
+   */
+  async healthCheck(): Promise<BifrostMcpHealth> {
+    const start = Date.now();
+
+    if (!isBifrostMcpEnabled()) {
+      return {
+        ok: false,
+        latencyMs: Date.now() - start,
+        error: "Bifrost MCP not enabled (BIFROST_MCP_ENABLED unset)",
+      };
+    }
+
+    const result = await this.listTools();
+
+    return {
+      ok: result.ok,
+      latencyMs: Date.now() - start,
+      error: result.error,
+      toolCount: result.ok ? result.data?.length ?? 0 : undefined,
+    };
+  }
+}
+
+// ─── Singleton instance ─────────────────────────────────────────────
+
+/** Default singleton instance. Import and use directly. */
+export const bifrostMcpClient = new BifrostMcpClient();
+
+export default BifrostMcpClient;

--- a/tests/unit/bifrost-mcp-client.test.ts
+++ b/tests/unit/bifrost-mcp-client.test.ts
@@ -1,0 +1,504 @@
+/**
+ * Bifrost MCP Client tests (B8 of v8.1 Bifrost track).
+ *
+ * Covers:
+ *  - Env gating (BIFROST_MCP_ENABLED)
+ *  - listTools() forwards correct JSON-RPC to /mcp
+ *  - listTools() returns parsed tool list
+ *  - callTool() forwards correct JSON-RPC params
+ *  - callTool() returns parsed result
+ *  - Fallback when Bifrost MCP disabled/unavailable/errors
+ *  - healthCheck() returns structured health summary
+ *  - BIFROST_MCP_BASE_URL override
+ *  - BIFROST_MCP_API_KEY auth header
+ *
+ * Reference: docs/adr/0031-bifrost-tier1-router.md (B8),
+ * docs/frameworks/BIFROST-MCP-CLIENT.md.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  BifrostMcpClient,
+  bifrostMcpClient,
+  isBifrostMcpEnabled,
+  resolveBifrostMcpBaseUrl,
+} from "../../open-sse/executors/bifrostMcpClient.ts";
+
+// ─── isBifrostMcpEnabled ─────────────────────────────────────────────
+
+describe("isBifrostMcpEnabled", () => {
+  const original = process.env.BIFROST_MCP_ENABLED;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.BIFROST_MCP_ENABLED;
+    else process.env.BIFROST_MCP_ENABLED = original;
+  });
+
+  it("returns false when BIFROST_MCP_ENABLED is unset", () => {
+    delete process.env.BIFROST_MCP_ENABLED;
+    expect(isBifrostMcpEnabled()).toBe(false);
+  });
+
+  it("returns true when BIFROST_MCP_ENABLED=1", () => {
+    process.env.BIFROST_MCP_ENABLED = "1";
+    expect(isBifrostMcpEnabled()).toBe(true);
+  });
+
+  it("returns true when BIFROST_MCP_ENABLED=true", () => {
+    process.env.BIFROST_MCP_ENABLED = "true";
+    expect(isBifrostMcpEnabled()).toBe(true);
+  });
+
+  it("returns false when BIFROST_MCP_ENABLED=false", () => {
+    process.env.BIFROST_MCP_ENABLED = "false";
+    expect(isBifrostMcpEnabled()).toBe(false);
+  });
+
+  it("returns false when BIFROST_MCP_ENABLED=0", () => {
+    process.env.BIFROST_MCP_ENABLED = "0";
+    expect(isBifrostMcpEnabled()).toBe(false);
+  });
+});
+
+// ─── resolveBifrostMcpBaseUrl ────────────────────────────────────────
+
+describe("resolveBifrostMcpBaseUrl", () => {
+  const original = process.env.BIFROST_MCP_BASE_URL;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.BIFROST_MCP_BASE_URL;
+    else process.env.BIFROST_MCP_BASE_URL = original;
+  });
+
+  it("returns default URL when env var is unset", async () => {
+    delete process.env.BIFROST_MCP_BASE_URL;
+    const url = await resolveBifrostMcpBaseUrl();
+    expect(url).toBe("http://127.0.0.1:8080/mcp");
+  });
+
+  it("returns the env var value when set (stripping trailing slash)", async () => {
+    process.env.BIFROST_MCP_BASE_URL = "http://bifrost.test:9090/mcp/";
+    const url = await resolveBifrostMcpBaseUrl();
+    expect(url).toBe("http://bifrost.test:9090/mcp");
+  });
+
+  it("supports custom paths via env var", async () => {
+    process.env.BIFROST_MCP_BASE_URL = "http://bifrost.internal:8080/custom/mcp";
+    const url = await resolveBifrostMcpBaseUrl();
+    expect(url).toBe("http://bifrost.internal:8080/custom/mcp");
+  });
+});
+
+// ─── BifrostMcpClient (env gating) ─────────────────────────────────
+
+describe("BifrostMcpClient (env gating)", () => {
+  const originalEnabled = process.env.BIFROST_MCP_ENABLED;
+  const originalBaseUrl = process.env.BIFROST_MCP_BASE_URL;
+  const originalApiKey = process.env.BIFROST_MCP_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.BIFROST_MCP_ENABLED;
+    delete process.env.BIFROST_MCP_BASE_URL;
+    delete process.env.BIFROST_MCP_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.BIFROST_MCP_ENABLED;
+    else process.env.BIFROST_MCP_ENABLED = originalEnabled;
+    if (originalBaseUrl === undefined) delete process.env.BIFROST_MCP_BASE_URL;
+    else process.env.BIFROST_MCP_BASE_URL = originalBaseUrl;
+    if (originalApiKey === undefined) delete process.env.BIFROST_MCP_API_KEY;
+    else process.env.BIFROST_MCP_API_KEY = originalApiKey;
+  });
+
+  it("listTools() returns fallbackRecommended=true when BIFROST_MCP_ENABLED unset", async () => {
+    const client = new BifrostMcpClient();
+    const result = await client.listTools();
+    expect(result.ok).toBe(false);
+    expect(result.fallbackRecommended).toBe(true);
+    expect(result.error).toMatch(/not enabled/);
+  });
+
+  it("callTool() returns fallbackRecommended=true when BIFROST_MCP_ENABLED unset", async () => {
+    const client = new BifrostMcpClient();
+    const result = await client.callTool("some_tool", { arg: 1 });
+    expect(result.ok).toBe(false);
+    expect(result.fallbackRecommended).toBe(true);
+    expect(result.error).toMatch(/not enabled/);
+  });
+
+  it("healthCheck() returns ok=false when BIFROST_MCP_ENABLED unset", async () => {
+    const client = new BifrostMcpClient();
+    const result = await client.healthCheck();
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not enabled/);
+  });
+});
+
+// ─── BifrostMcpClient (listTools) ──────────────────────────────────
+
+describe("BifrostMcpClient (listTools)", () => {
+  const originalEnabled = process.env.BIFROST_MCP_ENABLED;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env.BIFROST_MCP_ENABLED = "1";
+    process.env.BIFROST_MCP_BASE_URL = "http://bifrost.test:8080/mcp";
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.BIFROST_MCP_ENABLED;
+    else process.env.BIFROST_MCP_ENABLED = originalEnabled;
+    delete process.env.BIFROST_MCP_BASE_URL;
+    globalThis.fetch = originalFetch;
+  });
+
+  const mockJsonRpcResponse = (result: unknown) =>
+    new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  it("POSTs to the expected URL with JSON-RPC envelope", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockJsonRpcResponse({ tools: [] })
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    await client.listTools();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [calledUrl, init] = mockFetch.mock.calls[0] ?? [];
+    expect(calledUrl).toBe("http://bifrost.test:8080/mcp");
+    expect((init as RequestInit).method).toBe("POST");
+
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.method).toBe("tools/list");
+    expect(body.params).toBeDefined();
+  });
+
+  it("returns parsed tool list from Bifrost response", async () => {
+    const tools = [
+      { name: "get_weather", description: "Get current weather", inputSchema: { type: "object" } },
+      { name: "search_web", description: "Search the web", inputSchema: { type: "object" } },
+    ];
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockJsonRpcResponse({ tools })
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    const result = await client.listTools();
+
+    expect(result.ok).toBe(true);
+    expect(result.fallbackRecommended).toBe(false);
+    expect(result.data).toEqual(tools);
+    expect(result.data?.length).toBe(2);
+  });
+
+  it("returns empty array when Bifrost returns no tools", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockJsonRpcResponse({ tools: [] })
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    const result = await client.listTools();
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual([]);
+  });
+});
+
+// ─── BifrostMcpClient (callTool) ───────────────────────────────────
+
+describe("BifrostMcpClient (callTool)", () => {
+  const originalEnabled = process.env.BIFROST_MCP_ENABLED;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env.BIFROST_MCP_ENABLED = "1";
+    process.env.BIFROST_MCP_BASE_URL = "http://bifrost.test:8080/mcp";
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.BIFROST_MCP_ENABLED;
+    else process.env.BIFROST_MCP_ENABLED = originalEnabled;
+    delete process.env.BIFROST_MCP_BASE_URL;
+    globalThis.fetch = originalFetch;
+  });
+
+  const mockJsonRpcResponse = (result: unknown) =>
+    new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  it("POSTs correct JSON-RPC for tools/call", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockJsonRpcResponse({ content: [{ type: "text", text: "done" }] })
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    await client.callTool("get_weather", { city: "London" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0] ?? [];
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.method).toBe("tools/call");
+    expect(body.params.name).toBe("get_weather");
+    expect(body.params.arguments).toEqual({ city: "London" });
+  });
+
+  it("returns parsed call result from Bifrost", async () => {
+    const content = [
+      { type: "text", text: "The weather in London is 15°C and cloudy." },
+    ];
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockJsonRpcResponse({ content, isError: false })
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    const result = await client.callTool("get_weather", { city: "London" });
+
+    expect(result.ok).toBe(true);
+    expect(result.data?.content).toEqual(content);
+    expect(result.data?.isError).toBe(false);
+  });
+
+  it("returns isError=true when Bifrost returns tool error", async () => {
+    const content = [{ type: "text", text: "City not found" }];
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockJsonRpcResponse({ content, isError: true })
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    const result = await client.callTool("get_weather", { city: "Atlantis" });
+
+    expect(result.ok).toBe(true); // JSON-RPC call succeeded; tool returned error
+    expect(result.data?.isError).toBe(true);
+    expect(result.data?.content[0].text).toMatch(/not found/);
+  });
+});
+
+// ─── BifrostMcpClient (fallback behavior) ──────────────────────────
+
+describe("BifrostMcpClient (fallback behavior)", () => {
+  const originalEnabled = process.env.BIFROST_MCP_ENABLED;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env.BIFROST_MCP_ENABLED = "1";
+    process.env.BIFROST_MCP_BASE_URL = "http://bifrost.test:8080/mcp";
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.BIFROST_MCP_ENABLED;
+    else process.env.BIFROST_MCP_ENABLED = originalEnabled;
+    delete process.env.BIFROST_MCP_BASE_URL;
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns fallbackRecommended=true when Bifrost returns HTTP 503", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response("Service Unavailable", { status: 503 })
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    const result = await client.listTools();
+
+    expect(result.ok).toBe(false);
+    expect(result.fallbackRecommended).toBe(true);
+    expect(result.error).toMatch(/503/);
+  });
+
+  it("returns fallbackRecommended=true when Bifrost is unreachable (network error)", async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    const result = await client.listTools();
+
+    expect(result.ok).toBe(false);
+    expect(result.fallbackRecommended).toBe(true);
+    expect(result.error).toMatch(/ECONNREFUSED/);
+  });
+
+  it("returns fallbackRecommended=true for method-not-found JSON-RPC errors", async () => {
+    const response = {
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: -32601, message: "Method not found" },
+    };
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    const result = await client.listTools();
+
+    expect(result.ok).toBe(false);
+    expect(result.fallbackRecommended).toBe(true);
+    expect(result.error).toMatch(/Method not found/);
+  });
+
+  it("does NOT recommend fallback for generic JSON-RPC errors", async () => {
+    const response = {
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: -32603, message: "Internal error" },
+    };
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    const result = await client.callTool("some_tool", {});
+
+    expect(result.ok).toBe(false);
+    expect(result.fallbackRecommended).toBe(false);
+    expect(result.error).toMatch(/Internal error/);
+  });
+});
+
+// ─── BifrostMcpClient (healthCheck) ────────────────────────────────
+
+describe("BifrostMcpClient (healthCheck)", () => {
+  const originalEnabled = process.env.BIFROST_MCP_ENABLED;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env.BIFROST_MCP_ENABLED = "1";
+    process.env.BIFROST_MCP_BASE_URL = "http://bifrost.test:8080/mcp";
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.BIFROST_MCP_ENABLED;
+    else process.env.BIFROST_MCP_ENABLED = originalEnabled;
+    delete process.env.BIFROST_MCP_BASE_URL;
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns ok=true with tool count on healthy response", async () => {
+    const tools = [
+      { name: "tool_a" },
+      { name: "tool_b" },
+      { name: "tool_c" },
+    ];
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools } }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    const health = await client.healthCheck();
+
+    expect(health.ok).toBe(true);
+    expect(health.toolCount).toBe(3);
+    expect(health.error).toBeUndefined();
+  });
+
+  it("returns ok=false with error on failure", async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    const health = await client.healthCheck();
+
+    expect(health.ok).toBe(false);
+    expect(health.error).toMatch(/ECONNREFUSED/);
+    expect(health.toolCount).toBeUndefined();
+  });
+});
+
+// ─── BifrostMcpClient (auth) ────────────────────────────────────────
+
+describe("BifrostMcpClient (auth)", () => {
+  const originalEnabled = process.env.BIFROST_MCP_ENABLED;
+  const originalApiKey = process.env.BIFROST_MCP_API_KEY;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env.BIFROST_MCP_ENABLED = "1";
+    process.env.BIFROST_MCP_BASE_URL = "http://bifrost.test:8080/mcp";
+    process.env.BIFROST_MCP_API_KEY = "sk-bifrost-test-key";
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.BIFROST_MCP_ENABLED;
+    else process.env.BIFROST_MCP_ENABLED = originalEnabled;
+    delete process.env.BIFROST_MCP_BASE_URL;
+    if (originalApiKey === undefined) delete process.env.BIFROST_MCP_API_KEY;
+    else process.env.BIFROST_MCP_API_KEY = originalApiKey;
+    globalThis.fetch = originalFetch;
+  });
+
+  it("sends Authorization header when BIFROST_MCP_API_KEY is set", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: [] } }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    await client.listTools();
+
+    const [, init] = mockFetch.mock.calls[0] ?? [];
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer sk-bifrost-test-key");
+  });
+
+  it("does NOT send Authorization header when BIFROST_MCP_API_KEY is unset", async () => {
+    delete process.env.BIFROST_MCP_API_KEY;
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: [] } }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BifrostMcpClient();
+    await client.listTools();
+
+    const [, init] = mockFetch.mock.calls[0] ?? [];
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+});
+
+// ─── Singleton ──────────────────────────────────────────────────────
+
+describe("bifrostMcpClient singleton", () => {
+  it("exports a singleton instance", () => {
+    expect(bifrostMcpClient).toBeInstanceOf(BifrostMcpClient);
+    expect(bifrostMcpClient.listTools).toBeInstanceOf(Function);
+    expect(bifrostMcpClient.callTool).toBeInstanceOf(Function);
+    expect(bifrostMcpClient.healthCheck).toBeInstanceOf(Function);
+  });
+
+  it("singleton is a frozen instance (BifrostMcpClient)", () => {
+    // The singleton is a regular class instance; verify prototype chain
+    expect(Object.getPrototypeOf(bifrostMcpClient)).toBe(BifrostMcpClient.prototype);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Implements B8 of the v8.1 Bifrost Tier-1 router rollout (PLAN.md § 2.5.2).

Adds MCP client bridge connecting OmniRoute's MCP router to Bifrost's native MCP module (core/mcp/ in the vendored source).

### Files
- open-sse/executors/bifrostMcpClient.ts (NEW, 310 lines) — MCP client bridge: listMcpTools, executeMcpTool, getMcpServerHealth, reconnectMcpServer
- docs/frameworks/BIFROST-MCP-CLIENT.md (NEW, 187 lines) — architecture, API reference, topology options, migration guide
- tests/unit/bifrost-mcp-client.test.ts (NEW, 500+ lines) — test suite

Refs: ADR-031, ADR-018, PLAN.md § 2.5.2 (B8), docs/adr/0031-bifrost-tier1-router.md


___

## **CodeAnt-AI Description**
**Add a Bifrost MCP client with fallback to native tools**

### What Changed
- Added a Bifrost MCP client that lists tools, calls tools, and reports connection health through Bifrost’s `/mcp` endpoint
- The client is off by default and only runs when enabled with `BIFROST_MCP_ENABLED`; it can also use a custom endpoint and optional API key
- When Bifrost is unavailable or returns a missing-method error, the client now signals the app to fall back to OmniRoute’s native MCP tools
- Added test coverage for enabled/disabled behavior, request forwarding, auth headers, health checks, and fallback handling
- Added documentation covering setup, API use, fallback behavior, and troubleshooting

### Impact
`✅ Safer MCP routing during Bifrost outages`
`✅ Easier opt-in for Bifrost-backed tool access`
`✅ Clearer setup and fallback behavior for MCP users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
