### PR TITLE
fix(db): add migration 108 routing_decisions schema; remove stale test skip

### DIFF
--- a/src/lib/db/migrations/108_routing_decisions_audit.sql
+++ b/src/lib/db/migrations/108_routing_decisions_audit.sql
@@ -1,0 +1,46 @@
+-- Migration 108: Routing decisions audit table
+--
+-- Closes DEBT-011: replaces the `// TODO: Write to database audit table`
+-- placeholder in routingLogger.ts with a real persistence target.
+--
+-- Unlike request_detail_logs (which stores full request/response payloads),
+-- routing_decisions stores lightweight decision snapshots: which provider
+-- and model were selected, at what score, with what fallback chain, and
+-- the W3C trace context for correlation.
+--
+-- Migration 002 (mcp_a2a_tables) already created a routing_decisions table
+-- with an incompatible schema (provider_selected, model_selected, etc.).
+-- This migration drops that table and recreates it with the correct schema
+-- that routingDecisions.ts writes to. The table holds only telemetry data
+-- (no user data), so dropping is safe.
+
+DROP INDEX IF EXISTS idx_rd_request;
+DROP INDEX IF EXISTS idx_rd_combo;
+DROP INDEX IF EXISTS idx_rd_provider;
+DROP INDEX IF EXISTS idx_rd_created;
+DROP INDEX IF EXISTS idx_routing_decisions_created_at;
+DROP INDEX IF EXISTS idx_routing_decisions_provider;
+DROP TABLE IF EXISTS routing_decisions;
+
+CREATE TABLE routing_decisions (
+  id            TEXT PRIMARY KEY,
+  task_type     TEXT NOT NULL DEFAULT '',
+  combo_id      TEXT NOT NULL DEFAULT '',
+  provider      TEXT NOT NULL DEFAULT '',
+  model         TEXT NOT NULL DEFAULT '',
+  score         REAL NOT NULL DEFAULT 0,
+  factors       TEXT NOT NULL DEFAULT '[]',
+  fallbacks     TEXT NOT NULL DEFAULT '[]',
+  success       INTEGER NOT NULL DEFAULT 1,
+  latency_ms    INTEGER NOT NULL DEFAULT 0,
+  cost          REAL NOT NULL DEFAULT 0,
+  trace_id      TEXT,
+  span_id       TEXT,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_routing_decisions_created_at
+  ON routing_decisions (created_at DESC);
+
+CREATE INDEX idx_routing_decisions_provider
+  ON routing_decisions (provider, created_at DESC);

--- a/tests/unit/autoCombo/suffixComposition-4517.test.ts
+++ b/tests/unit/autoCombo/suffixComposition-4517.test.ts
@@ -84,9 +84,7 @@ describe("suffixComposition :free tier (#4517)", () => {
     assert.equal(filter, null);
   });
 
-  // TODO: skip until DB migration version collision is resolved (POST-MERGE-AUDIT.md)
-  // getResolvedModelCapabilities() calls the DB which throws the migration collision error.
-  it.skip("buildAutoCandidateFilter keeps free candidates alongside capability checks", () => {
+  it("buildAutoCandidateFilter keeps free candidates alongside capability checks", () => {
     // The category and tier checks are AND-combined. For "coding:free" the
     // category check is a pass-through (no vision/reasoning filter), so
     // any free model should be kept.


### PR DESCRIPTION
## Summary

- **Root cause**: Migration `108_routing_decisions_audit.sql` was never committed (untracked file). Migration `002_mcp_a2a_tables.sql` already created `routing_decisions` with an incompatible schema (`provider_selected`, `model_selected`, `factors_json` columns). Migration 108's `CREATE TABLE IF NOT EXISTS` was silently a no-op, leaving the table without the `provider` column that `routingDecisions.ts` writes to — causing `SQLITE_ERROR: no such column: provider` at runtime.
- **Fix**: Migration 108 now drops the legacy 002-era table and its indexes before recreating with the correct schema (`provider`, `model`, `factors`, `fallbacks`, `trace_id`, `span_id`). The table is telemetry-only (no user data), so dropping is safe.
- **Stale skip removed**: `suffixComposition-4517.test.ts` had `it.skip("buildAutoCandidateFilter keeps free candidates alongside capability checks")` because DB init was throwing during the migration collision. Now that migrations run cleanly, the test passes (unskipped).

## Test plan

- [x] `node --import tsx/esm --test tests/unit/autoCombo/arenaEloFreeAlias-migration.test.ts` — 3/3 pass
- [x] `node --import tsx/esm --test tests/unit/db-migration-version-uniqueness.test.ts` — 2/2 pass
- [x] `npm run typecheck:core` — 0 errors