### PR TITLE
fix(memory,mcp): add migration 111 + real Zod schemas for substrate dispatch tools

### DIFF
--- a/open-sse/mcp-server/tools/dispatchTools.ts
+++ b/open-sse/mcp-server/tools/dispatchTools.ts
@@ -11,10 +11,12 @@
  *   SUBSTRATE_HTTP_URL env var (e.g., http://localhost:8000)
  */
 
+import { z } from "zod";
+
 interface McpToolExtraLike {
   name: string;
   description: string;
-  inputSchema: Record<string, unknown>;
+  inputSchema: z.ZodTypeAny;
   handler: (input: Record<string, unknown>, extra?: Record<string, unknown>) => Promise<object>;
 }
 
@@ -117,31 +119,22 @@ export const dispatchTools: McpToolExtraLike[] = [
     name: "substrate_dispatch",
     description:
       "Dispatch a prompt to substrate with optional tier-based model routing (heavy=reasoning, main=standard, worker=fast). Returns task status and artifacts.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        prompt: {
-          type: "string",
-          description: "The prompt, task description, or codebase instruction to dispatch.",
-        },
-        tier: {
-          type: "string",
-          enum: ["heavy", "main", "worker"],
-          description:
-            "Model tier: heavy (gpt-5.5 reasoning), main (gpt-5.4-mini), worker (codex spark). Defaults to auto.",
-        },
-        engine: {
-          type: "string",
-          enum: ["forge", "codex", "claude", "agentapi"],
-          description: "Execution engine. Defaults to forge.",
-        },
-        cwd: {
-          type: "string",
-          description: "Working directory for execution context (optional).",
-        },
-      },
-      required: ["prompt"],
-    },
+    inputSchema: z.object({
+      prompt: z
+        .string()
+        .describe("The prompt, task description, or codebase instruction to dispatch."),
+      tier: z
+        .enum(["heavy", "main", "worker"])
+        .optional()
+        .describe(
+          "Model tier: heavy (gpt-5.5 reasoning), main (gpt-5.4-mini), worker (codex spark). Defaults to auto."
+        ),
+      engine: z
+        .enum(["forge", "codex", "claude", "agentapi"])
+        .optional()
+        .describe("Execution engine. Defaults to forge."),
+      cwd: z.string().optional().describe("Working directory for execution context (optional)."),
+    }),
     handler: async (
       input: Record<string, unknown>,
       extra?: Record<string, unknown>,
@@ -159,25 +152,14 @@ export const dispatchTools: McpToolExtraLike[] = [
     name: "substrate_plan",
     description:
       "Invoke substrate planner to generate task plan without execution. Returns structured plan for review before running dispatch.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        prompt: {
-          type: "string",
-          description: "Task description or request to plan.",
-        },
-        engine: {
-          type: "string",
-          enum: ["forge", "codex", "claude", "agentapi"],
-          description: "Planner engine. Defaults to claude.",
-        },
-        cwd: {
-          type: "string",
-          description: "Working directory context (optional).",
-        },
-      },
-      required: ["prompt"],
-    },
+    inputSchema: z.object({
+      prompt: z.string().describe("Task description or request to plan."),
+      engine: z
+        .enum(["forge", "codex", "claude", "agentapi"])
+        .optional()
+        .describe("Planner engine. Defaults to claude."),
+      cwd: z.string().optional().describe("Working directory context (optional)."),
+    }),
     handler: async (
       input: Record<string, unknown>,
       extra?: Record<string, unknown>,
@@ -193,10 +175,7 @@ export const dispatchTools: McpToolExtraLike[] = [
   {
     name: "substrate_health",
     description: "Health check: verify substrate HTTP server is reachable and operational.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-    },
+    inputSchema: z.object({}),
     handler: async (
       _input: Record<string, unknown>,
       extra?: Record<string, unknown>,

--- a/src/lib/db/migrations/111_memory_typed_decay.sql
+++ b/src/lib/db/migrations/111_memory_typed_decay.sql
@@ -1,0 +1,10 @@
+-- TV6 — Typed memory decay: track access frequency so decay can grant access-based immunity.
+--
+-- `access_count` increments each time a memory is injected into a prompt; `last_accessed_at`
+-- records the most recent injection (and re-bases the decay clock so recently-used memories
+-- survive). Both default to a never-accessed baseline, so every pre-existing row behaves as
+-- freshly-created: its decay clock falls back to `created_at` and its access count starts at 0.
+-- These columns only feed the OPT-IN, default-off decay sweep (`MEMORY_TYPED_DECAY_ENABLED`);
+-- with the sweep disabled they are pure, harmless telemetry.
+ALTER TABLE memories ADD COLUMN access_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE memories ADD COLUMN last_accessed_at TEXT;


### PR DESCRIPTION
PR #196 resolved the shared typecheck errors but left two **latent runtime bugs** on `main` that a typecheck pass alone cannot catch. This PR fixes both (superseding the now-closed #198, which was rebased down to exactly these two files before its branch got reused by another session).

## 1. Missing migration for memory access-tracking columns
`src/lib/memory/store.ts` reads/writes `access_count` and `last_accessed_at` (9 references), but **no migration on `main` creates those columns** (max migration was 107). At runtime the memory access-tracking SQL throws `no such column: access_count`.

Adds `src/lib/db/migrations/111_memory_typed_decay.sql` — the two TV6 typed-decay telemetry columns (`access_count INTEGER NOT NULL DEFAULT 0`, `last_accessed_at TEXT`). Both default to a never-accessed baseline and only feed the opt-in, default-off decay sweep, so pre-existing rows are unaffected.

## 2. Substrate dispatch MCP tools would crash on first call
`open-sse/mcp-server/tools/dispatchTools.ts` declared `inputSchema` as a plain JSON-schema object literal, but `server.ts` calls `toolDef.inputSchema.parse(...)`. #196 silenced the resulting type error with `as unknown as z.ZodTypeAny`, but a plain object has no `.parse()` method — the 3 substrate tools (`substrate_dispatch`, `substrate_plan`, `substrate_health`) would throw on first invocation.

Converts them to real `z.object({...})` schemas (satisfies Hard Rule #7: validate inputs with Zod), so `.parse()` works at runtime and validation is enforced.

## Verification
`npm run typecheck:core` = **0 errors** on the rebased branch (against current `origin/main`).