### PR TITLE
chore(security): gitignore .credentials.json (P0.5 only — repo is OmniRoute/TS, not a Rust forgecode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,8 @@ security-analysis/
 
 # Deploy workflow (contains sensitive VPS credentials)
 clipr/
+# Local credential store — never commit
+.credentials.json
 app.log
 *.tgz
 .gh-discussions.json


### PR DESCRIPTION
## Summary

This branch was opened to execute "Phase P0 — de-fork the doc/governance surface" of a *forgecode* ("34-crate Rust workspace") overhaul plan. On inspection, **the task premise does not match this repository**:

- This repo is **OmniRoute** — a 100% TypeScript / Next.js 16 monorepo (`src/`, `open-sse/`, `electron/`), a fork of 9router. There is **no `Cargo.toml`, no `crates/`, and zero `.rs` files** anywhere; `cargo build` cannot run here.
- The referenced plan `docs/sessions/20260628-forgecode-overhaul/03_DAG_WBS.md` **does not exist**.
- `docs/SSOT.md` is correctly titled *OmniRoute* and already states `Rust: N/A` — accurate. Rewriting it to describe a Rust workspace would make it false.
- The README is the OmniRoute AI-DD metaproject README, not "ForgeCode Evals — TypeScript evaluation/bounty-cli".
- The remote is `KooshaPari/OmniRoute`, not `KooshaPari/forgecode`.

Per the repo's honesty/AI-DD posture and the global "fail loudly, never fabricate" rule, P0.1–P0.4 were **not** executed — doing so literally would have introduced false Rust/crate claims and replaced a working npm-based `Justfile` with `cargo` recipes that can never run.

## What this PR actually does (the one P0 task that is correct for OmniRoute)

**P0.5** — Add `.credentials.json` to `.gitignore` so the local credential store is never committed.

## Verification

- `git check-ignore .credentials.json` → matches (exit 0).
- 0o600 regression test `@omniroute/opencode-plugin/tests/disk-snapshot-perms.test.ts` → **1 pass / 0 fail**.

No code or doc fabrication; `.gitignore` is the only changed file.