### PR TITLE
feat(combo): add /api/combos/exhaustion/skip-reason route (PR-022)

### DIFF
--- a/src/app/api/combos/exhaustion/skip-reason/route.ts
+++ b/src/app/api/combos/exhaustion/skip-reason/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { getExhaustedTargetSkipReason } from "@omniroute/open-sse/services/combo/comboPredicates.ts";
+import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+
+type ResolvedComboTargetShape = Parameters<typeof getExhaustedTargetSkipReason>[0];
+
+/**
+ * Parse a comma-separated query value into a ReadonlySet<string>.
+ *
+ * Empty / missing values yield an empty set so `getExhaustedTargetSkipReason`
+ * can be exercised with the no-exhaustion inputs without sending any query
+ * params. Whitespace around each entry is trimmed; empty entries
+ * (e.g. trailing commas) are skipped, since `getExhaustedTargetSkipReason`
+ * keys `exhaustedConnections` on `provider:connectionId` pairs and a stray
+ * empty key would silently match the target. (#1731v2)
+ */
+function parseStringSet(raw: string | null): ReadonlySet<string> {
+  if (!raw) return new Set();
+  const entries = raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  return new Set(entries);
+}
+
+/**
+ * GET /api/combos/exhaustion/skip-reason
+ *
+ * Thin management-auth wrapper around the pure
+ * `getExhaustedTargetSkipReason` predicate from
+ * `open-sse/services/combo/comboPredicates.ts`. Returns the same
+ * skip-reason string the in-process combo dispatchers (handleComboChat /
+ * handleRoundRobinCombo) log before falling through to the next target, so
+ * operators can debug "why did this combo target get skipped?" by replaying
+ * the input the dispatcher saw.
+ *
+ * Query params:
+ *   model               (required)  — ResolvedComboTarget.modelStr
+ *   provider            (required)  — ResolvedComboTarget.provider
+ *   connectionId        (optional)  — ResolvedComboTarget.connectionId
+ *   exhaustedProviders  (optional, CSV) — entries of the #1731 exhaustedProviders set
+ *   exhaustedConnections (optional, CSV) — entries of the #1731v2 exhaustedConnections set
+ *
+ * Response: `{ model, provider, connectionId, exhaustedProviders, exhaustedConnections, reason }`
+ *   `reason` is the same string the dispatcher would have logged, or `null`
+ *   when nothing in the supplied sets matches the target.
+ */
+export async function GET(request: Request) {
+  const authError = await requireManagementAuth(request);
+  if (authError) return authError;
+
+  let url: URL;
+  try {
+    url = new URL(request.url);
+  } catch {
+    return NextResponse.json({ error: "Invalid request URL" }, { status: 400 });
+  }
+
+  const model = url.searchParams.get("model")?.trim() ?? "";
+  const provider = url.searchParams.get("provider")?.trim() ?? "";
+  const connectionIdRaw = url.searchParams.get("connectionId");
+  const connectionId = connectionIdRaw === null ? null : connectionIdRaw.trim();
+
+  if (!model) {
+    return NextResponse.json(
+      { error: "Missing required query parameter 'model'" },
+      { status: 400 }
+    );
+  }
+  if (!provider) {
+    return NextResponse.json(
+      { error: "Missing required query parameter 'provider'" },
+      { status: 400 }
+    );
+  }
+
+  const exhaustedProviders = parseStringSet(url.searchParams.get("exhaustedProviders"));
+  const exhaustedConnections = parseStringSet(url.searchParams.get("exhaustedConnections"));
+
+  // Build the smallest target shape `getExhaustedTargetSkipReason` actually
+  // reads. The function only consumes `provider`, `modelStr`, and
+  // `connectionId` (#1731 / #1731v2) — see comboPredicates.ts. The remaining
+  // fields are populated so the returned object is a self-describing record
+  // operators can feed back into the diagnostic UI.
+  const target: ResolvedComboTargetShape = {
+    kind: "model",
+    stepId: "skip-reason-diagnostic",
+    executionKey: "skip-reason-diagnostic",
+    modelStr: model,
+    provider,
+    providerId: null,
+    connectionId: connectionId && connectionId.length > 0 ? connectionId : null,
+    weight: 1,
+    label: null,
+  };
+
+  const reason = getExhaustedTargetSkipReason(target, exhaustedProviders, exhaustedConnections);
+
+  return NextResponse.json({
+    model,
+    provider,
+    connectionId: target.connectionId,
+    exhaustedProviders: Array.from(exhaustedProviders),
+    exhaustedConnections: Array.from(exhaustedConnections),
+    reason,
+  });
+}

--- a/tests/unit/combo/combo-exhaustion-skip-reason-route.test.ts
+++ b/tests/unit/combo/combo-exhaustion-skip-reason-route.test.ts
@@ -1,0 +1,234 @@
+// tests/unit/combo/combo-exhaustion-skip-reason-route.test.ts
+// Tests for the GET /api/combos/exhaustion/skip-reason route handler — a thin
+// management-auth wrapper around the pure `getExhaustedTargetSkipReason`
+// predicate (open-sse/services/combo/comboPredicates.ts). The predicate's own
+// behavior is locked by combo-exhausted-skip.test.ts; this file focuses on
+// the route's wire shape + HTTP-level validation + auth gating.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const routePath = path.join(
+  repoRoot,
+  "src/app/api/combos/exhaustion/skip-reason/route.ts"
+);
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-exh-skip-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = "test-api-key-secret";
+
+const core = await import("../../../src/lib/db/core.ts");
+const localDb = await import("../../../src/lib/localDb.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+function buildRoute() {
+  return import(
+    // Path is repo-root-relative at runtime; tests live at tests/unit/combo/
+    // so we walk up 3 levels to the project root and back into src/app/...
+    "../../../src/app/api/combos/exhaustion/skip-reason/route.ts"
+  );
+}
+
+function skipAuthRequest(url: string): Request {
+  return new Request(url);
+}
+
+test("GET /api/combos/exhaustion/skip-reason exists and exports GET", () => {
+  const source = fs.readFileSync(routePath, "utf8");
+  assert.match(source, /export async function GET/);
+  assert.match(
+    source,
+    /requireManagementAuth/,
+    "route must require management auth (matches sibling /api/combos routes)"
+  );
+});
+
+test("returns reason: null when nothing is exhausted", async () => {
+  await localDb.updateSettings({ requireLogin: false });
+
+  const { GET } = await buildRoute();
+  const response = await GET(
+    skipAuthRequest(
+      "https://example.com/api/combos/exhaustion/skip-reason?model=openai/gpt-4o&provider=openai&connectionId=conn-1"
+    )
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.reason, null);
+  assert.deepEqual(body.exhaustedProviders, []);
+  assert.deepEqual(body.exhaustedConnections, []);
+  assert.equal(body.model, "openai/gpt-4o");
+  assert.equal(body.provider, "openai");
+  assert.equal(body.connectionId, "conn-1");
+});
+
+test("returns the #1731 provider-exhaustion reason when provider is exhausted", async () => {
+  await localDb.updateSettings({ requireLogin: false });
+
+  const { GET } = await buildRoute();
+  const response = await GET(
+    skipAuthRequest(
+      "https://example.com/api/combos/exhaustion/skip-reason" +
+        "?model=openai/gpt-4o&provider=openai&connectionId=conn-1" +
+        "&exhaustedProviders=openai,anthropic"
+    )
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(
+    body.reason,
+    "Skipping openai/gpt-4o \u2014 provider openai marked exhausted this request (#1731)"
+  );
+  assert.deepEqual(body.exhaustedProviders, ["openai", "anthropic"]);
+});
+
+test("returns the #1731v2 connection-pair reason when provider:connection is exhausted", async () => {
+  await localDb.updateSettings({ requireLogin: false });
+
+  const { GET } = await buildRoute();
+  const response = await GET(
+    skipAuthRequest(
+      "https://example.com/api/combos/exhaustion/skip-reason" +
+        "?model=openai/gpt-4o&provider=openai&connectionId=conn-1" +
+        "&exhaustedConnections=openai:conn-1,anthropic:conn-2"
+    )
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(
+    body.reason,
+    "Skipping openai/gpt-4o \u2014 connection conn-1 for provider openai had connection error (#1731v2)"
+  );
+});
+
+test("connection-pair exhaustion takes precedence over provider exhaustion", async () => {
+  await localDb.updateSettings({ requireLogin: false });
+
+  const { GET } = await buildRoute();
+  const response = await GET(
+    skipAuthRequest(
+      "https://example.com/api/combos/exhaustion/skip-reason" +
+        "?model=openai/gpt-4o&provider=openai&connectionId=conn-1" +
+        "&exhaustedProviders=openai" +
+        "&exhaustedConnections=openai:conn-1"
+    )
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.ok(
+    body.reason?.includes("(#1731v2)"),
+    "connection-level skip must win over provider-level skip (#1731v2 precedence)"
+  );
+  assert.ok(!body.reason?.includes("(#1731)"));
+});
+
+test("connectionId is optional and omitted sets normalize to null", async () => {
+  await localDb.updateSettings({ requireLogin: false });
+
+  const { GET } = await buildRoute();
+  const response = await GET(
+    skipAuthRequest(
+      "https://example.com/api/combos/exhaustion/skip-reason" +
+        "?model=openai/gpt-4o&provider=openai" +
+        "&exhaustedProviders=openai"
+    )
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(
+    body.reason,
+    "Skipping openai/gpt-4o \u2014 provider openai marked exhausted this request (#1731)"
+  );
+  assert.equal(body.connectionId, null);
+});
+
+test("unrelated connection of an exhausted pair is not skipped", async () => {
+  await localDb.updateSettings({ requireLogin: false });
+
+  const { GET } = await buildRoute();
+  const response = await GET(
+    skipAuthRequest(
+      "https://example.com/api/combos/exhaustion/skip-reason" +
+        "?model=openai/gpt-4o&provider=openai&connectionId=conn-2" +
+        "&exhaustedConnections=openai:conn-1"
+    )
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.reason, null);
+});
+
+test("400 when 'model' query param is missing", async () => {
+  await localDb.updateSettings({ requireLogin: false });
+
+  const { GET } = await buildRoute();
+  const response = await GET(
+    skipAuthRequest(
+      "https://example.com/api/combos/exhaustion/skip-reason?provider=openai"
+    )
+  );
+
+  assert.equal(response.status, 400);
+  const body = await response.json();
+  assert.match(String(body.error), /model/);
+});
+
+test("400 when 'provider' query param is missing", async () => {
+  await localDb.updateSettings({ requireLogin: false });
+
+  const { GET } = await buildRoute();
+  const response = await GET(
+    skipAuthRequest(
+      "https://example.com/api/combos/exhaustion/skip-reason?model=openai/gpt-4o"
+    )
+  );
+
+  assert.equal(response.status, 400);
+  const body = await response.json();
+  assert.match(String(body.error), /provider/);
+});
+
+test("trims whitespace and skips empty entries in CSV set inputs", async () => {
+  // Reproduces the documented contract: trailing commas / stray whitespace
+  // must NOT silently match the target via an empty entry.
+  await localDb.updateSettings({ requireLogin: false });
+
+  const { GET } = await buildRoute();
+  const response = await GET(
+    skipAuthRequest(
+      "https://example.com/api/combos/exhaustion/skip-reason" +
+        "?model=openai/gpt-4o&provider=openai&connectionId=conn-1" +
+        "&exhaustedProviders=%20openai%20,,%20%20,anthropic" +
+        "&exhaustedConnections=%20,:conn-1,openai:conn-1"
+    )
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  // The actual skip reason is the #1731v2 connection-match — we just assert
+  // no spurious match was generated from the empty / whitespace-only entries.
+  assert.ok(body.reason?.includes("(#1731v2)"));
+});


### PR DESCRIPTION
## Summary

Add a management-authenticated REST route `GET /api/combos/exhaustion/skip-reason` that wraps the pure `getExhaustedTargetSkipReason` predicate from `open-sse/services/combo/comboPredicates.ts`, so operators can replay a combo dispatcher's decision and see exactly why a given target was skipped on a per-request basis.

## Context

The in-process combo dispatchers (`handleComboChat` / `handleRoundRobinCombo`) call `getExhaustedTargetSkipReason` to decide whether a target should be skipped before being tried (#1731 provider-level, #1731v2 connection-pair). The predicate returns a human-readable `reason` string that the dispatcher logs, but until now there was no way to invoke it from outside the request loop — debugging "why did this combo target get skipped?" required attaching a debugger or adding temporary logging.

This PR exposes that exact same predicate as a thin GET endpoint so operators can POST the inputs back at it after the fact.

## Changes

- **`src/app/api/combos/exhaustion/skip-reason/route.ts`** (new, 107 lines)
  - `GET` handler, gated by `requireManagementAuth` (matches sibling `/api/combos/*` routes).
  - Required query params: `model`, `provider`. Optional: `connectionId`, `exhaustedProviders` (CSV), `exhaustedConnections` (CSV).
  - Builds the minimal `ResolvedComboTarget` shape (`provider`, `modelStr`, `connectionId` are the only fields the predicate reads) and returns the predicate's `reason` string verbatim — same string the dispatcher would have logged — or `null` when nothing in the supplied sets matches the target.
  - CSV parser trims whitespace and skips empty entries so a stray trailing comma can't produce a silently matching empty key against `exhaustedConnections` (#1731v2 contract).

- **`tests/unit/combo/combo-exhaustion-skip-reason-route.test.ts`** (new, 234 lines, 10 tests, all passing)
  - Wire shape (route file exports `GET`, requires management auth).
  - `null` when nothing is exhausted.
  - `#1731` provider-exhaustion reason string.
  - `#1731v2` connection-pair reason string.
  - Connection-pair takes precedence over provider-level.
  - `connectionId` is optional; omitted → `null` in the response.
  - A different `connectionId` of the same provider is NOT skipped on the connection check.
  - 400 when `model` is missing.
  - 400 when `provider` is missing.
  - CSV whitespace + empty entries are trimmed/skipped (no spurious match).

### Key Implementation Details

The predicate is imported directly from `@omniroute/open-sse/services/combo/comboPredicates.ts` (not via the `combo.ts` barrel) because the barrel only *consumes* `getExhaustedTargetSkipReason` — it does not re-export it. The route therefore reuses the same import path the existing characterization test (`combo-exhausted-skip.test.ts`) uses, which is locked by the existing test suite to prevent the predicate from drifting.

The route deliberately does NOT round-trip through `combo.ts` to avoid pulling in 3,000+ lines of dispatch logic, runtime state (rrState, semaphore, etc.), and DB dependencies. The whole point of exposing this is debug-time replay — so the route stays a thin pure wrapper.

## Use Cases

- After a failed combo request, an operator grabs the `exhaustedProviders` / `exhaustedConnections` set from the dispatcher logs and a target from the combo config, then re-runs them through the endpoint to get the exact skip reason that would have been logged.
- Verifying that the connection-pair precedence rule (#1731v2) is correctly applied without spinning up a full combo chat request.
- A future debug UI can call this endpoint to render a "skipped targets" panel.

## Testing

```bash
# Unit tests (10 cases, all pass)
cd C:\Users\koosh\OmniRoute-clean
npx cross-env DISABLE_SQLITE_AUTO_BACKUP=true node \
  --max-old-space-size=8192 \
  --import tsx \
  --import ./open-sse/utils/setupPolyfill.ts \
  --import ./tests/_setup/isolateDataDir.ts \
  --test --test-force-exit --test-concurrency=1 \
  tests/unit/combo/combo-exhaustion-skip-reason-route.test.ts

# Typecheck
npx tsc --pretty false -p tsconfig.typecheck-core.json

# Lint (only the new files)
npx eslint src/app/api/combos/exhaustion/skip-reason/route.ts \
  tests/unit/combo/combo-exhaustion-skip-reason-route.test.ts

# Smoke the endpoint against a running dev server
curl -G 'http://localhost:3000/api/combos/exhaustion/skip-reason' \
  --data-urlencode 'model=openai/gpt-4o' \
  --data-urlencode 'provider=openai' \
  --data-urlencode 'connectionId=conn-1' \
  --data-urlencode 'exhaustedProviders=openai' \
  --data-urlencode 'exhaustedConnections=openai:conn-1' \
  -H 'Cookie: <mgmt-session>'
# → { "reason": "Skipping openai/gpt-4o — connection conn-1 for provider openai had connection error (#1731v2)", ... }
```

The pre-existing characterization test `tests/unit/combo/combo-exhausted-skip.test.ts` (which locks the predicate itself) continues to pass, and no unrelated files were modified.

## Links

- Plan: `plans/2026-06-24-omniroute-100-pr-plan-v1.md`
- Predicate: `open-sse/services/combo/comboPredicates.ts`
- Predicate characterization tests (pre-existing): `tests/unit/combo/combo-exhausted-skip.test.ts`
- Sibling route patterns: `src/app/api/combos/auto/route.ts`, `src/app/api/combos/reorder/route.ts`, `src/app/api/combos/test/route.ts`
