### PR TITLE
refactor(executors): extract stripVersionedToolModelPrefix leaf (PR-016)

### DIFF
--- a/open-sse/executors/__tests__/stripVersionedToolModelPrefix.test.ts
+++ b/open-sse/executors/__tests__/stripVersionedToolModelPrefix.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for the extracted `stripVersionedToolModelPrefix` leaf (PR-016).
+ *
+ * Extracted from `open-sse/executors/base.ts` (the function used to live
+ * inline at line ~378 in the v3.8.34 tag) and given a dedicated test
+ * surface so the prefix-stripping behavior on versioned built-in tool
+ * entries is locked in.
+ *
+ * The function is intentionally narrow: it only touches tool entries whose
+ * `type` matches the Anthropic versioned-built-in pattern
+ * `^[a-z][a-z0-9_]*_\d{8}$` AND whose `model` is a string containing a `/`.
+ * Every test below pins one of those invariants or one of the edge cases
+ * the prefix-stripping code must remain safe against.
+ */
+import { describe, it, expect } from "vitest";
+import { stripVersionedToolModelPrefix } from "../stripVersionedToolModelPrefix.ts";
+
+describe("stripVersionedToolModelPrefix", () => {
+  // ---------- empty / non-array inputs ----------
+
+  it("empty array is a no-op", () => {
+    const tools: unknown[] = [];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools).toEqual([]);
+  });
+
+  it("non-array input is silently ignored (does not throw)", () => {
+    expect(() => stripVersionedToolModelPrefix(undefined)).not.toThrow();
+    expect(() => stripVersionedToolModelPrefix(null)).not.toThrow();
+    expect(() => stripVersionedToolModelPrefix("claude-opus-4-8")).not.toThrow();
+    expect(() => stripVersionedToolModelPrefix(42)).not.toThrow();
+    expect(() =>
+      stripVersionedToolModelPrefix({ type: "advisor_20260301" }),
+    ).not.toThrow();
+  });
+
+  // ---------- plain (unprefixed) models ----------
+
+  it("plain unprefixed model on a versioned tool is left unchanged", () => {
+    const tools = [{ type: "advisor_20260301", model: "claude-opus-4-8" }];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-opus-4-8");
+  });
+
+  // ---------- versioned-name / provider-prefix cases ----------
+
+  it("strips a single provider prefix from a versioned tool", () => {
+    const tools = [{ type: "advisor_20260301", model: "cc/claude-opus-4-8" }];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-opus-4-8");
+  });
+
+  it("strips a provider prefix from another versioned tool (bash)", () => {
+    const tools = [
+      { type: "bash_20250124", model: "anthropic/claude-3-5-sonnet" },
+    ];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-3-5-sonnet");
+  });
+
+  it("strips the last segment of a multi-segment prefix", () => {
+    // `t.model.split("/").pop()` is greedy on the last `/`, so a path-style
+    // provider name is collapsed to just the trailing model id.
+    const tools = [
+      { type: "advisor_20260301", model: "team-a/cc/claude-opus-4-8" },
+    ];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-opus-4-8");
+  });
+
+  it("strips prefix on a model whose name itself contains dashes", () => {
+    const tools = [
+      {
+        type: "advisor_20260301",
+        model: "cc/claude-3-5-sonnet-20241022",
+      },
+    ];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-3-5-sonnet-20241022");
+  });
+
+  it("strips prefix on a model whose name contains many dashes", () => {
+    const tools = [
+      {
+        type: "advisor_20260301",
+        model: "cc/claude-opus-4-8-extended-context",
+      },
+    ];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-opus-4-8-extended-context");
+  });
+
+  // ---------- type-pattern gating ----------
+
+  it("non-versioned tool type is left untouched even with a prefix", () => {
+    // `web_search` (no `_YYYYMMDD` suffix) is a custom tool, not a
+    // versioned built-in. The stripper must not touch it.
+    const tools = [{ type: "web_search", model: "cc/claude-opus-4-8" }];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("cc/claude-opus-4-8");
+  });
+
+  it("non-versioned tool type with non-8-digit date suffix is left untouched", () => {
+    // 6 digits and 9 digits both fail the `_\\d{8}$` anchor.
+    const six = [{ type: "advisor_202603", model: "cc/claude-opus-4-8" }];
+    stripVersionedToolModelPrefix(six);
+    expect(six[0].model).toBe("cc/claude-opus-4-8");
+
+    const nine = [
+      { type: "advisor_202603011", model: "cc/claude-opus-4-8" },
+    ];
+    stripVersionedToolModelPrefix(nine);
+    expect(nine[0].model).toBe("cc/claude-opus-4-8");
+  });
+
+  it("versioned tool type whose name starts with a digit is not matched", () => {
+    // `^[a-z]` requires a leading letter.
+    const tools = [
+      { type: "1dvisor_20260301", model: "cc/claude-opus-4-8" },
+    ];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("cc/claude-opus-4-8");
+  });
+
+  it("versioned tool type with uppercase letter is not matched", () => {
+    // `[a-z]` is lowercase only; `Bash_20250124` must not be classified as
+    // a versioned built-in.
+    const tools = [
+      { type: "Bash_20250124", model: "cc/claude-3-5-sonnet" },
+    ];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("cc/claude-3-5-sonnet");
+  });
+
+  // ---------- missing / non-string model ----------
+
+  it("versioned tool without a model field is left untouched", () => {
+    const tools = [{ type: "advisor_20260301" }];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBeUndefined();
+  });
+
+  it("versioned tool with non-string model is left untouched", () => {
+    const tools: Array<Record<string, unknown>> = [
+      { type: "advisor_20260301", model: 42 },
+      { type: "advisor_20260301", model: null },
+      { type: "advisor_20260301", model: { id: "x" } },
+    ];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe(42);
+    expect(tools[1].model).toBeNull();
+    expect(tools[2].model).toEqual({ id: "x" });
+  });
+
+  it("versioned tool whose model has no slash is left untouched", () => {
+    const tools = [{ type: "advisor_20260301", model: "claude-opus-4-8" }];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-opus-4-8");
+  });
+
+  it("versioned tool with empty-string model is left untouched", () => {
+    // `""` does not contain `/`, so the stripper skips it.
+    const tools = [{ type: "advisor_20260301", model: "" }];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("");
+  });
+
+  // ---------- edge cases: leading, trailing, multiple slashes ----------
+
+  it("trailing slash in model collapses to an empty string", () => {
+    // `"cc/".split("/").pop()` returns `""` — that is the literal
+    // behavior of the function, so we lock it in.
+    const tools = [{ type: "advisor_20260301", model: "cc/" }];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("");
+  });
+
+  it("leading slash in model becomes the only segment", () => {
+    // `"/claude-opus-4-8".split("/").pop()` is `"claude-opus-4-8"`.
+    const tools = [{ type: "advisor_20260301", model: "/claude-opus-4-8" }];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-opus-4-8");
+  });
+
+  it("lone slash in model collapses to an empty string", () => {
+    const tools = [{ type: "advisor_20260301", model: "/" }];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("");
+  });
+
+  it("multiple consecutive slashes collapse to the final segment", () => {
+    // The function only keeps the final segment; intermediate empties are
+    // dropped, but the very last segment survives.
+    const tools = [
+      { type: "advisor_20260301", model: "a//b///claude-opus-4-8" },
+    ];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-opus-4-8");
+  });
+
+  // ---------- batch / ordering / idempotency ----------
+
+  it("multiple versioned tools in one array are each stripped", () => {
+    const tools = [
+      { type: "advisor_20260301", model: "cc/claude-opus-4-8" },
+      { type: "bash_20250124", model: "anthropic/claude-3-5-sonnet" },
+      { type: "web_search_20250305", model: "openai/gpt-4o" },
+    ];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-opus-4-8");
+    expect(tools[1].model).toBe("claude-3-5-sonnet");
+    expect(tools[2].model).toBe("gpt-4o");
+  });
+
+  it("mixed array: only versioned types get stripped", () => {
+    const tools = [
+      { type: "web_search", model: "cc/claude-opus-4-8" }, // custom → untouched
+      { type: "advisor_20260301", model: "cc/claude-opus-4-8" }, // versioned → stripped
+      { type: "bash_20250124", model: "claude-3-5-sonnet" }, // versioned, no prefix → untouched
+      { type: "memory_20250818", model: "team/memory-1" }, // versioned → stripped
+    ];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("cc/claude-opus-4-8");
+    expect(tools[1].model).toBe("claude-opus-4-8");
+    expect(tools[2].model).toBe("claude-3-5-sonnet");
+    expect(tools[3].model).toBe("memory-1");
+  });
+
+  it("mutates the input array in place (no return value)", () => {
+    const tools = [{ type: "advisor_20260301", model: "cc/claude-opus-4-8" }];
+    const ref = tools;
+    const ret = stripVersionedToolModelPrefix(tools);
+    expect(ret).toBeUndefined();
+    expect(tools).toBe(ref);
+    expect(tools[0].model).toBe("claude-opus-4-8");
+  });
+
+  it("repeated calls are idempotent once stripped", () => {
+    const tools = [{ type: "advisor_20260301", model: "cc/claude-opus-4-8" }];
+    stripVersionedToolModelPrefix(tools);
+    stripVersionedToolModelPrefix(tools);
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-opus-4-8");
+  });
+
+  // ---------- property preservation ----------
+
+  it("extra fields on a tool entry are preserved", () => {
+    const tools = [
+      {
+        type: "advisor_20260301",
+        model: "cc/claude-opus-4-8",
+        name: "advisor",
+        input_schema: { type: "object" },
+        cache_control: { type: "ephemeral" },
+      },
+    ];
+    stripVersionedToolModelPrefix(tools);
+    expect(tools[0].model).toBe("claude-opus-4-8");
+    expect(tools[0].name).toBe("advisor");
+    expect(tools[0].input_schema).toEqual({ type: "object" });
+    expect(tools[0].cache_control).toEqual({ type: "ephemeral" });
+  });
+});

--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -61,6 +61,7 @@ import {
   stainlessRuntimeVersion,
   stripProxyToolPrefix,
 } from "./claudeIdentity.ts";
+import { stripVersionedToolModelPrefix } from "./stripVersionedToolModelPrefix.ts";
 
 /**
  * Sanitizes a custom API path to prevent path traversal attacks.
@@ -417,27 +418,6 @@ export function sanitizeReasoningEffortForProvider(
   }
 
   return body;
-}
-
-/**
- * Strip the OmniRoute provider prefix from versioned built-in tool model
- * fields (e.g. `cc/claude-opus-4-8` → `claude-opus-4-8`). Versioned built-in
- * tool types carry an 8-digit date suffix (`advisor_20260301`, `bash_20250124`);
- * the real Claude CLI sends a bare model id there, never a prefixed one, so a
- * leaked OmniRoute prefix makes Anthropic reject the request. Mutates in place.
- */
-export function stripVersionedToolModelPrefix(tools: unknown): void {
-  if (!Array.isArray(tools)) return;
-  for (const t of tools as Array<Record<string, unknown>>) {
-    if (
-      typeof t.type === "string" &&
-      /^[a-z][a-z0-9_]*_\d{8}$/.test(t.type) &&
-      typeof t.model === "string" &&
-      t.model.includes("/")
-    ) {
-      t.model = t.model.split("/").pop();
-    }
-  }
 }
 
 /**

--- a/open-sse/executors/stripVersionedToolModelPrefix.ts
+++ b/open-sse/executors/stripVersionedToolModelPrefix.ts
@@ -1,0 +1,42 @@
+/**
+ * Strip the OmniRoute provider prefix from versioned built-in tool model
+ * fields (e.g. `cc/claude-opus-4-8` → `claude-opus-4-8`).
+ *
+ * Anthropic's `tools[]` entries with a *versioned* built-in `type` (e.g.
+ * `advisor_20260301`, `bash_20250124`) carry a `model` field on the tool
+ * itself. The real Claude CLI always sends a bare model id there (e.g.
+ * `claude-opus-4-8`) — never a `<provider>/<model>` prefixed one. When a
+ * request enters OmniRoute with an OmniRoute-style provider prefix still
+ * attached, the upstream Anthropic API rejects the request. This helper
+ * surgically removes the prefix on those specific tool entries.
+ *
+ * Behavior:
+ *   - Non-array input is silently ignored.
+ *   - Each entry is checked: only when `type` matches
+ *     `^[a-z][a-z0-9_]*_\d{8}$` (lowercase name, optional digits/underscores,
+ *     underscore, 8 digits) AND `model` is a string containing `/`, is the
+ *     prefix stripped.
+ *   - The match is greedy on the *last* `/`: `t.model.split("/").pop()`,
+ *     so `cc/claude-opus-4-8` → `claude-opus-4-8`,
+ *     `a/b/claude-opus-4-8` → `claude-opus-4-8`.
+ *   - Entries whose `type` is not a versioned built-in tool are left
+ *     untouched (e.g. `web_search_20250305` is matched; `web_search` is not).
+ *   - Mutates the input array in place; returns nothing.
+ *
+ * @param tools - The `tools` array from an Anthropic request body, treated
+ *                as `unknown` to keep this helper a no-op for unrelated
+ *                call sites that pass non-tool values.
+ */
+export function stripVersionedToolModelPrefix(tools: unknown): void {
+  if (!Array.isArray(tools)) return;
+  for (const t of tools as Array<Record<string, unknown>>) {
+    if (
+      typeof t.type === "string" &&
+      /^[a-z][a-z0-9_]*_\d{8}$/.test(t.type) &&
+      typeof t.model === "string" &&
+      t.model.includes("/")
+    ) {
+      t.model = t.model.split("/").pop();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Extract the inline `stripVersionedToolModelPrefix` function out of `open-sse/executors/base.ts` into a dedicated sibling module and re-import it from base.ts. Adds a focused vitest suite that locks in the prefix-stripping behavior on versioned built-in tool entries.

## Why

`base.ts` is the central import hub for the executor package; even a small leaf function pulls the whole file into every consumer's type-check surface. Pulling this leaf out:

* shrinks `base.ts` by 21 lines (1392 lines, down from 1412),
* lets the prefix-stripping behavior live next to a dedicated test file,
* makes the leaf independently reviewable,
* continues the leaf-extraction series (PR-014 `reasoningEffortMaps`, PR-015 `hasActiveClaudeThinking`, this PR).

## What changed

* **New:** `open-sse/executors/stripVersionedToolModelPrefix.ts` — the function, with a JSDoc block that documents every gating invariant (type pattern, model string, slash presence) and the in-place mutation semantics.
* **New:** `open-sse/executors/__tests__/stripVersionedToolModelPrefix.test.ts` — 24 `it()` blocks / 25 vitest cases covering:
  * empty / non-array inputs (no throw, no-op)
  * plain unprefixed models left unchanged
  * single and multi-segment provider-prefix stripping (`cc/x`, `team-a/cc/x`)
  * models with embedded dashes (claude-3-5-sonnet-20241022, claude-opus-4-8-extended-context)
  * type-pattern gating (custom `web_search` not touched; `Bash_20250124` rejected for uppercase; `1dvisor_20260301` rejected for leading digit; 6- and 9-digit date suffixes rejected)
  * missing or non-string `model` left alone
  * trailing slash, leading slash, lone slash, multiple consecutive slashes — `.split("/").pop()` semantics locked in
  * multi-entry arrays, mixed entries, idempotency, property preservation
* **Modified:** `open-sse/executors/base.ts` — adds `import { stripVersionedToolModelPrefix } from "./stripVersionedToolModelPrefix.ts";` and removes the inline function body. Net change: -21 / +1.

## Verification

* `npx vitest run --config vitest.config.ts open-sse/executors/__tests__/stripVersionedToolModelPrefix.test.ts` → **25/25 passed**
* `npx tsc --noEmit -p tsconfig.typecheck-core.json` → clean (exit 0, no diagnostics)
* The call site in `base.ts` (line 910) is unchanged — this is a pure refactor with no behavior change.