### PR TITLE
feat(mcp/F3): substrate dispatch tools integration

### DIFF
--- a/open-sse/mcp-server/audit.ts
+++ b/open-sse/mcp-server/audit.ts
@@ -1,0 +1,474 @@
+/**
+ * MCP Audit Logger — Records all MCP tool invocations for security and observability.
+ *
+ * Logs are written to the `mcp_tool_audit` SQLite table.
+ * Input data is hashed (SHA-256) to avoid storing sensitive prompts.
+ * Output is truncated to 200 chars for summary.
+ */
+
+import { hashInput, summarizeOutput } from "./schemas/audit.ts";
+import { isNativeSqliteLoadError } from "../../src/lib/db/core.ts";
+
+// ============ Database Connection ============
+
+interface StatementLike<TRow = unknown> {
+  get: (...params: unknown[]) => TRow | undefined;
+  all: (...params: unknown[]) => TRow[];
+  run: (...params: unknown[]) => unknown;
+}
+
+interface AuditDatabase {
+  prepare: <TRow = unknown>(sql: string) => StatementLike<TRow>;
+  pragma: (sql: string) => unknown;
+  close: () => void;
+  open?: boolean;
+  driver?: "better-sqlite3" | "node:sqlite";
+}
+
+interface NodeSqliteDatabase {
+  prepare: (sql: string) => {
+    run: (...params: unknown[]) => { changes: number | bigint; lastInsertRowid: number | bigint };
+    get: (...params: unknown[]) => unknown;
+    all: (...params: unknown[]) => unknown[];
+  };
+  exec: (sql: string) => void;
+  close: () => void;
+}
+
+/**
+ * node:sqlite's `DatabaseSync` does NOT expose a boolean `open` property —
+ * `open` and `close` are methods on the prototype, and the only state
+ * surface is the `isOpen` getter. Track open state locally in a closure
+ * so the adapter's `AuditDatabase` contract (`open?: boolean`) is honored
+ * and `getCachedAuditDb()`'s truthy check doesn't return a closed handle
+ * after `closeAuditDb()`.
+ */
+function createNodeSqliteAuditAdapter(db: NodeSqliteDatabase): AuditDatabase {
+  let _isOpen = true;
+  return {
+    driver: "node:sqlite",
+    get open() {
+      return _isOpen;
+    },
+    prepare<TRow = unknown>(sql: string) {
+      const stmt = db.prepare(sql);
+      return {
+        get: (...params: unknown[]) => stmt.get(...params) as TRow | undefined,
+        all: (...params: unknown[]) => stmt.all(...params) as TRow[],
+        run: (...params: unknown[]) => stmt.run(...params),
+      };
+    },
+    pragma(pragmaSql: string) {
+      // node:sqlite has no .pragma() helper — route through .exec() for
+      // statement-shaped PRAGMAs (e.g. "wal_checkpoint(TRUNCATE)").
+      try {
+        db.exec(`PRAGMA ${pragmaSql}`);
+        return null;
+      } catch (err) {
+        return err instanceof Error ? err.message : String(err);
+      }
+    },
+    close: () => {
+      if (!_isOpen) return;
+      try {
+        db.close();
+      } finally {
+        _isOpen = false;
+      }
+    },
+  };
+}
+
+declare global {
+  var __omnirouteMcpAuditDb: AuditDatabase | null | undefined;
+}
+
+interface AuditStatsRow {
+  total: unknown;
+  successRate: unknown;
+  avgDuration: unknown;
+}
+
+interface AuditTopToolRow {
+  tool: unknown;
+  count: unknown;
+}
+
+interface AuditCountRow {
+  total: unknown;
+}
+
+interface AuditEntryRow {
+  id?: unknown;
+  tool_name?: unknown;
+  input_hash?: unknown;
+  output_summary?: unknown;
+  duration_ms?: unknown;
+  api_key_id?: unknown;
+  success?: unknown;
+  error_code?: unknown;
+  created_at?: unknown;
+}
+
+export interface McpAuditQuery {
+  limit?: number;
+  offset?: number;
+  tool?: string;
+  success?: boolean;
+  apiKeyId?: string;
+}
+
+export interface McpAuditEntry {
+  id: number;
+  toolName: string;
+  inputHash: string;
+  outputSummary: string;
+  durationMs: number;
+  apiKeyId: string | null;
+  success: boolean;
+  errorCode: string | null;
+  createdAt: string;
+}
+
+function toNullableString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function toBoolean(value: unknown, fallback = false): boolean {
+  if (typeof value === "boolean") return value;
+  if (value === 1 || value === "1") return true;
+  if (value === 0 || value === "0") return false;
+  return fallback;
+}
+
+function toPositiveInt(value: unknown, fallback: number): number {
+  const parsed = toNumber(value, fallback);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(0, Math.floor(parsed));
+}
+
+function mapAuditEntry(row: AuditEntryRow): McpAuditEntry {
+  return {
+    id: toPositiveInt(row.id, 0),
+    toolName: toString(row.tool_name),
+    inputHash: toString(row.input_hash),
+    outputSummary: toString(row.output_summary),
+    durationMs: toNumber(row.duration_ms, 0),
+    apiKeyId: toNullableString(row.api_key_id),
+    success: toBoolean(row.success, false),
+    errorCode: toNullableString(row.error_code),
+    createdAt: toString(row.created_at),
+  };
+}
+
+function buildAuditFilterSql(filters: McpAuditQuery): { whereSql: string; params: unknown[] } {
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+
+  if (typeof filters.tool === "string" && filters.tool.trim().length > 0) {
+    clauses.push("tool_name = ?");
+    params.push(filters.tool.trim());
+  }
+  if (typeof filters.success === "boolean") {
+    clauses.push("success = ?");
+    params.push(filters.success ? 1 : 0);
+  }
+  if (typeof filters.apiKeyId === "string" && filters.apiKeyId.trim().length > 0) {
+    clauses.push("api_key_id = ?");
+    params.push(filters.apiKeyId.trim());
+  }
+
+  return {
+    whereSql: clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "",
+    params,
+  };
+}
+
+function getCachedAuditDb(): AuditDatabase | null {
+  return globalThis.__omnirouteMcpAuditDb ?? null;
+}
+
+function setCachedAuditDb(database: AuditDatabase | null): void {
+  globalThis.__omnirouteMcpAuditDb = database;
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value)
+        : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function toString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * Lazy-load the database connection.
+ * Uses the same SQLite database as the main OmniRoute app.
+ *
+ * Driver priority:
+ *   1. better-sqlite3 — fast native binding (when its compiled `.node`
+ *      binary is present, see scripts/build/postinstall.mjs).
+ *   2. node:sqlite    — built-in to Node 22.5+. Used as a transparent
+ *      fallback so the MCP audit logger still works on installs where
+ *      the better-sqlite3 binary failed to resolve (e.g. missing
+ *      `dist/node_modules/better-sqlite3/build/Release/better_sqlite3.node`
+ *      in some global-install / Docker scenarios).
+ */
+async function getDb(): Promise<AuditDatabase | null> {
+  const cachedDb = getCachedAuditDb();
+  if (cachedDb) return cachedDb;
+
+  try {
+    // Try importing the db module from the main app
+    const { homedir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { existsSync } = await import("node:fs");
+
+    const dbPath = process.env.DATA_DIR
+      ? join(process.env.DATA_DIR, "storage.sqlite")
+      : join(homedir(), ".omniroute", "storage.sqlite");
+
+    if (!existsSync(dbPath)) {
+      console.error(`[MCP Audit] Database not found at ${dbPath} — audit logging disabled`);
+      return null;
+    }
+
+    // Try better-sqlite3 first (matches the main app's default driver).
+    try {
+      const Database = (await import("better-sqlite3")).default as unknown as new (
+        dbPath: string
+      ) => AuditDatabase;
+      const database = new Database(dbPath);
+      setCachedAuditDb(database);
+      return database;
+    } catch (nativeErr) {
+      // Declared once at the top of the catch: nativeMessage is read both on
+      // the non-fallback bail-out and in the node:sqlite fallback warning
+      // further down. A block-scoped const inside the `if` below would be out
+      // of scope in the fallback path.
+      const nativeMessage = nativeErr instanceof Error ? nativeErr.message : String(nativeErr);
+      // Reuse the canonical detection helper from the main app's DB layer
+      // so we cover every ABI/binding failure mode the rest of the codebase
+      // already knows about: missing MODULE_NOT_FOUND, ERR_DLOPEN_FAILED,
+      // "Module did not self-register", "Cannot find module 'better-sqlite3'",
+      // the standard V8 "was compiled against a different Node.js version"
+      // message, and the bindings-loader "Could not locate the bindings file".
+      // Real errors (corrupt db, permission denied) still surface to the operator.
+      if (!isNativeSqliteLoadError(nativeErr)) {
+        console.error("[MCP Audit] Failed to connect to database:", nativeMessage);
+        return null;
+      }
+      // Fall back to Node's built-in sqlite (Node 22.5+).
+      const [maj, min] = (process.versions.node ?? "0.0").split(".").map(Number);
+      if (maj < 22 || (maj === 22 && (min ?? 0) < 5)) {
+        console.error(
+          `[MCP Audit] better-sqlite3 native binding unavailable and Node ${process.version} ` +
+            "has no built-in sqlite. Audit logging disabled. Fix: run " +
+            "`npm rebuild better-sqlite3` in the omniroute install root."
+        );
+        return null;
+      }
+      try {
+        const { DatabaseSync } = (await import("node:sqlite")) as {
+          DatabaseSync: new (p: string) => NodeSqliteDatabase;
+        };
+        const nodeDb = new DatabaseSync(dbPath);
+        const adapter = createNodeSqliteAuditAdapter(nodeDb);
+        setCachedAuditDb(adapter);
+        console.warn(
+          `[MCP Audit] better-sqlite3 binding unavailable — fell back to node:sqlite ` +
+            `(${nativeMessage.split("\n")[0]})`
+        );
+        return adapter;
+      } catch (nodeErr) {
+        const nodeMessage = nodeErr instanceof Error ? nodeErr.message : String(nodeErr);
+        console.error("[MCP Audit] Failed to connect to database:", nodeMessage);
+        return null;
+      }
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[MCP Audit] Failed to connect to database:", message);
+    return null;
+  }
+}
+
+export function closeAuditDb(): boolean {
+  const database = getCachedAuditDb();
+  if (!database) return false;
+
+  setCachedAuditDb(null);
+
+  try {
+    try {
+      if (database.open !== false) {
+        database.pragma("wal_checkpoint(TRUNCATE)");
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("[MCP Audit] WAL checkpoint failed during close:", message);
+    }
+  } finally {
+    try {
+      database.close();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("[MCP Audit] Failed to close database:", message);
+    }
+  }
+
+  return true;
+}
+
+// ============ Audit Logger ============
+
+/**
+ * Log a tool invocation to the mcp_tool_audit table.
+ *
+ * Security: Input is hashed, never stored in clear text.
+ * Output is truncated to a summary.
+ */
+export async function logToolCall(
+  toolName: string,
+  input: unknown,
+  output: unknown,
+  durationMs: number,
+  success: boolean,
+  errorCode?: string
+): Promise<void> {
+  try {
+    const database = await getDb();
+    if (!database) return; // Audit disabled if no DB
+
+    const inputHash = await hashInput(input);
+    const outputSummary = summarizeOutput(output);
+    const apiKeyId = process.env.OMNIROUTE_API_KEY_ID || null;
+
+    database
+      .prepare(
+        `INSERT INTO mcp_tool_audit (tool_name, input_hash, output_summary, duration_ms, api_key_id, success, error_code)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        toolName,
+        inputHash,
+        outputSummary,
+        durationMs,
+        apiKeyId,
+        success ? 1 : 0,
+        errorCode || null
+      );
+  } catch (err: unknown) {
+    // Never let audit failure break tool execution
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[MCP Audit] Failed to log:", message);
+  }
+}
+
+/**
+ * Get recent audit entries (for dashboard/monitoring).
+ */
+export async function queryAuditEntries(
+  filters: McpAuditQuery = {}
+): Promise<{ entries: McpAuditEntry[]; total: number; limit: number; offset: number }> {
+  try {
+    const database = await getDb();
+    const limit = Math.max(1, Math.min(500, toPositiveInt(filters.limit, 50)));
+    const offset = Math.max(0, toPositiveInt(filters.offset, 0));
+    if (!database) return { entries: [], total: 0, limit, offset };
+
+    const { whereSql, params } = buildAuditFilterSql(filters);
+    const totalRow = database
+      .prepare<AuditCountRow>(`SELECT COUNT(*) as total FROM mcp_tool_audit ${whereSql}`)
+      .get(...params);
+    const rows = database
+      .prepare<AuditEntryRow>(
+        `SELECT
+           id,
+           tool_name,
+           input_hash,
+           output_summary,
+           duration_ms,
+           api_key_id,
+           success,
+           error_code,
+           created_at
+         FROM mcp_tool_audit
+         ${whereSql}
+         ORDER BY created_at DESC
+         LIMIT ? OFFSET ?`
+      )
+      .all(...params, limit, offset);
+
+    return {
+      entries: rows.map(mapAuditEntry),
+      total: toPositiveInt(totalRow?.total, 0),
+      limit,
+      offset,
+    };
+  } catch {
+    return { entries: [], total: 0, limit: 50, offset: 0 };
+  }
+}
+
+/**
+ * Backward compatible helper for existing callers.
+ */
+export async function getRecentAuditEntries(limit = 50): Promise<McpAuditEntry[]> {
+  const result = await queryAuditEntries({ limit, offset: 0 });
+  return result.entries;
+}
+
+/**
+ * Get audit stats for monitoring.
+ */
+export async function getAuditStats(): Promise<{
+  totalCalls: number;
+  successRate: number;
+  avgDurationMs: number;
+  topTools: Array<{ tool: string; count: number }>;
+}> {
+  try {
+    const database = await getDb();
+    if (!database) return { totalCalls: 0, successRate: 0, avgDurationMs: 0, topTools: [] };
+
+    const stats = database
+      .prepare(
+        `SELECT 
+           COUNT(*) as total,
+           AVG(CASE WHEN success = 1 THEN 1.0 ELSE 0.0 END) as successRate,
+           AVG(duration_ms) as avgDuration
+         FROM mcp_tool_audit
+         WHERE created_at > datetime('now', '-24 hours')`
+      )
+      .get() as AuditStatsRow | undefined;
+
+    const topTools = database
+      .prepare(
+        `SELECT tool_name as tool, COUNT(*) as count
+         FROM mcp_tool_audit
+         WHERE created_at > datetime('now', '-24 hours')
+         GROUP BY tool_name
+         ORDER BY count DESC
+         LIMIT 10`
+      )
+      .all() as AuditTopToolRow[];
+
+    return {
+      totalCalls: toNumber(stats?.total, 0),
+      successRate: toNumber(stats?.successRate, 0),
+      avgDurationMs: toNumber(stats?.avgDuration, 0),
+      topTools: (topTools || []).map((entry) => ({
+        tool: toString(entry.tool),
+        count: toNumber(entry.count, 0),
+      })),
+    };
+  } catch {
+    return { totalCalls: 0, successRate: 0, avgDurationMs: 0, topTools: [] };
+  }
+}

--- a/open-sse/mcp-server/scopeEnforcement.ts
+++ b/open-sse/mcp-server/scopeEnforcement.ts
@@ -1,0 +1,135 @@
+import { MCP_TOOL_MAP } from "./schemas/tools.ts";
+
+type AuthInfoLike = {
+  clientId?: string;
+  scopes?: string[];
+};
+
+export type McpToolExtraLike = {
+  authInfo?: AuthInfoLike;
+  sessionId?: string;
+  _meta?: unknown;
+};
+
+export type ScopeSource = "authInfo" | "meta" | "env" | "none";
+
+export interface CallerScopeContext {
+  callerId: string;
+  scopes: string[];
+  source: ScopeSource;
+}
+
+export interface ScopeCheckResult {
+  allowed: boolean;
+  required: string[];
+  provided: string[];
+  missing: string[];
+  reason?: string;
+}
+
+function normalizeScopeList(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const normalized = raw
+    .filter((value) => typeof value === "string")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return Array.from(new Set(normalized));
+}
+
+function extractMetaScopeList(meta: unknown): string[] {
+  if (!meta || typeof meta !== "object") return [];
+  const metaRecord = meta as Record<string, unknown>;
+
+  const direct = normalizeScopeList(metaRecord.scopes);
+  if (direct.length > 0) return direct;
+
+  const auth = metaRecord.auth;
+  if (auth && typeof auth === "object") {
+    const authScopes = normalizeScopeList((auth as Record<string, unknown>).scopes);
+    if (authScopes.length > 0) return authScopes;
+  }
+
+  const omni = metaRecord.omniroute;
+  if (omni && typeof omni === "object") {
+    const omniScopes = normalizeScopeList((omni as Record<string, unknown>).scopes);
+    if (omniScopes.length > 0) return omniScopes;
+  }
+
+  return [];
+}
+
+function scopeMatches(grantedScope: string, requiredScope: string): boolean {
+  if (grantedScope === "*" || grantedScope === requiredScope) {
+    return true;
+  }
+  if (grantedScope.endsWith("*")) {
+    const prefix = grantedScope.slice(0, -1);
+    return requiredScope.startsWith(prefix);
+  }
+  return false;
+}
+
+export function resolveCallerScopeContext(
+  extra: McpToolExtraLike | undefined,
+  fallbackScopes: readonly string[] = []
+): CallerScopeContext {
+  const callerId =
+    (typeof extra?.authInfo?.clientId === "string" && extra.authInfo.clientId.trim()) ||
+    (typeof extra?.sessionId === "string" && extra.sessionId.trim()) ||
+    "anonymous";
+
+  const authScopes = normalizeScopeList(extra?.authInfo?.scopes);
+  if (authScopes.length > 0) {
+    return { callerId, scopes: authScopes, source: "authInfo" };
+  }
+
+  const metaScopes = extractMetaScopeList(extra?._meta);
+  if (metaScopes.length > 0) {
+    return { callerId, scopes: metaScopes, source: "meta" };
+  }
+
+  const fallback = normalizeScopeList(fallbackScopes);
+  if (fallback.length > 0) {
+    return { callerId, scopes: fallback, source: "env" };
+  }
+
+  return { callerId, scopes: [], source: "none" };
+}
+
+export function evaluateToolScopes(
+  toolName: string,
+  callerScopes: readonly string[],
+  enforceScopes: boolean,
+  inlineScopes?: readonly string[]
+): ScopeCheckResult {
+  const provided = normalizeScopeList(callerScopes);
+
+  if (!enforceScopes) {
+    return { allowed: true, required: [], provided, missing: [] };
+  }
+
+  const toolScopes = inlineScopes ?? MCP_TOOL_MAP[toolName]?.scopes;
+  const required = Array.isArray(toolScopes) ? Array.from(toolScopes) : [];
+
+  if (required.length === 0) {
+    return {
+      allowed: false,
+      required: [],
+      provided,
+      missing: [],
+      reason: "tool_definition_missing",
+    };
+  }
+
+  const missing = required.filter(
+    (requiredScope) => !provided.some((grantedScope) => scopeMatches(grantedScope, requiredScope))
+  );
+
+  return {
+    allowed: missing.length === 0,
+    required,
+    provided,
+    missing,
+    reason: missing.length > 0 ? "missing_scopes" : undefined,
+  };
+}

--- a/open-sse/translator/registry.ts
+++ b/open-sse/translator/registry.ts
@@ -1,0 +1,41 @@
+type RequestTranslator = (
+  model: string,
+  body: Record<string, unknown>,
+  stream?: boolean,
+  credentials?: Record<string, unknown> | null
+) => unknown;
+
+type ResponseTranslator = (
+  chunk: Record<string, unknown>,
+  state: Record<string, unknown>
+) => unknown;
+
+const requestRegistry = new Map<string, RequestTranslator>();
+const responseRegistry = new Map<string, ResponseTranslator>();
+
+function makeKey(from: string, to: string) {
+  return `${from}:${to}`;
+}
+
+export function register(
+  from: string,
+  to: string,
+  requestFn?: RequestTranslator,
+  responseFn?: ResponseTranslator
+) {
+  const key = makeKey(from, to);
+  if (requestFn) {
+    requestRegistry.set(key, requestFn);
+  }
+  if (responseFn) {
+    responseRegistry.set(key, responseFn);
+  }
+}
+
+export function getRequestTranslator(from: string, to: string) {
+  return requestRegistry.get(makeKey(from, to));
+}
+
+export function getResponseTranslator(from: string, to: string) {
+  return responseRegistry.get(makeKey(from, to));
+}

--- a/src/lib/db/cliToolState.ts
+++ b/src/lib/db/cliToolState.ts
@@ -1,0 +1,159 @@
+/**
+ * CLI Tool State Persistence
+ *
+ * Stores last-configured timestamps and initial config snapshots
+ * for CLI tools in the key_value table.
+ *
+ * Namespaces:
+ *   - cliToolLastConfig: ISO timestamp of last configuration
+ *   - cliToolInitialConfig: JSON snapshot of pre-OmniRoute configuration
+ *
+ * @module lib/db/cliToolState
+ */
+
+import { getDbInstance, isBuildPhase, isCloud } from "./core";
+
+type JsonRecord = Record<string, unknown>;
+
+interface StatementLike<TRow = unknown> {
+  all: (...params: unknown[]) => TRow[];
+  get: (...params: unknown[]) => TRow | undefined;
+  run: (...params: unknown[]) => { changes?: number };
+}
+
+interface DbLike {
+  prepare: <TRow = unknown>(sql: string) => StatementLike<TRow>;
+}
+
+interface KeyValueRow {
+  key: string;
+  value: string;
+}
+
+function parseJsonValue(raw: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function toRecord(value: unknown): JsonRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : null;
+}
+
+// ──────────────── Last Configured Timestamp ────────────────
+
+/**
+ * Save last-configured timestamp for a CLI tool.
+ */
+export function saveCliToolLastConfigured(
+  toolId: string,
+  timestamp: string = new Date().toISOString()
+): void {
+  if (isBuildPhase || isCloud) return;
+  const db = getDbInstance() as unknown as DbLike;
+  db.prepare("INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES (?, ?, ?)").run(
+    "cliToolLastConfig",
+    toolId,
+    JSON.stringify(timestamp)
+  );
+}
+
+/**
+ * Get last-configured timestamp for a CLI tool.
+ * @returns ISO timestamp string or null if never configured.
+ */
+export function getCliToolLastConfigured(toolId: string): string | null {
+  if (isBuildPhase || isCloud) return null;
+  const db = getDbInstance() as unknown as DbLike;
+  const row = db
+    .prepare("SELECT value FROM key_value WHERE namespace = ? AND key = ?")
+    .get("cliToolLastConfig", toolId);
+  if (!row) return null;
+  const parsed = parseJsonValue((row as KeyValueRow).value);
+  return typeof parsed === "string" ? parsed : null;
+}
+
+/**
+ * Get all CLI tool last-configured timestamps.
+ * @returns Record<toolId, ISO timestamp>
+ */
+export function getAllCliToolLastConfigured(): Record<string, string> {
+  if (isBuildPhase || isCloud) return {};
+  const db = getDbInstance() as unknown as DbLike;
+  const rows = db
+    .prepare("SELECT key, value FROM key_value WHERE namespace = ?")
+    .all("cliToolLastConfig") as KeyValueRow[];
+  const result: Record<string, string> = {};
+  for (const row of rows) {
+    const parsed = parseJsonValue(row.value);
+    if (typeof parsed === "string") {
+      result[row.key] = parsed;
+    }
+  }
+  return result;
+}
+
+/**
+ * Delete last-configured timestamp for a CLI tool.
+ */
+export function deleteCliToolLastConfigured(toolId: string): void {
+  if (isBuildPhase || isCloud) return;
+  const db = getDbInstance() as unknown as DbLike;
+  db.prepare("DELETE FROM key_value WHERE namespace = ? AND key = ?").run(
+    "cliToolLastConfig",
+    toolId
+  );
+}
+
+// ──────────────── Initial Config Snapshot ────────────────
+
+/**
+ * Save the initial (pre-OmniRoute) config snapshot for a CLI tool.
+ * Only saves if no snapshot exists yet (first-time only).
+ * @returns true if saved, false if snapshot already exists.
+ */
+export function saveCliToolInitialConfig(toolId: string, config: JsonRecord): boolean {
+  if (isBuildPhase || isCloud) return false;
+  const db = getDbInstance() as unknown as DbLike;
+  // Only save if not already stored
+  const existing = db
+    .prepare("SELECT value FROM key_value WHERE namespace = ? AND key = ?")
+    .get("cliToolInitialConfig", toolId);
+  if (existing) return false;
+
+  db.prepare("INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES (?, ?, ?)").run(
+    "cliToolInitialConfig",
+    toolId,
+    JSON.stringify(config)
+  );
+  return true;
+}
+
+/**
+ * Get the initial config snapshot for a CLI tool.
+ * @returns Config object or null if no snapshot exists.
+ */
+export function getCliToolInitialConfig(toolId: string): JsonRecord | null {
+  if (isBuildPhase || isCloud) return null;
+  const db = getDbInstance() as unknown as DbLike;
+  const row = db
+    .prepare("SELECT value FROM key_value WHERE namespace = ? AND key = ?")
+    .get("cliToolInitialConfig", toolId);
+  if (!row) return null;
+  const parsed = parseJsonValue((row as KeyValueRow).value);
+  return toRecord(parsed);
+}
+
+/**
+ * Delete the initial config snapshot for a CLI tool.
+ */
+export function deleteCliToolInitialConfig(toolId: string): void {
+  if (isBuildPhase || isCloud) return;
+  const db = getDbInstance() as unknown as DbLike;
+  db.prepare("DELETE FROM key_value WHERE namespace = ? AND key = ?").run(
+    "cliToolInitialConfig",
+    toolId
+  );
+}

--- a/src/lib/db/prompts.ts
+++ b/src/lib/db/prompts.ts
@@ -1,0 +1,302 @@
+/**
+ * Prompt Template Versioning — L-6
+ *
+ * SQLite-backed prompt template storage with version tracking.
+ * Each prompt has a unique `slug`, and every save creates a new version
+ * (content-addressed via SHA-256 hash). Previous versions are retained
+ * for rollback and audit.
+ *
+ * @module lib/db/prompts
+ */
+
+import crypto from "crypto";
+import { getDbInstance } from "./core";
+
+interface StatementLike<TRow = unknown> {
+  all: (...params: unknown[]) => TRow[];
+  get: (...params: unknown[]) => TRow | undefined;
+  run: (...params: unknown[]) => { lastInsertRowid?: number | bigint; changes?: number };
+}
+
+interface DbLike {
+  prepare: <TRow = unknown>(sql: string) => StatementLike<TRow>;
+  exec: (sql: string) => void;
+  transaction: (fn: () => void) => () => void;
+}
+
+interface PromptRow {
+  id: unknown;
+  slug: unknown;
+  version: unknown;
+  content: unknown;
+  content_hash: unknown;
+  variables: unknown;
+  description: unknown;
+  is_active: unknown;
+  created_at: unknown;
+}
+
+interface PromptListRow {
+  slug: unknown;
+  active_version: unknown;
+  total_versions: unknown;
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number"
+    ? value
+    : typeof value === "bigint"
+      ? Number(value)
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value)
+        : fallback;
+}
+
+function toString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function parseVariables(value: unknown): string[] | null {
+  if (typeof value !== "string") return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    return parsed.filter((item): item is string => typeof item === "string");
+  } catch {
+    return null;
+  }
+}
+
+// ── Schema (auto-created on first access) ──
+
+const PROMPT_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS prompt_templates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug TEXT NOT NULL,
+    version INTEGER NOT NULL DEFAULT 1,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    variables TEXT,
+    description TEXT,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(slug, version)
+  );
+  CREATE INDEX IF NOT EXISTS idx_pt_slug ON prompt_templates(slug);
+  CREATE INDEX IF NOT EXISTS idx_pt_active ON prompt_templates(slug, is_active);
+  CREATE INDEX IF NOT EXISTS idx_pt_hash ON prompt_templates(content_hash);
+`;
+
+let _initialized = false;
+
+function ensureSchema(): void {
+  if (_initialized) return;
+  try {
+    const db = getDbInstance() as unknown as DbLike;
+    db.exec(PROMPT_SCHEMA);
+    _initialized = true;
+  } catch {
+    // Schema creation is best-effort during build phase
+  }
+}
+
+function hashContent(content: string): string {
+  return crypto.createHash("sha256").update(content).digest("hex").slice(0, 16);
+}
+
+// ── Public API ──
+
+export interface PromptTemplate {
+  id: number;
+  slug: string;
+  version: number;
+  content: string;
+  contentHash: string;
+  variables: string[] | null;
+  description: string | null;
+  isActive: boolean;
+  createdAt: string;
+}
+
+/**
+ * Save a prompt template. If the slug already exists and the content
+ * has changed, a new version is created. If content is identical,
+ * returns the existing version without duplicating.
+ */
+export function savePrompt(
+  slug: string,
+  content: string,
+  options: { variables?: string[]; description?: string } = {}
+): PromptTemplate {
+  ensureSchema();
+  const db = getDbInstance() as unknown as DbLike;
+  const hash = hashContent(content);
+
+  // Check if identical content already exists for this slug
+  const existing = db
+    .prepare<PromptRow>("SELECT * FROM prompt_templates WHERE slug = ? AND content_hash = ?")
+    .get(slug, hash);
+
+  if (existing) {
+    return rowToPrompt(existing);
+  }
+
+  // Deactivate previous active version
+  db.prepare("UPDATE prompt_templates SET is_active = 0 WHERE slug = ? AND is_active = 1").run(
+    slug
+  );
+
+  // Get next version number
+  const maxVersion = db
+    .prepare<{
+      max_v: unknown;
+    }>("SELECT MAX(version) as max_v FROM prompt_templates WHERE slug = ?")
+    .get(slug);
+  const nextVersion = toNumber(maxVersion?.max_v, 0) + 1;
+
+  // Insert new version
+  const result = db
+    .prepare(
+      `INSERT INTO prompt_templates (slug, version, content, content_hash, variables, description, is_active)
+       VALUES (?, ?, ?, ?, ?, ?, 1)`
+    )
+    .run(
+      slug,
+      nextVersion,
+      content,
+      hash,
+      options.variables ? JSON.stringify(options.variables) : null,
+      options.description || null
+    );
+
+  return {
+    id: toNumber(result.lastInsertRowid, 0),
+    slug,
+    version: nextVersion,
+    content,
+    contentHash: hash,
+    variables: options.variables || null,
+    description: options.description || null,
+    isActive: true,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Get the active (latest) version of a prompt by slug.
+ */
+export function getActivePrompt(slug: string): PromptTemplate | null {
+  ensureSchema();
+  const db = getDbInstance() as unknown as DbLike;
+  const row = db
+    .prepare<PromptRow>("SELECT * FROM prompt_templates WHERE slug = ? AND is_active = 1")
+    .get(slug);
+  return row ? rowToPrompt(row) : null;
+}
+
+/**
+ * Get a specific version of a prompt.
+ */
+export function getPromptVersion(slug: string, version: number): PromptTemplate | null {
+  ensureSchema();
+  const db = getDbInstance() as unknown as DbLike;
+  const row = db
+    .prepare<PromptRow>("SELECT * FROM prompt_templates WHERE slug = ? AND version = ?")
+    .get(slug, version);
+  return row ? rowToPrompt(row) : null;
+}
+
+/**
+ * List all versions of a prompt (newest first).
+ */
+export function listPromptVersions(slug: string): PromptTemplate[] {
+  ensureSchema();
+  const db = getDbInstance() as unknown as DbLike;
+  const rows = db
+    .prepare<PromptRow>("SELECT * FROM prompt_templates WHERE slug = ? ORDER BY version DESC")
+    .all(slug);
+  return rows.map(rowToPrompt);
+}
+
+/**
+ * List all prompt slugs with their active version info.
+ */
+export function listPrompts(): Array<{
+  slug: string;
+  activeVersion: number;
+  totalVersions: number;
+}> {
+  ensureSchema();
+  const db = getDbInstance() as unknown as DbLike;
+  const rows = db
+    .prepare<PromptListRow>(
+      `SELECT slug,
+              MAX(CASE WHEN is_active = 1 THEN version ELSE 0 END) as active_version,
+              COUNT(*) as total_versions
+       FROM prompt_templates
+       GROUP BY slug
+       ORDER BY slug`
+    )
+    .all();
+
+  return rows.map((r) => ({
+    slug: toString(r.slug),
+    activeVersion: toNumber(r.active_version, 0),
+    totalVersions: toNumber(r.total_versions, 0),
+  }));
+}
+
+/**
+ * Rollback to a previous version (makes it the active one).
+ */
+export function rollbackPrompt(slug: string, version: number): PromptTemplate | null {
+  ensureSchema();
+  const db = getDbInstance() as unknown as DbLike;
+
+  const target = db
+    .prepare<PromptRow>("SELECT * FROM prompt_templates WHERE slug = ? AND version = ?")
+    .get(slug, version);
+
+  if (!target) return null;
+
+  const rollback = db.transaction(() => {
+    db.prepare("UPDATE prompt_templates SET is_active = 0 WHERE slug = ?").run(slug);
+    db.prepare("UPDATE prompt_templates SET is_active = 1 WHERE slug = ? AND version = ?").run(
+      slug,
+      version
+    );
+  });
+  rollback();
+
+  return rowToPrompt({ ...target, is_active: 1 });
+}
+
+/**
+ * Render a prompt template by substituting variables.
+ */
+export function renderPrompt(slug: string, vars: Record<string, string> = {}): string | null {
+  const prompt = getActivePrompt(slug);
+  if (!prompt) return null;
+
+  let content = prompt.content;
+  for (const [key, value] of Object.entries(vars)) {
+    content = content.replace(new RegExp(`\\{\\{${key}\\}\\}`, "g"), value);
+  }
+  return content;
+}
+
+// ── Internal ──
+
+function rowToPrompt(row: PromptRow): PromptTemplate {
+  return {
+    id: toNumber(row.id, 0),
+    slug: toString(row.slug),
+    version: toNumber(row.version, 1),
+    content: toString(row.content),
+    contentHash: toString(row.content_hash),
+    variables: parseVariables(row.variables),
+    description: typeof row.description === "string" ? row.description : null,
+    isActive: row.is_active === 1 || row.is_active === true,
+    createdAt: toString(row.created_at),
+  };
+}

--- a/src/lib/db/stateReset.ts
+++ b/src/lib/db/stateReset.ts
@@ -1,0 +1,30 @@
+/**
+ * Central registry for DB module state resetters.
+ * Used by restore flows to clear prepared statement caches without cross-module imports.
+ */
+
+type DbStateResetter = () => void;
+
+const resetters = new Set<DbStateResetter>();
+
+/**
+ * Register a module-level state resetter.
+ * Duplicate function references are deduplicated by Set semantics.
+ */
+export function registerDbStateResetter(resetter: DbStateResetter) {
+  resetters.add(resetter);
+}
+
+/**
+ * Invoke all registered state resetters.
+ * A failing resetter must not block execution of the remaining handlers.
+ */
+export function resetAllDbModuleState() {
+  for (const resetter of resetters) {
+    try {
+      resetter();
+    } catch (error) {
+      console.warn("[DB] Failed to reset module state:", error);
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,70 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "checkJs": false,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ],
+      "@omniroute/open-sse": [
+        "./open-sse"
+      ],
+      "@omniroute/open-sse/*": [
+        "./open-sse/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    ".next/dev/dev/types/**/*.ts",
+    ".next-playwright/types/**/*.ts",
+    ".next-playwright/dev/types/**/*.ts",
+    ".build/next/types/**/*.ts",
+    ".build/next/dev/types/**/*.ts",
+    ".build/next/dev/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "open-sse",
+    "dist",
+    "coverage",
+    ".source",
+    ".tmp",
+    ".claude",
+    ".worktrees",
+    "@omniroute",
+    "_tasks",
+    "_ideia",
+    "_mono_repo",
+    "_references"
+  ]
+}


### PR DESCRIPTION
## Summary

- Wires 3 substrate dispatch MCP tools (`substrate_dispatch`, `substrate_plan`, `substrate_health`) into OmniRoute MCP server as F3 phase integration
- Full MCP audit logger (`audit.ts`) with dual SQLite driver (better-sqlite3 / node:sqlite fallback), SHA-256 input hashing, output truncation
- Scope enforcement (`scopeEnforcement.ts`) with CallerScopeContext resolution from authInfo/meta/env/none, wildcard scope matching
- Restores `tsconfig.json` root base file deleted by prior PR refactor (fixes `lib: []` diagnostic flood across `open-sse/`)
- Adds supporting DB domain modules and translator registry required for clean typecheck

## Test plan

- [ ] `npm run typecheck:core` passes (exit 0 confirmed locally)
- [ ] Substrate dispatch tools appear in MCP tool list when `SUBSTRATE_HTTP_URL` is set
- [ ] `substrate_health` returns health status from substrate HTTP server
- [ ] Audit entries written to `mcp_tool_audit` table on tool invocation