### PR TITLE
feat(cc-parity): Responses API surface audit + tool_use/structured_outputs/cache_control

### DIFF
--- a/docs/reference/RESPONSES-API.md
+++ b/docs/reference/RESPONSES-API.md
@@ -1,0 +1,207 @@
+---
+title: "Responses API Feature Coverage"
+version: 1.0.0
+lastUpdated: 2026-07-01
+audience: engineers integrating OpenAI Responses / Claude Code / Codex CLI clients with OmniRoute
+---
+
+# Responses API Feature Coverage
+
+This document maps the OpenAI Responses API surface (`/v1/responses`, the
+protocol used by Claude Code and the Codex CLI) against OmniRoute's
+current implementation. It is a **coverage matrix**, not a marketing
+comparison — every cell links to the source file that implements (or
+neglects to implement) the feature.
+
+The transformer that converts upstream Chat-Completions SSE into the
+Responses API SSE protocol lives in
+[`open-sse/transformer/responsesTransformer.ts`](../../open-sse/transformer/responsesTransformer.ts).
+Request-side translation (Responses API → Chat Completions) lives in
+[`open-sse/translator/helpers/responsesApiHelper.ts`](../../open-sse/translator/helpers/responsesApiHelper.ts).
+
+## Legend
+
+| Symbol | Meaning |
+| ------ | ------- |
+| ✅     | Supported in current `main`, covered by tests |
+| 🟡     | Partially supported — request accepted, response degraded, or surface incomplete |
+| ❌     | Not implemented (no code path; client will see a 4xx, empty `output[]`, or unexpected stream shape) |
+| 🚧     | Implementation in progress in the linked PR |
+
+## Coverage matrix
+
+### Request shape (client → OmniRoute)
+
+| Feature | Status | Notes / source |
+| ------- | :----: | -------------- |
+| `model` (string) | ✅ | `open-sse/translator/helpers/responsesApiHelper.ts::convertResponsesApiFormat` — resolves to upstream model id. |
+| `input` (string) | ✅ | Promoted to a single user message. |
+| `input` (array of `message` / `function_call_output` items) | ✅ | Translated to Chat-Completions `messages[]`. |
+| `instructions` (system prompt) | ✅ | Prepended as a `developer`/`system` message. |
+| `stream: true` | ✅ | Triggers SSE; `createResponsesApiTransformStream` is the wire format. |
+| `stream: false` | ✅ | Non-streaming Responses body. |
+| `temperature`, `top_p`, `max_output_tokens` | ✅ | Mapped to Chat-Completions counterparts. |
+| `tools[]` (Chat-style function tools) | ✅ | `function_call` items emitted in `output[]` (see below). |
+| `tools[]` (hosted tools: `web_search`, `file_search`, `code_interpreter`, `image_generation`) | ❌ | Hosted tools are stripped by the translator; client must invoke the corresponding provider directly. |
+| `tool_choice` | 🟡 | Passed through as a string; the structured `tool_choice: {type: "function", name: ...}` form is not auto-translated and falls back to "auto". |
+| `parallel_tool_calls` | 🟡 | Accepted but ignored when combo routing picks a target that does not honor it. |
+| `response_format: { type: "text" }` | ✅ | No-op. |
+| `response_format: { type: "json_object" }` | 🟡 | Translated to `response_format: { type: "json_object" }` for OpenAI-shaped providers only. Anthropic, Gemini, and most local providers silently ignore. |
+| `response_format: { type: "json_schema", json_schema: ... }` (structured outputs) | 🚧 | Implemented in this PR: translator accepts `json_schema` and forwards it; the response `output` is annotated with `format: "json_schema"` so the client can validate. |
+| `metadata` | 🟡 | Stored on the request for logging, but not echoed back in `response.metadata`. |
+| `previous_response_id` (server-side state) | ❌ | OmniRoute is stateless across requests; clients must send the full transcript in `input[]`. |
+| `store: true` | ❌ | We never store Responses. `store: false` is the only effective mode. |
+| `truncation: "auto" | "disabled"` | 🟡 | Accepted; "auto" is forwarded as a system-level hint and may be downgraded by the upstream target. |
+| `user` (end-user identifier) | ✅ | Forwarded as a request tag. |
+| `prompt_cache_key` | 🚧 | Implemented in this PR: stored on the request and surfaced in `response.prompt_cache_key` so a client can verify cache hits. |
+| `prompt_cache_control: { type: "ephemeral" }` (per-block cache markers) | 🚧 | Implemented in this PR: input items with `cache_control` are passed through to the upstream target and reflected in `usage.cache_creation_input_tokens` / `usage.cache_read_input_tokens` when the upstream reports them. |
+| `reasoning: { effort: "low" \| "medium" \| "high" }` | 🟡 | Forwarded as a system hint; the model decides. No per-item `reasoning` items emitted. |
+
+### Response shape (OmniRoute → client)
+
+| Field | Status | Notes |
+| ----- | :----: | ----- |
+| `id` (`resp_…`) | ✅ | Stable across the stream. |
+| `object: "response"` | ✅ | |
+| `created_at` (unix epoch) | ✅ | |
+| `status: "in_progress" | "completed" | "failed"` | ✅ | Failed state is emitted when upstream errors mid-stream. |
+| `output[]` — `message` items | ✅ | Streaming deltas, dense final ordering. |
+| `output[]` — `function_call` items | ✅ | Stable since PR #721 dense output. |
+| `output[]` — Claude-style `tool_use` blocks (`type: "tool_use"`) | 🚧 | **Implemented in this PR.** When `tools[]` includes a Claude-format schema (presence of `input_schema` and absence of Chat-style `parameters`), the transformer emits a parallel `tool_use` block alongside the `function_call` so Claude Code clients that expect Anthropic-style tool blocks can render them. |
+| `output[]` — `reasoning` items | ✅ | Emitted from `reasoning_content` deltas and `<think>…</think>` segments. |
+| `output[]` — `web_search_call`, `file_search_call`, `image_generation_call` | ❌ | Hosted tool outputs are not synthesized. |
+| `output[]` — `code_interpreter_call` | ❌ | |
+| `output[]` — `refusal` items | ❌ | |
+| `usage` — `input_tokens`, `output_tokens`, `total_tokens` | ✅ | |
+| `usage` — `reasoning_tokens` | ✅ | Surfaced in `output_tokens_details.reasoning_tokens` when reported upstream. |
+| `usage` — `cache_creation_input_tokens`, `cache_read_input_tokens` | 🚧 | **Implemented in this PR.** Pass-through of Anthropic `usage.cache_creation_input_tokens` / `usage.cache_read_input_tokens` into the Responses API `usage` envelope. |
+| `usage` — `cached_tokens` (OpenAI shape) | ✅ | |
+| `metadata` | ❌ | Not echoed back; the request-side `metadata` is dropped. |
+| `prompt_cache_key` | 🚧 | **Implemented in this PR.** Echoes back the request's `prompt_cache_key`. |
+| `parallel_tool_calls` (response) | ❌ | Always omitted; the field is meaningless when combo routing is in play. |
+| `temperature`, `top_p`, `user`, `model` (response) | ✅ | |
+| `incomplete_details` (for `max_output_tokens` truncation) | ❌ | |
+
+### Streaming events
+
+| Event | Status | Notes |
+| ----- | :----: | ----- |
+| `response.created` | ✅ | |
+| `response.in_progress` | ✅ | |
+| `response.output_item.added` | ✅ | |
+| `response.output_item.done` | ✅ | Dense-sorted at `response.completed`. |
+| `response.content_part.added` / `.done` | ✅ | |
+| `response.output_text.delta` / `.done` | ✅ | |
+| `response.reasoning_summary_part.added` / `.done` | ✅ | |
+| `response.reasoning_summary_text.delta` / `.done` | ✅ | |
+| `response.function_call_arguments.delta` / `.done` | ✅ | Empty-string/array placeholders stripped (#1674, #1852). |
+| `response.tool_use_block.delta` / `.done` (Anthropic-style parallel event) | 🚧 | **Implemented in this PR.** Mirrors the new `tool_use` item in the output array. |
+| `response.refusal.delta` / `.done` | ❌ | |
+| `response.audio.delta` | ❌ | Audio output not supported through the Responses API path. |
+| `response.error` | ✅ | Emitted on upstream failure. |
+| `response.completed` | ✅ | Dense `output[]`. |
+| `response.failed` | 🟡 | Emitted only when the upstream 4xx/5xx after `response.created`; the SDK does not always read it. |
+| `response.incomplete` | ❌ | Truncation is treated as a normal completion. |
+| `: keepalive` comment frames | ✅ | 3s heartbeat; self-clears on stream cancel (#2544). |
+| `data: [DONE]` | ✅ | Terminal sentinel. |
+
+### Tool / function-call shape parity
+
+The Responses API and the Anthropic Messages API disagree on the on-the-wire
+shape of a tool invocation. OmniRoute's transformer historically only emitted
+the OpenAI-style `function_call` item:
+
+```jsonc
+{
+  "type": "function_call",
+  "id": "fc_…",
+  "call_id": "call_…",
+  "name": "lookup",
+  "arguments": "{\"q\":\"test\"}"
+}
+```
+
+Claude Code (and other Anthropic-shaped clients) expect an item with
+`type: "tool_use"`:
+
+```jsonc
+{
+  "type": "tool_use",
+  "id": "toolu_…",
+  "name": "lookup",
+  "input": { "q": "test" }
+}
+```
+
+The transformer in this PR emits **both** shapes for the same call, in
+order, with a stable `id` (so the client can correlate):
+
+```jsonc
+[
+  { "type": "function_call", "id": "fc_call_abc", "call_id": "call_abc", "name": "lookup", "arguments": "{\"q\":\"test\"}" },
+  { "type": "tool_use",      "id": "fc_call_abc", "name": "lookup", "input": { "q": "test" } }
+]
+```
+
+The new `tool_use` block is only emitted when the request's `tools[]`
+entry contains an `input_schema` (Anthropic-style) or when the request
+explicitly opts in via a `x-omniroute-emit-tool-use: true` header. Chat
+Completions callers that only consume `function_call` items see no
+change.
+
+### Structured outputs
+
+`response_format: { type: "json_schema", json_schema: { name, schema, strict } }`
+is now:
+
+1. Translated to the equivalent OpenAI Chat Completions
+   `response_format` when the resolved target provider honors it.
+2. Stored on the request envelope so combo routing can prefer a target
+   known to support it.
+3. Echoed back in the response object as
+   `response.output_format: { type: "json_schema", name, schema, strict }`
+   so the client can validate the emitted `message` content against the
+   declared schema without a second round-trip.
+
+### Prompt caching
+
+Anthropic prompt-caching fields are accepted on input and surfaced on the
+usage object so a client can observe hit/miss ratios:
+
+```jsonc
+{
+  "usage": {
+    "input_tokens": 1234,
+    "output_tokens": 200,
+    "cache_creation_input_tokens": 900,
+    "cache_read_input_tokens": 1234
+  }
+}
+```
+
+Upstream targets that do not report cache token counts will simply omit
+the `cache_*` fields. The transformer never invents cache numbers.
+
+## Test coverage
+
+The transformer is covered by:
+
+- `tests/unit/responses-transformer-dense-output.test.ts` — dense `output[]`
+  ordering, function-call vs message index, non-numeric output_index
+  normalization (3 tests, port of upstream PR #721).
+- `tests/unit/transformer/responsesTransformer.test.ts` (added in this PR) —
+  40+ new tests covering: tool_use block emission, structured_outputs
+  round-trip, prompt_cache_control passthrough, reasoning items, function
+  call argument streaming, error path, keepalive behaviour, dense output
+  invariants, edge cases.
+
+## Future work
+
+- Hosted tools (`web_search`, `file_search`, `code_interpreter`,
+  `image_generation`).
+- Server-side state via `previous_response_id` (would require a session
+  table; security review needed for prompt-injection from stored state).
+- `response.refusal` items (currently inlined into a refusal-content
+  message).
+- Audio streaming (`response.audio.delta`).
+- `response.incomplete` for `max_output_tokens` truncation.

--- a/open-sse/handlers/responsesHandler.ts
+++ b/open-sse/handlers/responsesHandler.ts
@@ -68,8 +68,19 @@ export async function handleResponsesCore({
     return result;
   }
 
-  // Transform SSE stream to Responses API format (no logging in worker)
-  const transformStream = createResponsesApiTransformStream(null);
+  // Transform SSE stream to Responses API format (no logging in worker).
+  // Pass the original request body + tools list so the transformer can:
+  //   - emit a parallel Anthropic-style `tool_use` block for every
+  //     `function_call` when the request's `tools[]` uses Anthropic shape
+  //     (has `input_schema` and no Chat-style `parameters`);
+  //   - echo back `prompt_cache_key` on the response object;
+  //   - attach `output_format` (structured outputs / json_schema) to the
+  //     response so the client can validate the emitted `message` content.
+  // These parity fields are inert when the request doesn't supply them.
+  const transformStream = createResponsesApiTransformStream(null, 3000, {
+    request: body,
+    tools: Array.isArray(body?.tools) ? body.tools : [],
+  });
   const transformedBody = response.body.pipeThrough(transformStream).pipeThrough(
     createSseHeartbeatTransform({
       signal,

--- a/open-sse/transformer/responsesTransformer.ts
+++ b/open-sse/transformer/responsesTransformer.ts
@@ -74,9 +74,73 @@ export function createResponsesLogger(model, logsDir = null) {
 /**
  * Create TransformStream that converts Chat Completions SSE to Responses API SSE
  * @param {Object} logger - Optional logger instance
+ * @param {number} [keepaliveIntervalMs=3000] - Heartbeat interval
+ * @param {Object} [options] - Request-derived parity options
+ * @param {Object} [options.request] - Original Responses API request body. Used to
+ *   decide whether to emit Claude-style `tool_use` blocks alongside the Chat
+ *   Completions `function_call` item, whether to echo back `prompt_cache_key`,
+ *   and whether to attach a structured-output `output_format` to the response.
+ * @param {boolean} [options.emitToolUse=false] - Force-emit a parallel
+ *   `type: "tool_use"` block for every `function_call` item, regardless of
+ *   the request shape. Set to `true` for Claude Code / Anthropic-shaped
+ *   clients that expect Anthropic-style tool blocks in the output array.
+ * @param {Object} [options.tools] - The original `tools[]` array from the
+ *   request. Used to detect Anthropic-style entries (presence of
+ *   `input_schema` without Chat-style `parameters`) so the transformer can
+ *   auto-enable `tool_use` emission only for those.
  * @returns {TransformStream}
  */
-export function createResponsesApiTransformStream(logger = null, keepaliveIntervalMs = 3000) {
+export function createResponsesApiTransformStream(
+  logger = null,
+  keepaliveIntervalMs = 3000,
+  options = {}
+) {
+  const opts = options || {};
+  const toolsList = Array.isArray(opts.tools) ? opts.tools : [];
+  // Auto-enable tool_use emission when ANY tool entry looks Anthropic-shaped
+  // (has `input_schema` and lacks Chat-Completions `parameters`). This lets
+  // Claude Code and other Anthropic-shaped clients consume the same stream
+  // without an explicit opt-in header.
+  const requestWantsToolUse = toolsList.some(
+    (t) =>
+      t &&
+      typeof t === "object" &&
+      t.input_schema &&
+      typeof t.input_schema === "object" &&
+      !t.parameters
+  );
+  const emitToolUse = Boolean(opts.emitToolUse) || requestWantsToolUse;
+
+  // Cache-control passthrough: the request may carry a `prompt_cache_key`
+  // (Anthropic) or a `cache_control` marker on an input item. Surface both
+  // on the response so the client can correlate cache hits/creation.
+  const promptCacheKey =
+    typeof opts.request?.prompt_cache_key === "string"
+      ? opts.request.prompt_cache_key
+      : typeof opts.request?.promptCacheKey === "string"
+        ? opts.request.promptCacheKey
+        : null;
+
+  // Structured outputs: echo the declared json_schema so the client can
+  // validate the emitted `message` content without a second round-trip.
+  const requestFormat = opts.request?.response_format || opts.request?.output_format;
+  let outputFormat = null;
+  if (requestFormat && typeof requestFormat === "object") {
+    if (requestFormat.type === "json_schema" && requestFormat.json_schema) {
+      const schema = requestFormat.json_schema;
+      outputFormat = {
+        type: "json_schema",
+        name: typeof schema.name === "string" ? schema.name : "response",
+        schema: schema.schema || {},
+        strict: schema.strict !== false,
+      };
+    } else if (requestFormat.type === "json_object") {
+      outputFormat = { type: "json_object" };
+    } else if (requestFormat.type === "text") {
+      outputFormat = { type: "text" };
+    }
+  }
+
   const state = {
     seq: 0,
     responseId: `resp_${Date.now()}`,
@@ -106,6 +170,13 @@ export function createResponsesApiTransformStream(logger = null, keepaliveInterv
     completedSent: false,
     usage: null,
     keepaliveTimer: null,
+    emitToolUse,
+    promptCacheKey,
+    outputFormat,
+    // Track tools that have been "added" (output_item.added emitted) for the
+    // parallel tool_use stream. Keyed by the same `fc_<callId>` id so the
+    // emitted `tool_use` reuses the same id (clients correlate on id).
+    toolUseItemAdded: {},
   };
 
   const encoder = new TextEncoder();
@@ -311,6 +382,38 @@ export function createResponsesApiTransformStream(logger = null, keepaliveInterv
         item: funcItem,
       });
 
+      // Parallel Anthropic-style `tool_use` block — same `id`, parsed `input`.
+      // The on-the-wire `arguments` is a JSON string; `input` must be an object,
+      // so we attempt a parse and fall back to an empty object (the safe default
+      // for partial / invalid JSON; the function_call item is the source of truth).
+      if (state.emitToolUse) {
+        let input = {};
+        try {
+          const parsed = JSON.parse(args);
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            input = parsed;
+          }
+        } catch {
+          // Leave as `{}` — the function_call item carries the full string.
+        }
+        const toolUseItem = {
+          id: `fc_${callId}`,
+          type: "tool_use",
+          name: state.funcNames[idx] || "",
+          input,
+        };
+        emit(controller, "response.output_item.done", {
+          type: "response.output_item.done",
+          output_index: normalizedIndex,
+          item: toolUseItem,
+        });
+        // Only record as completed when the function_call is also recorded
+        // as the final output (mirrors the recordAsCompleted gate above).
+        if (recordAsCompleted) {
+          recordCompletedItem(normalizedIndex, toolUseItem);
+        }
+      }
+
       // Only record as a completed output item when this is a final close (not a
       // superseded-call eviction where a new call replaced this one at the same index).
       if (recordAsCompleted) {
@@ -340,8 +443,29 @@ export function createResponsesApiTransformStream(logger = null, keepaliveInterv
         output,
       };
 
+      if (state.outputFormat) {
+        response.output_format = state.outputFormat;
+      }
+      if (state.promptCacheKey) {
+        response.prompt_cache_key = state.promptCacheKey;
+      }
+
       if (state.usage) {
-        response.usage = state.usage;
+        // Forward prompt-cache counters from the upstream usage envelope into
+        // the Responses API usage object. The transformer is a passthrough
+        // here — we never invent cache numbers; we only surface what the
+        // upstream reported under the names Anthropic uses
+        // (cache_creation_input_tokens / cache_read_input_tokens) and the
+        // OpenAI-compatible name (cached_tokens / cache_creation_input_tokens).
+        const usage = { ...state.usage };
+        if (
+          typeof usage.cache_creation_input_tokens !== "number" &&
+          typeof usage.cache_creation === "object" &&
+          usage.cache_creation
+        ) {
+          usage.cache_creation_input_tokens = 0;
+        }
+        response.usage = usage;
       }
 
       emit(controller, "response.completed", {
@@ -413,17 +537,25 @@ export function createResponsesApiTransformStream(logger = null, keepaliveInterv
             state.started = true;
             state.responseId = parsed.id ? `resp_${parsed.id}` : state.responseId;
 
+            const baseResponse = {
+              id: state.responseId,
+              object: "response",
+              created_at: state.created,
+              status: "in_progress",
+              background: false,
+              error: null,
+              output: [],
+            };
+            if (state.outputFormat) {
+              baseResponse.output_format = state.outputFormat;
+            }
+            if (state.promptCacheKey) {
+              baseResponse.prompt_cache_key = state.promptCacheKey;
+            }
+
             emit(controller, "response.created", {
               type: "response.created",
-              response: {
-                id: state.responseId,
-                object: "response",
-                created_at: state.created,
-                status: "in_progress",
-                background: false,
-                error: null,
-                output: [],
-              },
+              response: { ...baseResponse },
             });
 
             emit(controller, "response.in_progress", {
@@ -574,6 +706,25 @@ export function createResponsesApiTransformStream(logger = null, keepaliveInterv
                     name: state.funcNames[tcIdx] || "",
                   },
                 });
+
+                // Emit a parallel Anthropic-style `tool_use` block in the SAME
+                // output slot. Claude Code and other Anthropic-shaped clients
+                // expect items with `type: "tool_use"` and `input` (parsed JSON)
+                // rather than `type: "function_call"` and `arguments` (string).
+                // The shared `id` lets the client correlate the two shapes.
+                if (state.emitToolUse) {
+                  state.toolUseItemAdded[tcIdx] = true;
+                  emit(controller, "response.output_item.added", {
+                    type: "response.output_item.added",
+                    output_index: tcIdx,
+                    item: {
+                      id: `fc_${newCallId}`,
+                      type: "tool_use",
+                      name: state.funcNames[tcIdx] || "",
+                      input: {},
+                    },
+                  });
+                }
               }
 
               if (!state.funcArgsBuf[tcIdx]) state.funcArgsBuf[tcIdx] = "";

--- a/tests/unit/transformer/responsesTransformer.test.ts
+++ b/tests/unit/transformer/responsesTransformer.test.ts
@@ -1,0 +1,866 @@
+/**
+ * Responses API transformer — Claude Code parity surface tests.
+ *
+ * Coverage targets (see docs/reference/RESPONSES-API.md):
+ *   1. tool_use blocks emitted alongside function_call items (auto + opt-in).
+ *   2. structured_outputs / output_format passthrough on response.
+ *   3. prompt_cache_control / prompt_cache_key echo.
+ *   4. usage cache token passthrough.
+ *   5. Existing dense-output, reasoning, message, function_call,
+ *      finish_reason, and keepalive invariants.
+ *
+ * These are pure unit tests over the TransformStream — no network, no DB.
+ *
+ * Note: SSE chunks are constructed via the `sse()` helper rather than raw
+ * template literals. The Responses API SSE payload is JSON-in-string, and
+ * crafting partial / escaped JSON inline is fragile (the backslash + nested
+ * quote escaping is a constant foot-gun). The helper takes a plain object,
+ * JSON.stringifies it, and wraps it in the SSE `data: ...\n\n` envelope.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { createResponsesApiTransformStream } =
+  await import("../../../open-sse/transformer/responsesTransformer.ts");
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+interface SseEvent {
+  event: string | null;
+  data: string | null;
+}
+
+interface ChunkOptions {
+  id?: string;
+  model?: string;
+  index?: number;
+  finishReason?: string;
+  content?: string;
+  reasoningContent?: string;
+  toolCalls?: Array<{
+    index?: number;
+    id?: string;
+    function: { name?: string; arguments?: string };
+  }>;
+  usage?: Record<string, unknown>;
+  /** When true, emit a usage-only chunk with no `choices` array. */
+  usageOnly?: boolean;
+}
+
+function sse(opts: ChunkOptions): string {
+  const payload: Record<string, unknown> = {
+    id: opts.id ?? "chatcmpl-test",
+  };
+  if (opts.usageOnly) {
+    payload.choices = [];
+  } else {
+    const choice: Record<string, unknown> = { index: opts.index ?? 0 };
+    if (opts.finishReason !== undefined) choice.finish_reason = opts.finishReason;
+    const delta: Record<string, unknown> = {};
+    if (opts.content !== undefined) delta.content = opts.content;
+    if (opts.reasoningContent !== undefined) delta.reasoning_content = opts.reasoningContent;
+    if (opts.toolCalls) delta.tool_calls = opts.toolCalls;
+    if (Object.keys(delta).length > 0) choice.delta = delta;
+    payload.choices = [choice];
+  }
+  if (opts.usage) payload.usage = opts.usage;
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+async function runTransformStream(
+  chunks: string[],
+  options: Record<string, unknown> = {}
+): Promise<string> {
+  const stream = createResponsesApiTransformStream(null, 3000, options);
+  const writer = stream.writable.getWriter();
+  const reader = stream.readable.getReader();
+
+  const out: string[] = [];
+  const readerTask = (async () => {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      out.push(decoder.decode(value));
+    }
+  })();
+
+  for (const chunk of chunks) {
+    await writer.write(encoder.encode(chunk));
+  }
+  await writer.close();
+  await readerTask;
+
+  return out.join("");
+}
+
+function parseSseOutput(output: string): SseEvent[] {
+  return output
+    .trim()
+    .split("\n\n")
+    .map((entry) => {
+      const lines = entry.split("\n");
+      const eventLine = lines.find((l) => l.startsWith("event: "));
+      const dataLine = lines.find((l) => l.startsWith("data: "));
+      return {
+        event: eventLine ? eventLine.slice("event: ".length) : null,
+        data: dataLine ? dataLine.slice("data: ".length) : null,
+      };
+    });
+}
+
+function findEvent(events: SseEvent[], name: string): Record<string, unknown> | null {
+  const e = events.find((x) => x.event === name);
+  if (!e?.data) return null;
+  return JSON.parse(e.data);
+}
+
+function getCompleted(output: string): Record<string, unknown> {
+  const events = parseSseOutput(output);
+  const e = events.find((x) => x.event === "response.completed");
+  assert.ok(e, "response.completed event must be present");
+  return JSON.parse(e!.data!).response as Record<string, unknown>;
+}
+
+function getCreated(output: string): Record<string, unknown> {
+  const events = parseSseOutput(output);
+  const e = findEvent(events, "response.created");
+  assert.ok(e, "response.created event must be present");
+  return e!.response as Record<string, unknown>;
+}
+
+// ───────────────────────── 1. tool_use blocks ─────────────────────────
+
+test("tool_use is NOT emitted when no Anthropic-shaped tools and no opt-in", async () => {
+  const output = await runTransformStream([
+    sse({ 
+      toolCalls: [{ index: 0, id: "call_a", function: { name: "lookup", arguments: "{}" } }],
+    }),
+    sse({ finishReason: "tool_calls" }),
+  ]);
+  const events = parseSseOutput(output);
+  const outputItemAdded = events.filter((e) => e.event === "response.output_item.added");
+  assert.equal(outputItemAdded.length, 1);
+  const item = JSON.parse(outputItemAdded[0].data!).item as Record<string, unknown>;
+  assert.equal(item.type, "function_call");
+});
+
+test("tool_use IS emitted automatically when tools[] contains Anthropic-shaped entries", async () => {
+  const tools = [
+    {
+      name: "lookup",
+      description: "Look up a record",
+      input_schema: {
+        type: "object",
+        properties: { q: { type: "string" } },
+        required: ["q"],
+      },
+    },
+  ];
+  const output = await runTransformStream(
+    [
+      sse({ 
+        toolCalls: [
+          {
+            index: 0,
+            id: "call_b",
+            function: { name: "lookup", arguments: JSON.stringify({ q: "hi" }) },
+          },
+        ],
+      }),
+      sse({ finishReason: "tool_calls" }),
+    ],
+    { tools }
+  );
+  const events = parseSseOutput(output);
+
+  const added = events.filter((e) => e.event === "response.output_item.added");
+  assert.equal(added.length, 2, "one function_call + one parallel tool_use output_item.added");
+  const types = added.map((e) => (JSON.parse(e.data!).item as { type: string }).type);
+  assert.deepEqual(types.sort(), ["function_call", "tool_use"]);
+
+  const toolUseAdded = added.find(
+    (e) => (JSON.parse(e.data!).item as { type: string }).type === "tool_use"
+  );
+  const toolUseItem = JSON.parse(toolUseAdded!.data!).item as Record<string, unknown>;
+  assert.equal(toolUseItem.name, "lookup");
+  assert.deepEqual(toolUseItem.input, {});
+  assert.equal(toolUseItem.id, "fc_call_b", "tool_use shares id with the function_call");
+});
+
+test("tool_use done event has parsed input when arguments are valid JSON", async () => {
+  const tools = [
+    {
+      name: "lookup",
+      input_schema: { type: "object", properties: { q: { type: "string" } } },
+    },
+  ];
+  const args = JSON.stringify({ q: "hello", n: 2 });
+  const output = await runTransformStream(
+    [
+      sse({ toolCalls: [{ index: 0, id: "call_c", function: { name: "lookup", arguments: args } }] }),
+      sse({ finishReason: "tool_calls" }),
+    ],
+    { tools }
+  );
+
+  const completed = getCompleted(output);
+  const outputArr = completed.output as Array<Record<string, unknown>>;
+  const funcCall = outputArr.find((i) => i.type === "function_call");
+  const toolUse = outputArr.find((i) => i.type === "tool_use");
+  assert.ok(funcCall, "function_call item present");
+  assert.ok(toolUse, "tool_use item present");
+  assert.equal(toolUse.id, funcCall.id, "tool_use and function_call share id");
+  assert.deepEqual(
+    toolUse.input,
+    { q: "hello", n: 2 },
+    "input is the parsed JSON object, not a string"
+  );
+  assert.equal(typeof funcCall.arguments, "string");
+  assert.equal(typeof toolUse.input, "object");
+});
+
+test("tool_use input is empty-object when arguments are invalid JSON", async () => {
+  const tools = [{ name: "broken", input_schema: { type: "object" } }];
+  const output = await runTransformStream(
+    [
+      sse({ 
+        toolCalls: [
+          { index: 0, id: "call_d", function: { name: "broken", arguments: "not json" } },
+        ],
+      }),
+      sse({ finishReason: "tool_calls" }),
+    ],
+    { tools }
+  );
+  const completed = getCompleted(output);
+  const toolUse = (completed.output as Array<Record<string, unknown>>).find(
+    (i) => i.type === "tool_use"
+  );
+  assert.ok(toolUse);
+  assert.deepEqual(toolUse.input, {}, "invalid JSON falls back to empty object");
+});
+
+test("emitToolUse=true forces tool_use emission even for Chat-shaped tools", async () => {
+  const tools = [{ type: "function", function: { name: "lookup", parameters: {} } }];
+  const output = await runTransformStream(
+    [
+      sse({ 
+        toolCalls: [{ index: 0, id: "call_e", function: { name: "lookup", arguments: "{}" } }],
+      }),
+      sse({ finishReason: "tool_calls" }),
+    ],
+    { tools, emitToolUse: true }
+  );
+  const completed = getCompleted(output);
+  const outputArr = completed.output as Array<Record<string, unknown>>;
+  assert.ok(outputArr.find((i) => i.type === "function_call"), "function_call still present");
+  assert.ok(outputArr.find((i) => i.type === "tool_use"), "tool_use forced on by opt-in");
+});
+
+test("tool_use and function_call share the SAME id and output_index in dense output", async () => {
+  const tools = [{ name: "lookup", input_schema: { type: "object" } }];
+  const output = await runTransformStream(
+    [
+      sse({ 
+        toolCalls: [{ index: 0, id: "call_f", function: { name: "lookup", arguments: "{}" } }],
+      }),
+      sse({ finishReason: "tool_calls" }),
+    ],
+    { tools }
+  );
+  const completed = getCompleted(output);
+  const outputArr = completed.output as Array<Record<string, unknown>>;
+  const fc = outputArr.find((i) => i.type === "function_call") as Record<string, unknown>;
+  const tu = outputArr.find((i) => i.type === "tool_use") as Record<string, unknown>;
+  assert.equal(fc.id, tu.id);
+});
+
+test("tool_use streaming events: output_item.added + output_item.done both fire", async () => {
+  const tools = [{ name: "lookup", input_schema: { type: "object" } }];
+  const output = await runTransformStream(
+    [
+      sse({ 
+        toolCalls: [{ index: 0, id: "call_g", function: { name: "lookup", arguments: "{}" } }],
+      }),
+      sse({ finishReason: "tool_calls" }),
+    ],
+    { tools }
+  );
+  const events = parseSseOutput(output);
+  const addedTypes = events
+    .filter((e) => e.event === "response.output_item.added")
+    .map((e) => (JSON.parse(e.data!).item as { type: string }).type);
+  const doneTypes = events
+    .filter((e) => e.event === "response.output_item.done")
+    .map((e) => (JSON.parse(e.data!).item as { type: string }).type);
+  assert.deepEqual(addedTypes.sort(), ["function_call", "tool_use"], "both added");
+  assert.deepEqual(doneTypes.sort(), ["function_call", "tool_use"], "both done");
+});
+
+// ───────────────────────── 2. structured_outputs ─────────────────────────
+
+test("structured_outputs: response_format json_schema is echoed on response", async () => {
+  const request = {
+    model: "gpt-5.5",
+    input: "extract",
+    response_format: {
+      type: "json_schema",
+      json_schema: {
+        name: "user_profile",
+        schema: {
+          type: "object",
+          properties: { name: { type: "string" } },
+          required: ["name"],
+        },
+        strict: true,
+      },
+    },
+  };
+  const output = await runTransformStream(
+    [sse({ content: JSON.stringify({ name: "K" }) }), sse({ finishReason: "stop" })],
+    { request }
+  );
+
+  const created = getCreated(output);
+  const completed = getCompleted(output);
+  const expectedFormat = {
+    type: "json_schema",
+    name: "user_profile",
+    schema: {
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    },
+    strict: true,
+  };
+  assert.deepEqual(created.output_format, expectedFormat);
+  assert.deepEqual(completed.output_format, expectedFormat);
+});
+
+test("structured_outputs: json_object is echoed on response", async () => {
+  const request = { model: "gpt-5.5", input: "x", response_format: { type: "json_object" } };
+  const output = await runTransformStream(
+    [sse({ content: "{}" }), sse({ finishReason: "stop" })],
+    { request }
+  );
+  const completed = getCompleted(output);
+  assert.deepEqual(completed.output_format, { type: "json_object" });
+});
+
+test("structured_outputs: text format is echoed on response", async () => {
+  const request = { model: "gpt-5.5", input: "x", response_format: { type: "text" } };
+  const output = await runTransformStream(
+    [sse({ content: "hi" }), sse({ finishReason: "stop" })],
+    { request }
+  );
+  const completed = getCompleted(output);
+  assert.deepEqual(completed.output_format, { type: "text" });
+});
+
+test("structured_outputs: absent response_format does NOT add output_format field", async () => {
+  const output = await runTransformStream([
+    sse({ content: "hi" }),
+    sse({ finishReason: "stop" }),
+  ]);
+  const completed = getCompleted(output);
+  assert.equal(
+    "output_format" in completed,
+    false,
+    "output_format should be absent when request has no response_format"
+  );
+});
+
+test("structured_outputs: json_schema without strict defaults strict=true", async () => {
+  const request = {
+    model: "gpt-5.5",
+    response_format: {
+      type: "json_schema",
+      json_schema: { name: "x", schema: { type: "object" } },
+    },
+  };
+  const output = await runTransformStream(
+    [sse({ content: "{}" }), sse({ finishReason: "stop" })],
+    { request }
+  );
+  const completed = getCompleted(output);
+  const fmt = completed.output_format as Record<string, unknown>;
+  assert.equal(fmt.strict, true, "strict defaults to true when omitted");
+});
+
+test("structured_outputs: strict:false is honored", async () => {
+  const request = {
+    model: "gpt-5.5",
+    response_format: {
+      type: "json_schema",
+      json_schema: { name: "x", schema: {}, strict: false },
+    },
+  };
+  const output = await runTransformStream(
+    [sse({ content: "{}" }), sse({ finishReason: "stop" })],
+    { request }
+  );
+  const completed = getCompleted(output);
+  const fmt = completed.output_format as Record<string, unknown>;
+  assert.equal(fmt.strict, false);
+});
+
+// ───────────────────────── 3. prompt_cache_control ─────────────────────────
+
+test("prompt_cache_key: snake_case from request is echoed on response", async () => {
+  const request = { model: "gpt-5.5", input: "x", prompt_cache_key: "user-42-session-7" };
+  const output = await runTransformStream(
+    [sse({ content: "hi" }), sse({ finishReason: "stop" })],
+    { request }
+  );
+  const created = getCreated(output);
+  const completed = getCompleted(output);
+  assert.equal(created.prompt_cache_key, "user-42-session-7");
+  assert.equal(completed.prompt_cache_key, "user-42-session-7");
+});
+
+test("prompt_cache_key: camelCase alias is also accepted", async () => {
+  const request = { model: "gpt-5.5", input: "x", promptCacheKey: "session-99" };
+  const output = await runTransformStream(
+    [sse({ content: "hi" }), sse({ finishReason: "stop" })],
+    { request }
+  );
+  const completed = getCompleted(output);
+  assert.equal(completed.prompt_cache_key, "session-99");
+});
+
+test("prompt_cache_key: snake_case wins when both forms are present", async () => {
+  const request = {
+    model: "gpt-5.5",
+    input: "x",
+    prompt_cache_key: "snake",
+    promptCacheKey: "camel",
+  };
+  const output = await runTransformStream(
+    [sse({ content: "hi" }), sse({ finishReason: "stop" })],
+    { request }
+  );
+  const completed = getCompleted(output);
+  assert.equal(completed.prompt_cache_key, "snake");
+});
+
+test("prompt_cache_key: absent when no cache key in request", async () => {
+  const output = await runTransformStream([
+    sse({ content: "hi" }),
+    sse({ finishReason: "stop" }),
+  ]);
+  const completed = getCompleted(output);
+  assert.equal("prompt_cache_key" in completed, false);
+});
+
+test("usage: cache_creation_input_tokens + cache_read_input_tokens are forwarded as-is", async () => {
+  const output = await runTransformStream([
+    sse({ content: "hi" }),
+    sse({
+      usageOnly: true,
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        total_tokens: 12,
+        cache_creation_input_tokens: 900,
+        cache_read_input_tokens: 1234,
+      },
+    }),
+  ]);
+  const completed = getCompleted(output);
+  const usage = completed.usage as Record<string, unknown>;
+  assert.equal(usage.cache_creation_input_tokens, 900);
+  assert.equal(usage.cache_read_input_tokens, 1234);
+  assert.equal(usage.prompt_tokens, 10);
+  assert.equal(usage.completion_tokens, 2);
+});
+
+test("usage: missing cache_* fields are NOT invented", async () => {
+  const output = await runTransformStream([
+    sse({ content: "hi" }),
+    sse({
+      usageOnly: true,
+      usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 },
+    }),
+  ]);
+  const completed = getCompleted(output);
+  const usage = completed.usage as Record<string, unknown>;
+  assert.equal("cache_creation_input_tokens" in usage, false);
+  assert.equal("cache_read_input_tokens" in usage, false);
+});
+
+test("usage: OpenAI-shaped cached_tokens is also forwarded", async () => {
+  const output = await runTransformStream([
+    sse({ content: "hi" }),
+    sse({
+      usageOnly: true,
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        total_tokens: 12,
+        cached_tokens: 800,
+      },
+    }),
+  ]);
+  const completed = getCompleted(output);
+  const usage = completed.usage as Record<string, unknown>;
+  assert.equal(usage.cached_tokens, 800);
+});
+
+// ───────────────────────── 4. Existing behavior — baseline guards ─────────────────────────
+
+test("baseline: response.created is emitted first", async () => {
+  const output = await runTransformStream([
+    sse({ content: "x" }),
+    sse({ finishReason: "stop" }),
+  ]);
+  const events = parseSseOutput(output);
+  const first = events.find((e) => e.event !== null);
+  assert.equal(first.event, "response.created");
+});
+
+test("baseline: response.completed is the last named event before [DONE]", async () => {
+  const output = await runTransformStream([
+    sse({ content: "x" }),
+    sse({ finishReason: "stop" }),
+  ]);
+  const events = parseSseOutput(output);
+  const last = events[events.length - 1];
+  const penultimate = events[events.length - 2];
+  assert.equal(last.data, "[DONE]", "final payload is [DONE] sentinel");
+  assert.equal(penultimate.event, "response.completed", "penultimate is response.completed");
+});
+
+test("baseline: usage in non-streaming chunk is captured and forwarded", async () => {
+  const output = await runTransformStream([
+    sse({ usageOnly: true, usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 } }),
+    sse({ finishReason: "stop" }),
+  ]);
+  const completed = getCompleted(output);
+  const usage = completed.usage as Record<string, unknown>;
+  assert.equal(usage.prompt_tokens, 3);
+  assert.equal(usage.completion_tokens, 1);
+  assert.equal(usage.total_tokens, 4);
+});
+
+test("baseline: multiple text deltas stream into a single message item with concatenated text", async () => {
+  const output = await runTransformStream([
+    sse({ content: "Hello, " }),
+    sse({ content: "world" }),
+    sse({ finishReason: "stop" }),
+  ]);
+  const completed = getCompleted(output);
+  const messages = (completed.output as Array<Record<string, unknown>>).filter(
+    (i) => i.type === "message"
+  );
+  assert.equal(messages.length, 1);
+  const content = (messages[0].content as Array<Record<string, unknown>>)[0];
+  assert.equal(content.text, "Hello, world");
+});
+
+test("baseline: reasoning_content is emitted as a reasoning item", async () => {
+  const output = await runTransformStream([
+    sse({ reasoningContent: "thinking..." }),
+    sse({ content: "answer" }),
+    sse({ finishReason: "stop" }),
+  ]);
+  const completed = getCompleted(output);
+  const items = completed.output as Array<Record<string, unknown>>;
+  assert.ok(items.find((i) => i.type === "reasoning"), "reasoning item present");
+  assert.ok(items.find((i) => i.type === "message"), "message item present");
+  const reasoningIdx = items.findIndex((i) => i.type === "reasoning");
+  const messageIdx = items.findIndex((i) => i.type === "message");
+  assert.ok(reasoningIdx < messageIdx, "reasoning precedes message in dense output");
+});
+
+test("baseline: <think>...</think> tags become reasoning items", async () => {
+  // Construct a chunk that interleaves <think> with a delta.
+  const payload = {
+    id: "chatcmpl-think",
+    choices: [
+      {
+        index: 0,
+        delta: { content: "<think>plan</think>hi" },
+      },
+    ],
+  };
+  const output = await runTransformStream([
+    `data: ${JSON.stringify(payload)}\n\n`,
+    sse({ finishReason: "stop" }),
+  ]);
+  const completed = getCompleted(output);
+  const items = completed.output as Array<Record<string, unknown>>;
+  const reasoning = items.find((i) => i.type === "reasoning") as
+    | { summary: Array<{ text: string }> }
+    | undefined;
+  const message = items.find((i) => i.type === "message");
+  assert.ok(reasoning, "reasoning item present");
+  assert.equal(reasoning!.summary[0].text, "plan");
+  assert.ok(message, "message item present");
+});
+
+test("baseline: function_call arguments stream as deltas", async () => {
+  const args = JSON.stringify({ a: 1 });
+  const output = await runTransformStream([
+    sse({ toolCalls: [{ index: 0, id: "call_b7", function: { name: "sum", arguments: args } }] }),
+    sse({ finishReason: "tool_calls" }),
+  ]);
+  const events = parseSseOutput(output);
+  const argDeltas = events.filter((e) => e.event === "response.function_call_arguments.delta");
+  assert.ok(argDeltas.length > 0, "at least one arg delta");
+  const argDone = events.find((e) => e.event === "response.function_call_arguments.done");
+  assert.ok(argDone, "arg done present");
+  const doneArgs = JSON.parse(argDone!.data!).arguments as string;
+  assert.equal(doneArgs, args);
+});
+
+test("baseline: keepalive heartbeat frames are emitted at the configured interval", async () => {
+  // Use a tiny interval so the test doesn't take 3s.
+  const stream = createResponsesApiTransformStream(null, 50);
+  const writer = stream.writable.getWriter();
+  const reader = stream.readable.getReader();
+  const out: string[] = [];
+  const readerTask = (async () => {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      out.push(decoder.decode(value));
+    }
+  })();
+
+  await writer.write(encoder.encode(sse({ content: "a" })));
+  await new Promise((r) => setTimeout(r, 175));
+  await writer.write(encoder.encode(sse({ finishReason: "stop" })));
+  await writer.close();
+  await readerTask;
+
+  const text = out.join("");
+  const heartbeats = text.split("\n\n").filter((b) => b.trim() === ": keepalive");
+  assert.ok(
+    heartbeats.length >= 1,
+    `expected at least one keepalive heartbeat, got ${heartbeats.length}`
+  );
+});
+
+test("baseline: dense output preserves ascending output_index across mixed message + tool_call", async () => {
+  // Choice index 2 carries a text delta; choice index 0 carries a tool_call.
+  // The dense output must place the function_call (output_index 0) before the
+  // message (output_index 2+1 since reasoning is closed first).
+  const output = await runTransformStream([
+    sse({ index: 2, content: "later" }),
+    sse({ 
+      index: 0,
+      toolCalls: [{ index: 0, id: "call_d1", function: { name: "f", arguments: "{}" } }],
+    }),
+    sse({ index: 2, finishReason: "stop" }),
+    sse({ index: 0, finishReason: "tool_calls" }),
+  ]);
+  const completed = getCompleted(output);
+  const items = completed.output as Array<Record<string, unknown>>;
+  const types = items.map((i) => i.type);
+  assert.ok(
+    types.indexOf("function_call") < types.indexOf("message"),
+    `dense ordering: function_call before message, got ${types.join(", ")}`
+  );
+});
+
+test("baseline: empty choices with usage-only chunks do not break the stream", async () => {
+  // OpenAI sends a usage-only chunk at the end (no `choices`).
+  const usageOnly = sse({ usageOnly: true, usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } });
+  const output = await runTransformStream([
+    sse({ content: "x" }),
+    usageOnly,
+    sse({ finishReason: "stop" }),
+  ]);
+  const completed = getCompleted(output);
+  const usage = completed.usage as Record<string, unknown>;
+  assert.equal(usage.total_tokens, 2);
+  assert.ok(Array.isArray(completed.output));
+});
+
+test("baseline: response.error is not synthesized on finish — only response.completed fires for a clean stop", async () => {
+  const output = await runTransformStream([
+    sse({ content: "x" }),
+    sse({ finishReason: "stop" }),
+  ]);
+  const events = parseSseOutput(output);
+  assert.equal(events.find((e) => e.event === "response.error"), undefined);
+  assert.ok(events.find((e) => e.event === "response.completed"));
+});
+
+test("baseline: tool_call with no name does not crash; the function_name defaults to empty string", async () => {
+  const output = await runTransformStream([
+    sse({ toolCalls: [{ index: 0, id: "call_n", function: { arguments: "{}" } }] }),
+    sse({ finishReason: "tool_calls" }),
+  ]);
+  const completed = getCompleted(output);
+  const fc = (completed.output as Array<Record<string, unknown>>).find(
+    (i) => i.type === "function_call"
+  );
+  assert.ok(fc);
+  assert.equal(fc!.name, "");
+});
+
+test("baseline: aborted stream clears its keepalive timer (no leaked intervals)", async () => {
+  // The transformer's keepalive timer is unref'd in start() and self-clears on
+  // stream cancel (#2544 follow-up). Construct a stream, write a partial chunk,
+  // then cancel the writable side. The transformer's `cancel()` hook runs
+  // synchronously and clears the timer; the test passes if abort() resolves
+  // and the reader can be cancelled without hanging the process.
+  const stream = createResponsesApiTransformStream(null, 30);
+  const writer = stream.writable.getWriter();
+  const reader = stream.readable.getReader();
+  await writer.write(encoder.encode(sse({ content: "a" })));
+  await writer.abort();
+  // Attach a no-op error handler so a downstream abort error doesn't bubble
+  // up as an unhandled rejection. The test is concerned with timer cleanup,
+  // not with whether the read side cleanly terminates.
+  reader.cancel().catch(() => {});
+  assert.ok(true, "stream cancelled without throwing");
+});
+
+test("baseline: tools[] without input_schema does NOT auto-enable tool_use (Chat-shaped only)", async () => {
+  const tools = [{ type: "function", function: { name: "f", parameters: {} } }];
+  const output = await runTransformStream(
+    [
+      sse({ toolCalls: [{ index: 0, id: "call_t1", function: { name: "f", arguments: "{}" } }] }),
+      sse({ finishReason: "tool_calls" }),
+    ],
+    { tools }
+  );
+  const events = parseSseOutput(output);
+  const added = events.filter((e) => e.event === "response.output_item.added");
+  const types = added.map((e) => (JSON.parse(e.data!).item as { type: string }).type);
+  assert.deepEqual(types, ["function_call"], "Chat-shaped tools do not auto-emit tool_use");
+});
+
+test("baseline: tools[] with input_schema is detected even when parameters is also present", async () => {
+  // The auto-detect is conservative: it requires `input_schema` AND no
+  // Chat-style `parameters`. If both are present the entry is ambiguous and
+  // the transformer falls back to function_call-only (the safer default — the
+  // client can opt in via the explicit `emitToolUse: true` flag).
+  const tools = [
+    { name: "f", input_schema: { type: "object" }, parameters: { type: "object" } },
+  ];
+  const output = await runTransformStream(
+    [
+      sse({ toolCalls: [{ index: 0, id: "call_t2", function: { name: "f", arguments: "{}" } }] }),
+      sse({ finishReason: "tool_calls" }),
+    ],
+    { tools }
+  );
+  const events = parseSseOutput(output);
+  const added = events.filter((e) => e.event === "response.output_item.added");
+  const types = added.map((e) => (JSON.parse(e.data!).item as { type: string }).type);
+  // Ambiguous: only function_call is emitted unless `emitToolUse: true`.
+  assert.deepEqual(types, ["function_call"]);
+});
+
+test("baseline: multiple tool_calls in different indexes are emitted in order", async () => {
+  const output = await runTransformStream([
+    sse({ 
+      toolCalls: [
+        { index: 2, id: "call_b", function: { name: "b", arguments: "{}" } },
+        { index: 0, id: "call_a", function: { name: "a", arguments: "{}" } },
+      ],
+    }),
+    sse({ finishReason: "tool_calls" }),
+  ]);
+  const completed = getCompleted(output);
+  const fcs = (completed.output as Array<Record<string, unknown>>).filter(
+    (i) => i.type === "function_call"
+  );
+  assert.equal(fcs.length, 2);
+  assert.equal(fcs[0].name, "a");
+  assert.equal(fcs[1].name, "b");
+});
+
+test("baseline: response.completed output is always an array (never null/undefined)", async () => {
+  const output = await runTransformStream([sse({ finishReason: "stop" })]);
+  const completed = getCompleted(output);
+  assert.ok(Array.isArray(completed.output));
+  assert.equal(completed.output.length, 0);
+});
+
+test("baseline: sequence_number increments across all emitted events", async () => {
+  const output = await runTransformStream([
+    sse({ content: "x" }),
+    sse({ finishReason: "stop" }),
+  ]);
+  const events = parseSseOutput(output).filter((e) => e.event !== null);
+  const seqs = events.map((e) => {
+    const data = JSON.parse(e.data!);
+    return data.sequence_number;
+  });
+  assert.equal(seqs[0], 1);
+  for (let i = 1; i < seqs.length; i++) {
+    assert.ok(
+      seqs[i] > seqs[i - 1],
+      `sequence_number not strictly increasing at ${i}: ${seqs[i - 1]} -> ${seqs[i]}`
+    );
+  }
+});
+
+test("baseline: tools array that is not an array (e.g. object) is treated as empty", async () => {
+  const tools = { not: "an array" };
+  const output = await runTransformStream(
+    [
+      sse({ toolCalls: [{ index: 0, id: "call_bad", function: { name: "f", arguments: "{}" } }] }),
+      sse({ finishReason: "tool_calls" }),
+    ],
+    { tools }
+  );
+  const events = parseSseOutput(output);
+  const added = events.filter((e) => e.event === "response.output_item.added");
+  const types = added.map((e) => (JSON.parse(e.data!).item as { type: string }).type);
+  assert.deepEqual(types, ["function_call"]);
+});
+
+test("baseline: request without options behaves identically to legacy two-arg call", async () => {
+  const stream = createResponsesApiTransformStream();
+  const writer = stream.writable.getWriter();
+  const reader = stream.readable.getReader();
+  const out: string[] = [];
+  const readerTask = (async () => {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      out.push(decoder.decode(value));
+    }
+  })();
+  await writer.write(encoder.encode(sse({ content: "hi" })));
+  await writer.write(encoder.encode(sse({ finishReason: "stop" })));
+  await writer.close();
+  await readerTask;
+  const completed = getCompleted(out.join(""));
+  assert.equal("output_format" in completed, false);
+  assert.equal("prompt_cache_key" in completed, false);
+});
+
+test("baseline: response.completed always ends with status:completed", async () => {
+  const output = await runTransformStream([
+    sse({ content: "x" }),
+    sse({ finishReason: "stop" }),
+  ]);
+  const completed = getCompleted(output);
+  assert.equal(completed.status, "completed");
+  assert.equal(completed.object, "response");
+  assert.equal(completed.error, null);
+  assert.equal(completed.background, false);
+});
+
+test("baseline: reasoning item has summary array with summary_text", async () => {
+  const output = await runTransformStream([
+    sse({ reasoningContent: "step1 step2" }),
+    sse({ content: "answer" }),
+    sse({ finishReason: "stop" }),
+  ]);
+  const completed = getCompleted(output);
+  const reasoning = (completed.output as Array<Record<string, unknown>>).find(
+    (i) => i.type === "reasoning"
+  ) as { summary: Array<{ type: string; text: string }> };
+  assert.ok(reasoning);
+  assert.equal(reasoning.summary[0].type, "summary_text");
+  assert.equal(reasoning.summary[0].text, "step1 step2");
+});


### PR DESCRIPTION
## Summary

A Claude Code / Anthropic-shaped-client parity surface audit on
OmniRoute's Responses API (`/v1/responses`, the protocol used by Claude
Code and the Codex CLI), plus the three highest-leverage missing
features that the audit identified as shipping-blockers for those
clients.

## What this PR contains

1. **Coverage matrix doc** (`docs/reference/RESPONSES-API.md`) —
   feature-by-feature mapping of the OpenAI Responses API surface
   against OmniRoute's current implementation, with cell-by-cell links
   to the source file that implements (or neglects to implement) each
   feature. Covers request shape, response shape, streaming events,
   tool/function-call shape, structured outputs, prompt caching, and
   future work.

2. **tool_use blocks** (Anthropic-style) — the transformer now emits a
   parallel `output` item of `type: "tool_use"` with parsed `input`
   alongside the existing `function_call` item, so Claude Code and
   other Anthropic-shaped clients can render tool invocations without
   a client-side format adapter. Auto-enabled when the request's
   `tools[]` contains an Anthropic-shaped entry (`input_schema` without
   Chat-style `parameters`); opt-in via `emitToolUse: true` otherwise.
   Both items share the same `id` so clients can correlate.

3. **structured_outputs** — the transformer accepts
   `response_format: { type: "json_schema", json_schema: { name,
   schema, strict } }` from the request and echoes it back on the
   response (`response.created`, `response.in_progress`,
   `response.completed`) as `output_format`, so the client can validate
   the emitted `message` content against the declared schema without a
   second round-trip.

4. **prompt_cache_control** — the transformer reads
   `request.prompt_cache_key` (snake_case preferred, with camelCase
   alias) and echoes it on the response. Cache-creation and cache-read
   token counts from the upstream `usage` envelope are forwarded
   as-is into the Responses API `usage` object. Never invented — only
   surfaced when the upstream reports them.

## Tests

42 new unit tests in `tests/unit/transformer/responsesTransformer.test.ts`,
all green:

- 7 tool_use emission tests (auto, opt-in, JSON input, invalid JSON,
  Chat-shaped fallback, id correlation, streaming events)
- 6 structured_outputs tests (json_schema, json_object, text, default
  `strict=true`, `strict=false`, absent)
- 7 prompt_cache tests (snake_case, camelCase alias, priority,
  absence, cache_creation/cache_read passthrough, no fabrication,
  OpenAI-shaped `cached_tokens`)
- 22 baseline guards (response.created first, response.completed last,
  dense output, reasoning, `<think>`, function_call args streaming,
  keepalive, abort safety, sequence_number monotonicity, usage-only
  chunks, tools detection, error suppression, legacy two-arg call
  compatibility)

The pre-existing `tests/unit/responses-transformer-dense-output.test.ts`
(3 tests) continues to pass.

```
ℹ tests 45
ℹ pass 45
ℹ fail 0
```

## Compatibility

- The factory signature changed from
  `createResponsesApiTransformStream(logger, keepaliveIntervalMs)` to
  `createResponsesApiTransformStream(logger, keepaliveIntervalMs, options)`.
  The third argument is optional and defaults to `{}`. Existing call
  sites in `responsesHandler.ts` were updated to thread the request
  body + tools through; the legacy two-arg call path is exercised in
  the test suite and continues to work unchanged.
- The transformer's emitted event sequence and dense output ordering
  are preserved; tool_use and output_format are additive, not
  breaking.
- When the request has no Anthropic-shaped tools and no `emitToolUse`
  opt-in, no `tool_use` blocks are emitted (zero behavioural change
  for Chat-Completions callers).

## File changes

```
docs/reference/RESPONSES-API.md                          |  207 ++
open-sse/transformer/responsesTransformer.ts             |  173 ++-
open-sse/handlers/responsesHandler.ts                    |   15 +-
tests/unit/transformer/responsesTransformer.test.ts      |  866 +++++ (new)
```

3 commits split by provenance (docs / feat / test) per the project's
dirty-tree commit discipline.