### PR TITLE
fix(chatcore): wire getUpstreamErrorIdentifier leaf (orphan from PR #160)

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1,6 +1,7 @@
 import { injectMemoryAndSkills } from "./chatCore/memorySkillsInjection.ts";
 import { checkIdempotencyCache } from "./chatCore/idempotency.ts";
 import { checkSemanticCache } from "./chatCore/semanticCache.ts";
+import { getUpstreamErrorIdentifier } from "./chatCore/getUpstreamErrorIdentifier.ts";
 import { sanitizeChatRequestBody } from "./chatCore/sanitization.ts";
 import { buildExecutorClientHeaders } from "./chatCore/buildExecutorClientHeaders.ts";
 import { CORS_HEADERS } from "../utils/cors.ts";
@@ -1134,12 +1135,6 @@ function createStreamingErrorResult(
       },
     }),
   };
-}
-
-function getUpstreamErrorIdentifier(error: unknown): string | undefined {
-  if (!error || typeof error !== "object") return undefined;
-  const value = (error as { code?: unknown }).code;
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function wrapReadableStreamWithFinalize<T>(

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1390,7 +1390,6 @@ function attachLogMeta(
  * @param {string} options.connectionId - Connection ID for settings lookup
  */
 
-<<<<<<< HEAD
 /**
  * Module-level cache for upstream proxy config (shared across all requests).
  * 10s TTL prevents per-request DB lookups while staying fresh enough for setting changes.


### PR DESCRIPTION
## Summary
PR #160 (refactor(chatcore): extract getUpstreamErrorIdentifier leaf) added the leaf file + test but the inline helper in chatCore.ts:1139 was not deleted and chatCore.ts:4238 still calls the inline version. This fix wires the import, deletes the duplicate, and verifies the leaf tests pass.

## Test plan
- [x] getUpstreamErrorIdentifier.test.ts: 18/18 pass