### PR TITLE
fix(ci/security): workflow injection + unpinned action (quality-gate + latency-budget)

### DIFF
--- a/.github/workflows/latency-budget.yml
+++ b/.github/workflows/latency-budget.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Annotate PR with budget results
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -141,7 +141,7 @@ jobs:
 
       - name: Comment PR with regression report
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/reusable/quality-gate.yml
+++ b/.github/workflows/reusable/quality-gate.yml
@@ -51,12 +51,14 @@ jobs:
     name: Quality Gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Parse not-applicable gates
         id: parse-na
+        # Bind workflow_call input to env var before use in shell — prevents script injection.
+        env:
+          NA_GATES: ${{ inputs.not-applicable }}
         run: |
-          NA_GATES="${{ inputs.not-applicable }}"
           echo "na_gates=${NA_GATES}" >> $GITHUB_OUTPUT
           [[ "$NA_GATES" == *"a11y"* ]] && echo "skip_a11y=true" >> $GITHUB_OUTPUT || echo "skip_a11y=false" >> $GITHUB_OUTPUT
           [[ "$NA_GATES" == *"e2e"* ]] && echo "skip_e2e=true" >> $GITHUB_OUTPUT || echo "skip_e2e=false" >> $GITHUB_OUTPUT
@@ -67,8 +69,10 @@ jobs:
 
       - name: Validate coverage report
         if: ${{ !contains(steps.parse-na.outputs.na_gates, 'coverage') }}
+        # Bind workflow_call input to env var before use in shell — prevents script injection.
+        env:
+          REPORT: ${{ inputs.coverage-report }}
         run: |
-          REPORT="${{ inputs.coverage-report }}"
           if [ ! -f "$REPORT" ]; then
             echo "❌ Coverage report not found: $REPORT"
             exit 1
@@ -78,10 +82,12 @@ jobs:
       - name: Parse coverage threshold
         if: ${{ !contains(steps.parse-na.outputs.na_gates, 'coverage') }}
         id: coverage
+        # Bind workflow_call inputs to env vars before use in shell — prevents script injection.
+        env:
+          THRESHOLD: ${{ inputs.threshold }}
+          FORMAT: ${{ inputs.coverage-format }}
+          REPORT: ${{ inputs.coverage-report }}
         run: |
-          THRESHOLD="${{ inputs.threshold }}"
-          FORMAT="${{ inputs.coverage-format }}"
-          REPORT="${{ inputs.coverage-report }}"
           if [ "$FORMAT" = "lcov" ]; then
             LINES_HIT=$(grep '^LH:' "$REPORT" | awk -F: '{sum += $2} END {print sum}')
             LINES_FOUND=$(grep '^LF:' "$REPORT" | awk -F: '{sum += $2} END {print sum}')


### PR DESCRIPTION
## Security fixes — 2 findings

### Finding 1: Script injection via workflow_call inputs (quality-gate.yml)

**File**: `.github/workflows/reusable/quality-gate.yml`
**Risk**: `${{ inputs.not-applicable }}`, `${{ inputs.coverage-report }}`, `${{ inputs.coverage-format }}`, `${{ inputs.threshold }}` were interpolated directly into `run:` blocks. A caller passing a crafted input value could inject arbitrary shell commands.

**Fix**: Bind each input to a step-level `env:` var and reference via `$VARNAME` in shell. This is the canonical safe pattern (GitHub security guidance: https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).

### Finding 2: Unpinned third-party action with write scope (latency-budget.yml)

**File**: `.github/workflows/latency-budget.yml`
**Risk**: `actions/github-script@v7` (tag reference) used 2× on a workflow with `pull-requests: write`. Tag mutation by the action owner would execute arbitrary code with write permission on PR comments.

**Fix**: Pin both instances to full commit SHA `f28e40c7f34bde8b3046d885e986cb6290c5673b` (v7 tag as of 2026-07-02).

## Verification

- Both files pass YAML lint (no syntax changes beyond the security fixes)
- All `${{ env.* }}` interpolations in `run:` blocks are safe (env context is not attacker-controlled)
- Summary/report echo steps use `${{ steps.*.outputs.* }}` from internal step outputs — safe