### PR TITLE
feat(v44-T2): CI workflow templates for 10 pheno-* sub-repos

### DIFF
--- a/.github/workflows-templates/pheno-agents-md.yml
+++ b/.github/workflows-templates/pheno-agents-md.yml
@@ -1,0 +1,18 @@
+# Template: ci.yml for pheno-agents-md
+name: ci-pheno-agents-md
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo build --workspace
+      - run: cargo test --workspace
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo deny check

--- a/.github/workflows-templates/pheno-cargo-template.yml
+++ b/.github/workflows-templates/pheno-cargo-template.yml
@@ -1,0 +1,18 @@
+# Template: ci.yml for pheno-cargo-template
+name: ci-pheno-cargo-template
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo build --workspace
+      - run: cargo test --workspace
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo deny check

--- a/.github/workflows-templates/pheno-cli-base.yml
+++ b/.github/workflows-templates/pheno-cli-base.yml
@@ -1,0 +1,18 @@
+# Template: ci.yml for pheno-cli-base
+name: ci-pheno-cli-base
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo build --workspace
+      - run: cargo test --workspace
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo deny check

--- a/.github/workflows-templates/pheno-data.yml
+++ b/.github/workflows-templates/pheno-data.yml
@@ -1,0 +1,18 @@
+# Template: ci.yml for pheno-data
+name: ci-pheno-data
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo build --workspace
+      - run: cargo test --workspace
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo deny check

--- a/.github/workflows-templates/pheno-events.yml
+++ b/.github/workflows-templates/pheno-events.yml
@@ -1,0 +1,18 @@
+# Template: ci.yml for pheno-events
+name: ci-pheno-events
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo build --workspace
+      - run: cargo test --workspace
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo deny check

--- a/.github/workflows-templates/pheno-flags.yml
+++ b/.github/workflows-templates/pheno-flags.yml
@@ -1,0 +1,18 @@
+# Template: ci.yml for pheno-flags
+name: ci-pheno-flags
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo build --workspace
+      - run: cargo test --workspace
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo deny check

--- a/.github/workflows-templates/pheno-llms-txt.yml
+++ b/.github/workflows-templates/pheno-llms-txt.yml
@@ -1,0 +1,18 @@
+# Template: ci.yml for pheno-llms-txt
+name: ci-pheno-llms-txt
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo build --workspace
+      - run: cargo test --workspace
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo deny check

--- a/.github/workflows-templates/pheno-pydantic-models.yml
+++ b/.github/workflows-templates/pheno-pydantic-models.yml
@@ -1,0 +1,18 @@
+# Template: ci.yml for pheno-pydantic-models
+name: ci-pheno-pydantic-models
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo build --workspace
+      - run: cargo test --workspace
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo deny check

--- a/.github/workflows-templates/pheno-scaffold-kit.yml
+++ b/.github/workflows-templates/pheno-scaffold-kit.yml
@@ -1,0 +1,18 @@
+# Template: ci.yml for pheno-scaffold-kit
+name: ci-pheno-scaffold-kit
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo build --workspace
+      - run: cargo test --workspace
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo deny check

--- a/.github/workflows-templates/pheno-tracing.yml
+++ b/.github/workflows-templates/pheno-tracing.yml
@@ -1,0 +1,18 @@
+# Template: ci.yml for pheno-tracing
+name: ci-pheno-tracing
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo build --workspace
+      - run: cargo test --workspace
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo deny check


### PR DESCRIPTION
### v44 Hardening T2: CI workflow templates

Adds `.github/workflows-templates/` with per-repo ci.yml templates for 10 pheno-* sub-repos that don't have their own CI yet:

Built-in template targets: pheno-data, pheno-events, pheno-tracing, pheno-flags, pheno-cli-base, pheno-llms-txt, pheno-pydantic-models, pheno-scaffold-kit, pheno-agents-md, pheno-cargo-template

Each template: build + test + fmt + clippy + deny on push/PR to main.

**Cycle:** 31 (v44 hardening)
**Branch:** feat/v44-hardening-T2-ci-templates-20260628