### PR TITLE
fix(executor): preserve system role for GLM ≥5.1 models (#5610)

### DIFF
--- a/open-sse/services/roleNormalizer.ts
+++ b/open-sse/services/roleNormalizer.ts
@@ -52,10 +52,23 @@ function defaultPreserveDeveloperForProvider(provider: string): boolean {
  * Uses prefix matching (e.g., "glm-" matches "glm-4.7", "glm-4.5", etc.)
  */
 const MODELS_WITHOUT_SYSTEM_ROLE = [
-  "glm-", // ZhipuAI GLM models (prefix: glm-5.1, glm-4.7, etc.)
   "glm", // Exact match for model id "glm" (e.g., Pollinations)
   "ernie-", // Baidu ERNIE models
 ];
+
+function isUnsupportedGlmSystemRoleModel(model: string): boolean {
+  // GLM 5.1+ models now support system-role injection. Older GLM generations do not.
+  const glmMatch = model.match(/^glm-(\d+)(?:\.(\d+))?/i);
+  if (!glmMatch) return true;
+
+  const major = Number(glmMatch[1] ?? "0");
+  const minor = Number(glmMatch[2] ?? "0");
+
+  if (Number.isNaN(major) || Number.isNaN(minor)) return true;
+  if (major > 5) return false;
+  if (major < 5) return true;
+  return minor < 1;
+}
 
 interface MessageContentPart {
   type?: string;
@@ -92,7 +105,17 @@ function supportsSystemRole(provider: string, model: string): boolean {
 
   const modelLower = (model || "").toLowerCase();
   for (const prefix of MODELS_WITHOUT_SYSTEM_ROLE) {
+    if (prefix === "glm") {
+      // Bare "glm" is an exact-match id (e.g., Pollinations), not a prefix.
+      // Versioned GLM ids (glm-5.1, etc.) are gated separately below.
+      if (modelLower === "glm") return false;
+      continue;
+    }
     if (modelLower.startsWith(prefix)) return false;
+  }
+
+  if (modelLower.startsWith("glm-") && isUnsupportedGlmSystemRoleModel(modelLower)) {
+    return false;
   }
 
   return true;

--- a/tests/unit/memory-glm-injection.test.ts
+++ b/tests/unit/memory-glm-injection.test.ts
@@ -122,7 +122,7 @@ describe("injectMemory — GLM providers use user role (#1701)", () => {
 // ── normalizeSystemRole — GLM model names ──────────────────────────────────────
 
 describe("normalizeSystemRole — GLM model names (#1701)", () => {
-  it("should convert system→user for glm-5.1", () => {
+  it("should preserve system role for glm-5.1", () => {
     const messages = [
       { role: "system", content: "Memory context: test" },
       { role: "user", content: "Hello" },
@@ -130,8 +130,20 @@ describe("normalizeSystemRole — GLM model names (#1701)", () => {
     const result = normalizeSystemRole(messages, "glm", "glm-5.1");
     assert.ok(Array.isArray(result));
     const roles = (result as { role: string }[]).map((m) => m.role);
-    assert.ok(!roles.includes("system"), "system role should be converted");
-    assert.ok(roles.includes("user"), "should have user role");
+    assert.ok(roles.includes("system"), "system role should be preserved");
+    assert.ok(roles.includes("user"), "should keep user role");
+  });
+
+  it("should preserve system role for glm-5.2", () => {
+    const messages = [
+      { role: "system", content: "Memory context: test" },
+      { role: "user", content: "Hello" },
+    ];
+    const result = normalizeSystemRole(messages, "glm", "glm-5.2");
+    assert.ok(Array.isArray(result));
+    const roles = (result as { role: string }[]).map((m) => m.role);
+    assert.ok(roles.includes("system"), "system role should be preserved");
+    assert.ok(roles.includes("user"), "should keep user role");
   });
 
   it("should convert system→user for glm-4.7", () => {

--- a/tests/unit/role-normalizer.test.ts
+++ b/tests/unit/role-normalizer.test.ts
@@ -84,6 +84,16 @@ test("normalizeSystemRole merges system and developer content into the first use
   ]);
 });
 
+test("normalizeSystemRole preserves system role for glm-5.1 and glm-5.2", () => {
+  const messages = [
+    { role: "system", content: "follow policy" },
+    { role: "user", content: "say hello" },
+  ];
+
+  assert.deepEqual(normalizeSystemRole(messages, "openai", "glm-5.1"), messages);
+  assert.deepEqual(normalizeSystemRole(messages, "openai", "glm-5.2"), messages);
+});
+
 test("normalizeSystemRole inserts a user message when no user exists and drops empty system payloads", () => {
   const messages = [
     { role: "system", content: [{ type: "image_url", image_url: { url: "ignored" } }] },
@@ -96,6 +106,22 @@ test("normalizeSystemRole inserts a user message when no user exists and drops e
   assert.deepEqual(result, [
     { role: "user", content: "[System Instructions]\nplain developer text" },
     { role: "assistant", content: "ready" },
+  ]);
+});
+
+test("normalizeSystemRole converts system role for older glm-5.0 models", () => {
+  const messages = [
+    { role: "system", content: "[Context compressed: earlier messages removed]" },
+    { role: "user", content: "say hello" },
+  ];
+
+  const result = normalizeSystemRole(messages, "openai", "glm-5.0");
+
+  assert.deepEqual(result, [
+    {
+      role: "user",
+      content: "[System Instructions]\n[Context compressed: earlier messages removed]\n\n[User Message]\nsay hello",
+    },
   ]);
 });
 


### PR DESCRIPTION
Cherry-picks the GLM 5.x system-role fix (originally f5cba5819, from fix/5610-glm-5-system-role) onto main, with manual conflict resolution against main's roleNormalizer lineage.

## Problem
`MODELS_WITHOUT_SYSTEM_ROLE` carried a blanket `"glm-"` prefix, so `normalizeSystemRole` stripped the `system` role from **all** GLM models — including GLM 5.1+, which do support system-role injection. This degraded prompt fidelity for current-gen GLM models.

## Fix
- Removed the blanket `"glm-"` prefix from `MODELS_WITHOUT_SYSTEM_ROLE`; bare `"glm"` stays as an exact-match id (Pollinations) only.
- Added `isUnsupportedGlmSystemRoleModel()` — version-gated: GLM major>5 or (5.x with minor≥1) keep system role; older/unparseable → convert. **Version-parsing logic ported verbatim from the original commit** (no simplification).
- `supportsSystemRole` now version-gates `glm-*` ids instead of blanket-rejecting them.

## Conflict resolution note
main's `roleNormalizer` predates the `PROVIDER_SCOPED_MODELS_WITHOUT_SYSTEM_ROLE` (ZenMux `z-ai/glm-*`) machinery that the original commit's parent had. That provider-scoped map does not exist on main, so the two ZenMux-specific tests from the original diff were replaced with an equivalent native-provider `glm-5.0` older-model regression test that exercises the same version-gate on main's lineage. The core `glm-5.1`/`glm-5.2` preservation assertions (both role-normalizer and memory-glm-injection suites) are ported intact.

## Tests (Hard Rule #18 — TDD regression guards)
- `tests/unit/role-normalizer.test.ts`: 13/13 pass — incl. new glm-5.1/5.2 preserve + glm-5.0 convert
- `tests/unit/memory-glm-injection.test.ts`: 23/23 pass — glm-5.1/5.2 preserve, glm-4.7 convert
- `npm run typecheck:core`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of system messages for GLM models so newer versions keep system instructions intact instead of being merged into user content.
  * Fixed version-specific behavior so older GLM versions continue to use the previous fallback, while newer versions are treated correctly.
* **Tests**
  * Expanded coverage for GLM message normalization to verify behavior across multiple model versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->