### PR TITLE
fix(tests): vitest mcp config — add open-sse alias, remove stale skips, drop tsx

### DIFF
--- a/open-sse/services/autoCombo/__tests__/autoCombo.test.ts
+++ b/open-sse/services/autoCombo/__tests__/autoCombo.test.ts
@@ -97,8 +97,7 @@ describe("Task Fitness", () => {
   describe("-free alias resolution (#4517)", () => {
     beforeEach(() => invalidateFitnessCache());
 
-    // TODO: skip until DB migration version collision is resolved (POST-MERGE-AUDIT.md)
-    it.skip("returns the base model's arena_elo when given a -free variant", async () => {
+    it("returns the base model's arena_elo when given a -free variant", async () => {
       // The fix: getTaskFitnessWithSource strips a trailing "-free" suffix
       // and re-queries arena_elo with the base id. We seed an arena_elo
       // row directly via the DB module, look up the free variant, and
@@ -131,8 +130,7 @@ describe("Task Fitness", () => {
       }
     });
 
-    // TODO: skip until DB migration version collision is resolved (POST-MERGE-AUDIT.md)
-    it.skip("does not strip -free when arena_elo is present on the literal model id", () => {
+    it("does not strip -free when arena_elo is present on the literal model id", () => {
       // If both "foo-free" and "foo" have arena_elo rows, the literal "foo-free"
       // wins (we never go through the alias path). This protects future
       // benchmark uploads that specifically tag free tiers.

--- a/vitest.mcp.config.ts
+++ b/vitest.mcp.config.ts
@@ -17,11 +17,12 @@ export default defineConfig({
       "open-sse/services/combo/__tests__/**/*.test.ts",
       "tests/unit/autoCombo/**/*.test.ts",
       "tests/unit/encryption.spec.ts",
-      "src/shared/components/**/*.test.tsx",
-      "src/shared/hooks/__tests__/**/*.test.tsx",
-      "src/app/(dashboard)/**/__tests__/**/*.test.tsx",
     ],
-    exclude: ["**/node_modules/**", "**/.git/**"],
+    exclude: [
+      "**/node_modules/**",
+      "**/.git/**",
+      "tests/unit/autoCombo/arenaEloFreeAlias-migration.test.ts",
+    ],
     coverage: {
       reportsDirectory: "coverage",
     },
@@ -29,6 +30,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "@omniroute/open-sse": path.resolve(__dirname, "./open-sse"),
     },
   },
 });


### PR DESCRIPTION
## Summary

Three related fixes to vitest.mcp.config.ts that restore a fully green vitest run (192/192, 0 skips):

1. **Add @omniroute/open-sse resolver alias** — only @ was aliased; imports through the workspace package alias failed with 'Cannot find package @omniroute/open-sse/...'. Now resolved to ./open-sse/.

2. **Remove .tsx patterns from mcp config include** — tsx tests belong in vitest.config.ts (jsdom+React). In pool:forks node env they caused EXIT=194 hangs.

3. **Exclude arenaEloFreeAlias-migration.test.ts from vitest** — uses node:test API, not vitest describe/it. Still runs under node --test runner.

4. **Remove 2 stale it.skip markers in autoCombo.test.ts** — free alias tests were skipped pending migration collision fix (PRs #202+#208). Now 192/192 pass.

## Test plan

- [x] node_modules/.bin/vitest run --config vitest.mcp.config.ts -> 192 passed, 0 skipped
- [x] npm run typecheck:core -> 0 errors