### PR TITLE
fix(sse): registry reasoning fallback in :free filter when DB caps unavailable (#4517)

### DIFF
--- a/open-sse/services/autoCombo/suffixComposition.ts
+++ b/open-sse/services/autoCombo/suffixComposition.ts
@@ -20,6 +20,7 @@ import type { AutoVariant } from "./autoPrefix";
 import { classifyTier } from "../tierResolver";
 import { getResolvedModelCapabilities } from "@/lib/modelCapabilities";
 import { isVisionModelId } from "@/shared/constants/visionModels";
+import { getRegistryEntry } from "../../config/providerRegistry";
 
 export type AutoCategory = "coding" | "reasoning" | "vision" | "chat" | "multimodal";
 export type AutoTier = "fast" | "cheap" | "floor" | "free" | "reliable" | "pro";
@@ -123,7 +124,11 @@ export function buildAutoCandidateFilter(
         const caps = getResolvedModelCapabilities({ provider: c.provider, model: c.model });
         return caps.reasoning === true || caps.supportsThinking === true;
       } catch {
-        return false;
+        // Capability resolution is DB-backed and can fail when the DB is
+        // unavailable (e.g. no-DB test env). Fall back to the provider
+        // registry's static reasoning declaration so a model flagged
+        // `supportsReasoning` isn't silently dropped from the reasoning pool.
+        return registryDeclaresReasoning(c);
       }
     });
   }
@@ -143,5 +148,15 @@ function safeClassifyTier(c: PoolCandidate): string {
     return classifyTier(c.provider, c.model).tier;
   } catch {
     return "cheap";
+  }
+}
+
+function registryDeclaresReasoning(c: PoolCandidate): boolean {
+  try {
+    const entry = getRegistryEntry(c.provider);
+    const model = entry?.models?.find((m) => m.id === c.model);
+    return model?.supportsReasoning === true;
+  } catch {
+    return false;
   }
 }


### PR DESCRIPTION
Fixes the failing `reasoning:free` / `opencode/big-pickle` assertion in `tests/unit/autoCombo/suffixComposition-4517.test.ts`.

## Root cause
`buildAutoCandidateFilter` (open-sse/services/autoCombo/suffixComposition.ts) resolves the reasoning capability check via `getResolvedModelCapabilities`, which is DB-backed. In a no-DB environment (the vitest test env) that call throws, and the `catch` returned `false` — silently dropping models the provider registry statically declares reasoning-capable. `opencode/big-pickle` (`supportsReasoning: true` in the registry) was therefore excluded from the `reasoning:free` pool.

Note: the noAuth free-provider-list part described in the issue (opencode/mimocode missing from `freeProviders`) was **already fixed at HEAD** via `deriveNoAuthFreeProviders()` in `tierConfig.ts`. The genuinely-failing assertion was the reasoning capability check.

## Fix
In the reasoning check `catch`, fall back to the provider registry`s static `supportsReasoning` flag (`registryDeclaresReasoning` helper, DB-free via `getRegistryEntry`) instead of returning `false`.

## Validation
- `npm run typecheck:core` — clean.
- Happy-path probe (working DB): all 4517 test assertions pass.
- Fallback-path probe (DB throws): `registryDeclaresReasoning` verdicts correct DB-free — `big-pickle: true`, `deepseek-v4-flash-free: true`, `minimax-m2.5-free: false`, `unknown: false`.

Test coverage: existing `tests/unit/autoCombo/suffixComposition-4517.test.ts` (its `reasoning:free`/`big-pickle` assertion was the failing case this fixes).