### PR TITLE
[codex] Pin OmniRoute audit workflow runner

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (JavaScript / TypeScript)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       security-events: write


### PR DESCRIPTION
## Summary
- pins the OmniRoute audit workflow runner from `ubuntu-latest` to `ubuntu-24.04`

## Validation
- git diff --check
