### PR TITLE
test(autoCombo): raise timeout on tieredRotation stress tests

### DIFF
--- a/tests/unit/autoCombo/tieredRotation.test.ts
+++ b/tests/unit/autoCombo/tieredRotation.test.ts
@@ -106,7 +106,10 @@ describe("Tiered Rotation in selectProvider", () => {
     resetDiversity();
   });
 
-  it("smart combo rotates within top tier across many requests", () => {
+  // Stress test: pays the one-time DB init on first getTaskFitness() call in
+  // this file plus many selectProvider() iterations, which exceeds vitest's
+  // default 5000ms limit. Raise the budget rather than thin the sample.
+  it("smart combo rotates within top tier across many requests", { timeout: 30000 }, () => {
     const topA = makeCandidate({ provider: "openai", model: "gpt-4o", quotaRemaining: 95 });
     const topB = makeCandidate({ provider: "anthropic", model: "claude-opus", quotaRemaining: 90 });
     const topC = makeCandidate({ provider: "google", model: "gemini-ultra", quotaRemaining: 88 });
@@ -123,7 +126,7 @@ describe("Tiered Rotation in selectProvider", () => {
     expect(seen.has("openai/gpt-4o") || seen.has("anthropic/claude-opus")).toBe(true);
   });
 
-  it("cheap combo pulls from rest tier (lower scores) more often than smart", () => {
+  it("cheap combo pulls from rest tier (lower scores) more often than smart", { timeout: 30000 }, () => {
     const top = makeCandidate({ provider: "openai", model: "gpt-4o", quotaRemaining: 100 });
     const rest = makeCandidate({
       provider: "cheap-provider",
@@ -175,7 +178,7 @@ describe("scorePool with connectionDensity", () => {
 });
 
 describe("Per-Connection Rotation", () => {
-  it("rotates across all 43 Cerebras connection IDs, not just one", () => {
+  it("rotates across all 43 Cerebras connection IDs, not just one", { timeout: 30000 }, () => {
     const cerebrasCandidates: ProviderCandidate[] = Array.from({ length: 43 }, (_, i) =>
       makeCandidate({
         provider: "cerebras",


### PR DESCRIPTION
## Problem

Three stress tests in `tests/unit/autoCombo/tieredRotation.test.ts` hit vitest's default 5000ms per-test limit and time out:

1. `smart combo rotates within top tier across many requests` (50 iterations, 4-candidate pool)
2. `cheap combo pulls from rest tier (lower scores) more often than smart` (200 iterations, 2-candidate pool)
3. `rotates across all 43 Cerebras connection IDs, not just one` (43-candidate pool, 200 iterations)

The first `getTaskFitness()` call in the file boots the SQLite migration runner (~2.6s one-time DB init). Combined with vitest's collection/pool overhead and the per-test iteration work, each test blows past the 5s default.

## Fix (Option A — per-test timeout)

Added `{ timeout: 30000 }` to each of the three `it(...)` calls. Chosen over reducing iteration counts (Option C) because Option A preserves the sample sizes and cannot alter the tests' statistical validity — the tests still exercise the exact same rotation behavior they were written to verify. Tests are **not** skipped or disabled.

## Validation

The file is vitest-native (`vi.mock` at the top), and the vitest runner is currently broken in worktrees (EXIT=194, zero output — tracked separately). Per Hard Rule #18, the rotation logic + timing were validated with a standalone `tsx` timing probe reproducing all three tests' bodies:

```
test3 connections seen: 43 (need >=10)  elapsed(incl DB init): 2640 ms
test1 seen.size: 4 (need >=2)  hasTop: true   elapsed(warm): 27 ms
test2 cheap count: 78 (need >0)  elapsed(warm): 115 ms
```

All three assertions pass; the DB-init cost (~2.6s) is what pushes the file over the 5s default. The 30000ms budget resolves it with no change to test behavior.