### PR TITLE
fix(typecheck): resolve 20 remaining type errors

### DIFF
--- a/open-sse/executors/base.ts
+++ b/open-sse/executors/base.ts
@@ -1,4 +1,5 @@
 import { HTTP_STATUS, FETCH_TIMEOUT_MS } from "../config/constants.ts";
+import { mergeAbortSignals } from "./mergeAbortSignals.ts";
 import { mergeClientAnthropicBeta } from "../config/anthropicHeaders.ts";
 import { applyContextEditingToBody } from "../config/contextEditing.ts";
 import { findOffendingField, stripGroqUnsupportedFields } from "../config/providerFieldStrips.ts";
@@ -172,7 +173,10 @@ export function mergeUpstreamExtraHeaders(
   }
 }
 
-// extracted to ./mergeAbortSignals.ts (Wave 6 resilience leaf)
+// extracted to ./mergeAbortSignals.ts (Wave 6 resilience leaf); re-exported here so
+// existing barrel importers (e.g. ./antigravity) keep resolving it from "./base".
+export { mergeAbortSignals } from "./mergeAbortSignals.ts";
+
 function hasActiveClaudeThinking(body: Record<string, unknown>): boolean {
   const thinking = body.thinking as Record<string, unknown> | undefined;
   return thinking?.type === "enabled" || thinking?.type === "adaptive";

--- a/open-sse/mcp-server/server.ts
+++ b/open-sse/mcp-server/server.ts
@@ -1321,13 +1321,13 @@ export function createMcpServer(): McpServer {
       toolDef.name,
       {
         description: toolDef.description,
-        inputSchema: toolDef.inputSchema,
+        inputSchema: toolDef.inputSchema as unknown as z.ZodTypeAny,
       },
       withScopeEnforcement(
         toolDef.name,
         async (args) => {
           try {
-            const parsedArgs = toolDef.inputSchema.parse(args ?? {});
+            const parsedArgs = (toolDef.inputSchema as unknown as z.ZodTypeAny).parse(args ?? {}) as Record<string, unknown>;
             const result = await toolDef.handler(parsedArgs);
             return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
           } catch (err) {

--- a/open-sse/translator/formats.ts
+++ b/open-sse/translator/formats.ts
@@ -5,6 +5,7 @@ export const FORMATS = {
   OPENAI_RESPONSE: "openai-response",
   CLAUDE: "claude",
   GEMINI: "gemini",
+  GEMINI_CLI: "gemini-cli",
   CODEX: "codex",
   ANTIGRAVITY: "antigravity",
   KIRO: "kiro",

--- a/src/lib/combos/steps.ts
+++ b/src/lib/combos/steps.ts
@@ -11,6 +11,7 @@ export interface ComboModelStep {
   weight: number;
   label?: string;
   tags?: string[];
+  allowedConnectionIds?: string[];
 }
 
 export interface ComboRefStep {
@@ -277,6 +278,11 @@ export function normalizeComboStep(
   const tags = Array.isArray(value.tags)
     ? value.tags.map((tag) => toTrimmedString(tag)).filter((tag): tag is string => !!tag)
     : undefined;
+  const allowedConnectionIds = Array.isArray(value.allowedConnectionIds)
+    ? value.allowedConnectionIds
+        .map((id) => toTrimmedString(id))
+        .filter((id): id is string => !!id)
+    : undefined;
 
   return {
     id:
@@ -289,6 +295,7 @@ export function normalizeComboStep(
     weight,
     ...(label ? { label } : {}),
     ...(tags && tags.length > 0 ? { tags } : {}),
+    ...(allowedConnectionIds && allowedConnectionIds.length > 0 ? { allowedConnectionIds } : {}),
   };
 }
 

--- a/src/lib/db/combos.ts
+++ b/src/lib/db/combos.ts
@@ -64,10 +64,10 @@ function normalizeStoredCombo(
   combo: JsonRecord,
   db: ReturnType<typeof getDbInstance>,
   extraNames: string[] = []
-): JsonRecord {
+) {
   return normalizeComboRecord(combo, {
     allCombos: getComboNameSet(db, extraNames),
-  }) as JsonRecord;
+  });
 }
 
 function parseComboRow(row: unknown): JsonRecord | null {

--- a/src/lib/memory/store.ts
+++ b/src/lib/memory/store.ts
@@ -30,6 +30,8 @@ interface MemoryRow {
   created_at: string;
   updated_at: string;
   expires_at: string | null;
+  access_count?: number | null;
+  last_accessed_at?: string | null;
 }
 
 // Memory cache configuration
@@ -79,6 +81,8 @@ function rowToMemory(row: MemoryRow): Memory {
     createdAt: new Date(String(row.created_at)),
     updatedAt: new Date(String(row.updated_at)),
     expiresAt: row.expires_at ? new Date(String(row.expires_at)) : null,
+    accessCount: typeof row.access_count === "number" ? row.access_count : 0,
+    lastAccessedAt: row.last_accessed_at ? new Date(String(row.last_accessed_at)) : null,
   };
 }
 
@@ -155,7 +159,7 @@ function scheduleVectorUpsert(id: string, content: string): void {
  * Create a new memory entry (UPSERT: updates existing if same apiKeyId + key)
  */
 export async function createMemory(
-  memory: Omit<Memory, "id" | "createdAt" | "updatedAt">
+  memory: Omit<Memory, "id" | "createdAt" | "updatedAt" | "accessCount" | "lastAccessedAt">
 ): Promise<Memory> {
   const db = getDbInstance();
   const now = new Date().toISOString();
@@ -190,6 +194,10 @@ export async function createMemory(
       createdAt: new Date(String(existing.created_at)),
       updatedAt: new Date(now),
       expiresAt: memory.expiresAt ?? null,
+      accessCount: typeof existing.access_count === "number" ? existing.access_count : 0,
+      lastAccessedAt: existing.last_accessed_at
+        ? new Date(String(existing.last_accessed_at))
+        : null,
     };
 
     // Invalidate and update cache
@@ -259,6 +267,8 @@ export async function createMemory(
     createdAt: new Date(now),
     updatedAt: new Date(now),
     expiresAt: memory.expiresAt ?? null,
+    accessCount: 0,
+    lastAccessedAt: null,
   };
 
   // Cache the newly created memory
@@ -542,4 +552,29 @@ export function getMemoryTokensUsed(apiKeyId?: string): number {
   );
   const row = stmt.get(...(apiKeyId ? [apiKeyId] : [])) as { tokensUsed: number } | undefined;
   return row?.tokensUsed ?? 0;
+}
+
+/**
+ * TV6: record that the given memories were injected into a prompt. Increments
+ * `access_count` and stamps `last_accessed_at` so the decay clock re-bases and access
+ * immunity can accrue. Best-effort and non-blocking by contract — callers fire-and-forget;
+ * any error (DB closed in test teardown, missing columns pre-migration) is swallowed so
+ * retrieval is never impacted.
+ */
+export function recordMemoryAccess(ids: string[]): void {
+  if (!Array.isArray(ids) || ids.length === 0) return;
+  const unique = Array.from(new Set(ids.filter((id) => typeof id === "string" && id)));
+  if (unique.length === 0) return;
+  try {
+    const db = getDbInstance();
+    const placeholders = unique.map(() => "?").join(", ");
+    const stmt = db.prepare(
+      `UPDATE memories SET access_count = access_count + 1, last_accessed_at = ? ` +
+        `WHERE id IN (${placeholders})`
+    );
+    stmt.run(new Date().toISOString(), ...unique);
+    for (const id of unique) invalidateMemoryCache(id);
+  } catch {
+    // intentional swallow — access tracking is opportunistic telemetry, never load-bearing
+  }
 }

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -270,7 +270,6 @@ function validateProviderSpecificData(
 // Re-export validation helpers from dedicated module to avoid webpack barrel-file
 // optimization bug that truncates exports from large files.
 export { validateBody, isValidationFailure } from "./helpers";
-export type { ValidationResult } from "./helpers";
 
 // ──── Provider Schemas ────
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,7 @@
  * Import from "@/types" in any file.
  */
 
-export type { ProviderConnection, ProviderNode, ModelCooldownErrorPayload } from "./provider";
+export type { ModelCooldownErrorPayload } from "./provider";
 export type { ApiKey } from "./apiKey";
 export type { Combo, ComboStrategy, ComboNode } from "./combo";
 export type { UsageEntry, UsageStats, ProviderUsageStats, ModelUsageStats, CallLog } from "./usage";


### PR DESCRIPTION
Fixes 20 remaining type errors across 7 clusters:

- **base.ts**: import + re-export `mergeAbortSignals` from its extracted leaf (`./mergeAbortSignals.ts`); the call sites at lines 616 and 825 now resolve, and `antigravity.ts` named import works
- **formats.ts**: add `GEMINI_CLI: "gemini-cli"` to `FORMATS` constant (used in response translator and stream utils)
- **combos/steps.ts**: add `allowedConnectionIds?: string[]` to `ComboModelStep` interface (used in `comboStructure.ts` per-step account allowlist)
- **db/combos.ts**: remove redundant `as JsonRecord` cast so `normalizeComboRecord` return type flows through correctly
- **memory/store.ts**: add `access_count`/`last_accessed_at` to `MemoryRow`; propagate to `rowToMemory`, update path, and `createdMemory`; update `createMemory` param `Omit` to exclude `accessCount`/`lastAccessedAt`; export `recordMemoryAccess` function (used by `retrieval.ts`)
- **validation/schemas.ts**: remove re-export of non-existent `ValidationResult` type from `./helpers`
- **types/index.ts**: remove exports of non-existent `ProviderConnection`/`ProviderNode` types from `./provider`
- **mcp-server/server.ts**: cast `dispatchTools` `inputSchema` via `unknown` to `z.ZodTypeAny` at the two call sites where it is passed to `registerTool` and `.parse()`