### PR TITLE
feat(T7): terraform-fmt + terraform-validate hooks + CI

### DIFF
--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -1,0 +1,40 @@
+name: terraform-pr
+
+on:
+  pull_request:
+    paths:
+      - "**/*.tf"
+      - "**/*.tfvars"
+      - "**/*.hcl"
+      - ".pre-commit-hooks/terraform-*.sh"
+      - ".github/workflows/terraform-pr.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e4311558cf03e74e50c0c7c
+        with:
+          terraform_version: 1.9
+          terraform_wrapper: false
+      - name: terraform fmt
+        run: ./.pre-commit-hooks/terraform-fmt.sh
+
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e4311558cf03e74e50c0c7c
+        with:
+          terraform_version: 1.9
+          terraform_wrapper: false
+      - name: terraform validate
+        run: ./.pre-commit-hooks/terraform-validate.sh

--- a/.pre-commit-hooks/terraform-fmt.sh
+++ b/.pre-commit-hooks/terraform-fmt.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# terraform-fmt.sh — L65 pillar: check Terraform formatting across the monorepo
+# Returns non-zero if any .tf file is not canonical-formatted.
+set -euo pipefail
+
+dirs=$(find "$(git rev-parse --show-toplevel)" -name "*.tf" -not -path "*/.terraform/*" -exec dirname {} \; | sort -u)
+
+if [ -z "$dirs" ]; then
+  echo "✓ No Terraform directories found."
+  exit 0
+fi
+
+failed=0
+for d in $dirs; do
+  echo "→ terraform fmt -check -diff -recursive $d"
+  if ! terraform fmt -check -diff -recursive "$d"; then
+    echo "  ✗ $d contains unformatted files (run 'terraform fmt -recursive $d')"
+    failed=$((failed + 1))
+  else
+    echo "  ✓ $d is formatted"
+  fi
+done
+
+if [ "$failed" -gt 0 ]; then
+  echo "✗ $failed Terraform director(ies) need formatting fixes."
+  exit 1
+fi
+
+echo "✓ All Terraform files are canonical-formatted."

--- a/.pre-commit-hooks/terraform-validate.sh
+++ b/.pre-commit-hooks/terraform-validate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# terraform-validate.sh — L65 pillar: validate Terraform configurations in-tree
+# Runs `terraform init -backend=false` + `terraform validate` in each directory
+# that contains *.tf files.
+set -euo pipefail
+
+dirs=$(find "$(git rev-parse --show-toplevel)" -name "*.tf" -not -path "*/.terraform/*" -exec dirname {} \; | sort -u)
+
+if [ -z "$dirs" ]; then
+  echo "✓ No Terraform directories found."
+  exit 0
+fi
+
+failed=0
+for d in $dirs; do
+  echo "→ terraform init -backend=false && terraform validate $d"
+  pushd "$d" >/dev/null
+  if ! terraform init -backend=false 2>/dev/null; then
+    echo "  ✗ terraform init failed in $d"
+    popd >/dev/null
+    failed=$((failed + 1))
+    continue
+  fi
+  if ! terraform validate; then
+    echo "  ✗ terraform validate failed in $d"
+    failed=$((failed + 1))
+  else
+    echo "  ✓ $d is valid"
+  fi
+  popd >/dev/null
+done
+
+if [ "$failed" -gt 0 ]; then
+  echo "✗ $failed Terraform director(ies) have validation errors."
+  exit 1
+fi
+
+echo "✓ All Terraform configurations are valid."


### PR DESCRIPTION
## **User description**
Adds terraform-fmt + terraform-validate hooks + CI for L65 terraform pillar. 3 files, ~70 lines total.

## Changes

| File | Lines | Purpose |
|------|-------|---------|
| `.pre-commit-hooks/terraform-fmt.sh` | 29 | Runs `terraform fmt -check -diff -recursive` across all directories containing `.tf` files. Fails CI if any file is not canonical-formatted. |
| `.pre-commit-hooks/terraform-validate.sh` | 38 | Runs `terraform init -backend=false` + `terraform validate` in each directory with `.tf` files. Fails CI on validation errors. |
| `.github/workflows/terraform-pr.yml` | 40 | Two-job workflow (fmt + validate) triggered on PRs touching `*.tf`, `*.tfvars`, `*.hcl`, or the hooks themselves. Uses `hashicorp/setup-terraform` v1.9. |

## How it works

Both hooks discover all Terraform directories in the monorepo by globbing for `*.tf` files (excluding `.terraform/`), deduplicating parent directories, then running the relevant `terraform` subcommand. Exit code is non-zero if any directory fails, which gating CI will pick up.

## Related

- L65 terraform pillar


___

## **CodeAnt-AI Description**
**Run Terraform formatting and validation checks on pull requests**

### What Changed
- Pull requests that touch Terraform files now run two checks: formatting and configuration validation
- Formatting issues are reported with the directories that need changes, so they can be fixed before merge
- Validation now checks each Terraform directory in place and reports which directory failed
- If no Terraform files are found, the checks exit cleanly instead of failing

### Impact
`✅ Fewer Terraform formatting mistakes`
`✅ Earlier detection of broken Terraform configurations`
`✅ Clearer PR feedback for infrastructure changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
