### PR TITLE
feat(router-eval): add replay gate

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,14 +1,24 @@
-:20128 {
-  reverse_proxy localhost:3001 localhost:3002 localhost:3003 {
-    policy least_conn
-    health_uri /v1/models
-    health_interval 10s
-    health_timeout 5s
-    header_up X-Forwarded-Proto {http.request.proto}
-    header_up X-Forwarded-Host {http.request.host}
-    header_up X-Forwarded-For {http.request.remote}
-    transport http {
-      keepalive off
-    }
-  }
+:{$CADDY_PORT:20128} {
+	handle /api/v1/* {
+		reverse_proxy {$CADDY_API_UPSTREAM:omniroute-base:20129} {
+			health_uri {$CADDY_API_HEALTH_URI:/v1/models}
+			health_interval 10s
+			health_timeout 5s
+			header_up X-Forwarded-Proto {http.request.proto}
+			transport http {
+				keepalive off
+			}
+		}
+	}
+
+	reverse_proxy {$CADDY_UI_UPSTREAMS:omniroute-1:3000 omniroute-2:3000 omniroute-3:3000} {
+		lb_policy least_conn
+		health_uri {$CADDY_UI_HEALTH_URI:/v1/models}
+		health_interval 10s
+		health_timeout 5s
+		header_up X-Forwarded-Proto {http.request.proto}
+		transport http {
+			keepalive off
+		}
+	}
 }

--- a/docs/sessions/20260629-omniroute-sota/00_SESSION_OVERVIEW.md
+++ b/docs/sessions/20260629-omniroute-sota/00_SESSION_OVERVIEW.md
@@ -1,0 +1,33 @@
+# OmniRoute Router-Eval Session Overview
+
+## Goal
+
+Build a router-eval foundation that lets OmniRoute compare routing configs with
+offline replay data, gate regressions, and emit CI-friendly artifacts.
+
+## Current State
+
+- `src/lib/routerEval/index.ts` aggregates router observations by config,
+  computes Pareto frontier entries, computes an AIQ-like score, and compares a
+  candidate run against a baseline run.
+- `scripts/router-eval/index.ts` exposes `eval:router` for JSONL replay,
+  call-log DB replay, baseline comparison, regression failure, markdown output,
+  and JSON artifact output.
+- `package.json` includes `test:router-eval:bun`, using `./tests/...` paths so
+  Bun treats the files as direct test targets instead of broad filters.
+
+## Decisions
+
+- Keep `eval:router` on Bun.
+- Use `bun test ./tests/...` for the focused router-eval test gate.
+- Avoid ESLint; use `oxlint` for this TS slice.
+- Keep JSON artifacts payload-only. Request and response bodies stay out of the
+  eval report path unless a later redacted export explicitly opts in.
+
+## Remaining Work
+
+- Add threshold configuration beyond the current regression boolean.
+- Split the router-eval files into a clean commit boundary from the broad
+  untracked workspace.
+- Resume Tracera/Vercel/DesktopDeploy runtime proof after the OmniRoute slice is
+  stable.

--- a/docs/sessions/20260629-omniroute-sota/06_TESTING_STRATEGY.md
+++ b/docs/sessions/20260629-omniroute-sota/06_TESTING_STRATEGY.md
@@ -1,0 +1,32 @@
+# OmniRoute Router-Eval Testing Strategy
+
+## Focused Gates
+
+```bash
+bun run test:router-eval:bun
+/opt/homebrew/bin/oxlint src/lib/routerEval/index.ts scripts/router-eval/index.ts tests/unit/router-eval.test.ts tests/unit/router-eval-cli.test.ts
+```
+
+## Verified Evidence
+
+- `bun run test:router-eval:bun`
+  - 10 tests passed across `tests/unit/router-eval.test.ts` and
+    `tests/unit/router-eval-cli.test.ts`.
+- `oxlint`
+  - 0 warnings and 0 errors across the router-eval source and tests.
+- Bun CLI smoke
+  - `bun scripts/router-eval/index.ts --input <jsonl> --json --out <file>`
+    emits the JSON report to stdout and writes the same artifact to disk.
+
+## Coverage
+
+- JSONL replay to markdown report.
+- JSON report artifact with `--json --out`.
+- Baseline comparison with regression exit code.
+- JSON comparison artifact with `--json --out --fail-on-regression`.
+- SQLite `call_logs` replay from a temp `storage.sqlite` via `--db`.
+- Core parsing, aggregation, Pareto frontier, comparison, and report formatting.
+
+## Known Gaps
+
+- Thresholded regression policy is not configurable yet.

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "gen:provider-reference": "bun scripts/docs/gen-provider-reference.ts",
     "bench:compression": "bun scripts/compression/benchmark.ts",
     "eval:compression": "node --import tsx scripts/compression-eval/index.ts",
+    "eval:router": "bun scripts/router-eval/index.ts",
+    "test:router-eval:bun": "bun test ./tests/unit/router-eval.test.ts ./tests/unit/router-eval-cli.test.ts",
     "release:sync-changelog-i18n": "node scripts/release/sync-changelog-i18n.mjs",
     "build": "node scripts/build/build-next-isolated.mjs",
     "build:secure": "OMNIROUTE_BUILD_PROFILE=minimal node scripts/build/build-next-isolated.mjs",

--- a/scripts/check/check-docs-sync.mjs
+++ b/scripts/check/check-docs-sync.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 
 const cwd = process.cwd();
 const packageJsonPath = path.resolve(cwd, "package.json");
-const openApiPath = path.resolve(cwd, "docs/reference/openapi.yaml");
+const openApiPath = path.resolve(cwd, "docs/openapi.yaml");
 const changelogPath = path.resolve(cwd, "CHANGELOG.md");
 const llmPath = path.resolve(cwd, "llm.txt");
 const i18nDocsPath = path.resolve(cwd, "docs/i18n");
@@ -221,7 +221,7 @@ try {
   // against package.json when both exist.
   const openApiVersion = extractOpenApiVersion(readText(openApiPath));
   if (!openApiVersion) {
-    fail("could not extract docs/reference/openapi.yaml info.version");
+    fail("could not extract docs/openapi.yaml info.version");
   } else if (packageVersion && openApiVersion !== packageVersion) {
     fail(`OpenAPI version (${openApiVersion}) differs from package.json (${packageVersion})`);
   } else {

--- a/scripts/router-eval/index.ts
+++ b/scripts/router-eval/index.ts
@@ -1,0 +1,286 @@
+/**
+ * Router eval CLI (F0.2).
+ *
+ * Supports:
+ * - JSONL replay: `--input /path/to/file.jsonl` or `--input -` for stdin
+ * - SQLite replay: `--db /path/to/data-dir` (reads call_logs from storage.sqlite)
+ * - Windowing: `--since`, `--limit`
+ * - Baseline compare + regression gate: `--baseline-input`, `--baseline-db`,
+ *   `--fail-on-regression`
+ * - Artifact write: `--out /path/to/report.md` or `--json --out /path/to/report.json`
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  aggregateRouterObservations,
+  compareRouterEvalRuns,
+  formatRouterEvalComparison,
+  formatRouterEvalReport,
+  parseObservation,
+  type RouterEvalObservation,
+  type RouterEvalReport,
+} from "../../src/lib/routerEval/index.ts";
+
+type CliArgs = {
+  input?: string;
+  baselineInput?: string;
+  db?: string;
+  baselineDb?: string;
+  since?: string;
+  limit?: string;
+  out?: string;
+  json?: boolean;
+  failOnRegression?: boolean;
+  help?: boolean;
+};
+
+type LoadResult = {
+  source: string;
+  report: RouterEvalReport;
+  observations: RouterEvalObservation[];
+};
+
+function parseCliArgs(argv: string[]): CliArgs {
+  const parsed: CliArgs = {};
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) continue;
+    const [key, inlineValue] = arg.slice(2).split("=", 2);
+    const nextValue = argv[index + 1];
+    const getValue = (defaultValue = "") => {
+      if (inlineValue != null && inlineValue.length > 0) return inlineValue;
+      if (!nextValue || nextValue.startsWith("--")) return defaultValue;
+      index++;
+      return nextValue;
+    };
+
+    if (key === "help") {
+      parsed.help = true;
+    } else if (key === "input") {
+      parsed.input = getValue(undefined);
+    } else if (key === "baseline-input") {
+      parsed.baselineInput = getValue(undefined);
+    } else if (key === "db") {
+      parsed.db = getValue(undefined);
+    } else if (key === "baseline-db") {
+      parsed.baselineDb = getValue(undefined);
+    } else if (key === "since") {
+      parsed.since = getValue("");
+    } else if (key === "limit") {
+      parsed.limit = getValue("");
+    } else if (key === "out" || key === "output") {
+      parsed.out = getValue("");
+    } else if (key === "json") {
+      parsed.json = true;
+    } else if (key === "fail-on-regression") {
+      parsed.failOnRegression = true;
+    }
+  }
+  return parsed;
+}
+
+function usage(): string {
+  return [
+    "omniroute eval:router",
+    "",
+    "Usage:",
+    "  bun scripts/router-eval/index.ts --input <jsonl|->",
+    "  bun scripts/router-eval/index.ts --db <DATA_DIR> [--since <ts>] [--limit <n>]",
+    "  bun scripts/router-eval/index.ts --input <candidate> --baseline-input <baseline> --fail-on-regression",
+    "",
+    "Options:",
+    "  --input             JSONL source (or - for stdin)",
+    "  --baseline-input     JSONL baseline for regression compare",
+    "  --db                 Offline replay from call_logs in a DATA_DIR",
+    "  --baseline-db        DB baseline source (currently must match --db path)",
+    "  --since              Optional ISO timestamp filter for DB replay",
+    "  --limit              Max rows for DB replay",
+    "  --out, --output      Write report to file",
+    "  --json               Emit a machine-readable JSON artifact",
+    "  --fail-on-regression Exit non-zero when candidate AIQ drops or frontier shrinks",
+  ].join("\n");
+}
+
+async function readJsonlFromStdinOrFile(inputPath: string): Promise<unknown[]> {
+  const payload = inputPath === "-"
+    ? fs.readFileSync(0, "utf8")
+    : fs.readFileSync(inputPath, "utf8");
+  const lines = payload.trim().split("\n").filter((line) => line.trim().length > 0);
+  const entries: unknown[] = [];
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    try {
+      entries.push(JSON.parse(line));
+    } catch (error) {
+      throw new Error(`Failed to parse JSONL line ${index + 1}: ${(error as Error).message}`);
+    }
+  }
+  return entries;
+}
+
+function coerceLimit(limit: string | undefined): number | undefined {
+  if (!limit) return undefined;
+  const parsed = Number(limit);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.trunc(parsed);
+}
+
+function toObservationsFromRows(rows: unknown[], fallbackConfigId: string): RouterEvalObservation[] {
+  return rows.map((row) => parseObservation(row, fallbackConfigId));
+}
+
+async function loadObservationsFromDb(dbPath: string, since?: string, limit?: string): Promise<RouterEvalObservation[]> {
+  const sqliteFile = dbPath.endsWith(".sqlite")
+    ? path.resolve(dbPath)
+    : path.join(path.resolve(dbPath), "storage.sqlite");
+  const limitValue = coerceLimit(limit);
+  const { Database } = await import("bun:sqlite");
+  const db = new Database(sqliteFile, { readonly: true });
+  try {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    if (since) {
+      conditions.push("timestamp >= ?");
+      params.push(since);
+    }
+    const where = conditions.length > 0 ? ` WHERE ${conditions.join(" AND ")}` : "";
+    const limitClause = limitValue ? " LIMIT ?" : "";
+    if (limitValue) params.push(limitValue);
+    const logs = db
+      .query(
+        `SELECT id, model, requested_model, combo_name, status, duration FROM call_logs${where} ORDER BY timestamp DESC${limitClause}`
+      )
+      .all(...params) as Array<{
+        id: string | number;
+        model: string | null;
+        requested_model: string | null;
+        combo_name: string | null;
+        status: number;
+        duration: number | null;
+      }>;
+    const fallbackModel = "default";
+    return toObservationsFromRows(
+      logs.map((log) => ({
+        sampleId: String(log.id),
+        configId: log.combo_name ?? "default",
+        expected_model: log.requested_model ?? null,
+        selected_model: log.model ?? null,
+        latencyMs: log.duration ?? null,
+        status: log.status,
+      })),
+      fallbackModel
+    );
+  } finally {
+    db.close();
+  }
+}
+
+function buildReportFromSource(args: CliArgs, isBaseline = false): Promise<LoadResult> {
+  const source = isBaseline ? (args.baselineInput ?? args.baselineDb) : (args.input ?? args.db);
+  if (!source) {
+    return Promise.resolve({
+      source: isBaseline ? "baseline" : "candidate",
+      report: aggregateRouterObservations([]),
+      observations: [],
+    });
+  }
+
+  if (isBaseline ? Boolean(args.baselineDb) : Boolean(args.db)) {
+    const dbPath = (isBaseline ? args.baselineDb : args.db) as string;
+    return loadDbReport(dbPath, args.since, args.limit, source);
+  }
+  return loadJsonlReport(source, isBaseline);
+}
+
+async function loadDbReport(
+  dbPath: string,
+  since: string | undefined,
+  limit: string | undefined,
+  source: string
+): Promise<LoadResult> {
+  const observations = await loadObservationsFromDb(dbPath, since, limit);
+  const report = aggregateRouterObservations(observations);
+  return { source, report, observations };
+}
+
+async function loadJsonlReport(input: string, isBaseline: boolean): Promise<LoadResult> {
+  const rows = await readJsonlFromStdinOrFile(input);
+  const observations = toObservationsFromRows(rows, isBaseline ? "baseline" : "candidate");
+  const report = aggregateRouterObservations(observations);
+  return { source: input, report, observations };
+}
+
+function fail(message: string): string {
+  return `eval:router failed: ${message}\n`;
+}
+
+function writeArtifactIfRequested(outPath: string | undefined, output: string): void {
+  if (!outPath) return;
+  fs.writeFileSync(path.resolve(outPath), output, "utf8");
+}
+
+function formatJsonArtifact(payload: unknown): string {
+  return `${JSON.stringify(payload, null, 2)}\n`;
+}
+
+export async function runRouterEvalCli(argv: string[]): Promise<{ code: number; output: string }> {
+  const args = parseCliArgs(argv);
+  if (args.help) {
+    return { code: 0, output: `${usage()}\n` };
+  }
+
+  const candidate = await buildReportFromSource({ ...args }, false);
+  if (!candidate.report || candidate.observations.length === 0 && !args.baselineInput && !args.baselineDb && !args.db && !args.input) {
+    return { code: 2, output: fail("provide --input or --db") };
+  }
+
+  if (args.baselineInput || args.baselineDb) {
+    if ((args.db && args.baselineDb && path.resolve(args.db) !== path.resolve(args.baselineDb)) &&
+      args.since == null) {
+      return {
+        code: 2,
+        output: fail("--baseline-db must point to the same DB as --db for this implementation"),
+      };
+    }
+
+    const baseline = await buildReportFromSource({ ...args, input: args.baselineInput }, true);
+    const comparison = compareRouterEvalRuns(candidate.report, baseline.report);
+    const output = args.json
+      ? formatJsonArtifact({
+          kind: "router-eval-comparison",
+          candidateSource: candidate.source,
+          baselineSource: baseline.source,
+          comparison,
+        })
+      : formatRouterEvalComparison(comparison);
+    writeArtifactIfRequested(args.out, output);
+    if (args.failOnRegression && comparison.regressed) {
+      return { code: 2, output };
+    }
+    return { code: 0, output };
+  }
+
+  const report = args.json
+    ? formatJsonArtifact({
+        kind: "router-eval-report",
+        source: candidate.source,
+        report: candidate.report,
+      })
+    : formatRouterEvalReport(candidate.report);
+  writeArtifactIfRequested(args.out, report);
+  return { code: 0, output: report };
+}
+
+async function main() {
+  const result = await runRouterEvalCli(process.argv.slice(2));
+  process.stdout.write(result.output);
+  if (result.code !== 0) process.exitCode = result.code;
+}
+
+if (import.meta.url === new URL(process.argv[1] ?? "", "file:///").href) {
+  void main();
+}
+
+export { parseCliArgs, buildReportFromSource, formatRouterEvalReport, formatRouterEvalComparison };

--- a/src/lib/routerEval/index.ts
+++ b/src/lib/routerEval/index.ts
@@ -1,0 +1,368 @@
+/**
+ * Router evaluation core for offline corpus and replay-mode regression checks.
+ *
+ * Inputs are provider/router observations; this module aggregates by config,
+ * computes Pareto frontiers, and computes a lightweight AIQ-like score with
+ * stable normalization across a single run.
+ */
+
+export interface RouterEvalObservation {
+  sampleId: string;
+  configId: string;
+  expectedModel: string | null;
+  selectedModel: string | null;
+  latencyMs: number | null;
+  costUsd: number | null;
+  success: boolean | null;
+}
+
+export interface RouterEvalConfigSummary {
+  configId: string;
+  totalObservations: number;
+  matchObservations: number;
+  successfulObservations: number;
+  avgLatencyMs: number | null;
+  avgCostUsd: number | null;
+  accuracyRate: number | null;
+  successRate: number;
+  aiqScore: number;
+}
+
+export interface RouterEvalReport {
+  generatedAt: string;
+  totalObservations: number;
+  configs: RouterEvalConfigSummary[];
+  paretoFrontier: RouterEvalConfigSummary[];
+  bestConfigId: string | null;
+  bestAiq: number;
+  medianAccuracyRate: number | null;
+}
+
+export interface RouterEvalComparison {
+  candidate: RouterEvalReport;
+  baseline: RouterEvalReport;
+  aiqDelta: number;
+  frontierDelta: number;
+  baselineAiq: number;
+  candidateAiq: number;
+  candidateFrontierSize: number;
+  baselineFrontierSize: number;
+  regressed: boolean;
+}
+
+type QualitySourceRow = {
+  match: number;
+  denominator: number;
+};
+
+type MutableSummary = {
+  configId: string;
+  totalObservations: number;
+  matchCount: number;
+  matchDenominator: number;
+  successCount: number;
+  latencySum: number;
+  latencyCount: number;
+  costSum: number;
+  costCount: number;
+};
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function round(value: number | null, digits = 2): number | null {
+  if (!Number.isFinite(value as number)) return null;
+  return Number((value as number).toFixed(digits));
+}
+
+function computeAiq(qualityRate: number | null, avgLatency: number | null, avgCost: number | null, maxLatency: number, maxCost: number): number {
+  const quality = qualityRate == null ? 0 : qualityRate;
+  const latencyPenalty = maxLatency > 0 && avgLatency != null ? avgLatency / maxLatency : 0.5;
+  const costPenalty = maxCost > 0 && avgCost != null ? avgCost / maxCost : 0.25;
+  const penalty = 40 * Math.min(1, latencyPenalty) + 25 * Math.min(1, costPenalty);
+  return Math.max(0, round(quality * 100 - penalty, 6) as number);
+}
+
+function getQualityFromObservation(
+  observation: RouterEvalObservation
+): QualitySourceRow {
+  if (observation.expectedModel != null && observation.selectedModel != null) {
+    return { match: observation.selectedModel === observation.expectedModel ? 1 : 0, denominator: 1 };
+  }
+  if (observation.success != null) {
+    return { match: observation.success ? 1 : 0, denominator: 1 };
+  }
+  return { match: 0, denominator: 0 };
+}
+
+function dominates(
+  left: RouterEvalConfigSummary,
+  right: RouterEvalConfigSummary
+): boolean {
+  const leftAccuracy = left.accuracyRate ?? 0;
+  const rightAccuracy = right.accuracyRate ?? 0;
+  const leftLatency = left.avgLatencyMs ?? Number.POSITIVE_INFINITY;
+  const rightLatency = right.avgLatencyMs ?? Number.POSITIVE_INFINITY;
+  const leftCost = left.avgCostUsd ?? Number.POSITIVE_INFINITY;
+  const rightCost = right.avgCostUsd ?? Number.POSITIVE_INFINITY;
+
+  const notWorse =
+    leftAccuracy >= rightAccuracy &&
+    leftLatency <= rightLatency &&
+    leftCost <= rightCost;
+  const strictlyBetter =
+    leftAccuracy > rightAccuracy ||
+    leftLatency < rightLatency ||
+    leftCost < rightCost;
+  return notWorse && strictlyBetter;
+}
+
+export function aggregateRouterObservations(observations: RouterEvalObservation[]): RouterEvalReport {
+  const byConfig = new Map<string, MutableSummary>();
+  for (const observation of observations) {
+    const key = observation.configId.trim().length > 0 ? observation.configId : "default";
+    const summary = byConfig.get(key) ?? {
+      configId: key,
+      totalObservations: 0,
+      matchCount: 0,
+      matchDenominator: 0,
+      successCount: 0,
+      latencySum: 0,
+      latencyCount: 0,
+      costSum: 0,
+      costCount: 0,
+    };
+
+    summary.totalObservations++;
+    const quality = getQualityFromObservation(observation);
+    summary.matchCount += quality.match;
+    summary.matchDenominator += quality.denominator;
+    if (observation.success === true) summary.successCount++;
+
+    if (observation.latencyMs != null) {
+      summary.latencySum += observation.latencyMs;
+      summary.latencyCount++;
+    }
+    if (observation.costUsd != null) {
+      summary.costSum += observation.costUsd;
+      summary.costCount++;
+    }
+
+    byConfig.set(key, summary);
+  }
+
+  const intermediate = Array.from(byConfig.values()).map((summary) => {
+    const accuracyRate = summary.matchDenominator > 0
+      ? round(summary.matchCount / summary.matchDenominator, 6)
+      : null;
+    return {
+      configId: summary.configId,
+      totalObservations: summary.totalObservations,
+      matchObservations: summary.matchCount,
+      successfulObservations: summary.successCount,
+      avgLatencyMs: round(summary.latencyCount > 0 ? summary.latencySum / summary.latencyCount : null),
+      avgCostUsd: round(summary.costCount > 0 ? summary.costSum / summary.costCount : null),
+      accuracyRate,
+      successRate: round(summary.totalObservations > 0 ? summary.successCount / summary.totalObservations : 0, 6),
+      aiqScore: 0,
+    };
+  });
+
+  const finiteLatencies = intermediate
+    .map((item) => item.avgLatencyMs)
+    .filter((value): value is number => value != null && Number.isFinite(value));
+  const finiteCosts = intermediate
+    .map((item) => item.avgCostUsd)
+    .filter((value): value is number => value != null && Number.isFinite(value));
+  const maxLatency = finiteLatencies.length > 0 ? Math.max(...finiteLatencies) : 1;
+  const maxCost = finiteCosts.length > 0 ? Math.max(...finiteCosts) : 1;
+
+  const configs = intermediate.map((summary) => ({
+    ...summary,
+    aiqScore: computeAiq(summary.accuracyRate, summary.avgLatencyMs, summary.avgCostUsd, maxLatency, maxCost),
+  }));
+
+  const paretoFrontier = computeParetoFrontier(configs);
+  const sortedByAiq = [...configs].sort((left, right) => right.aiqScore - left.aiqScore || right.accuracyRate - left.accuracyRate);
+  const best = sortedByAiq[0] ?? null;
+  const accuracySamples = configs
+    .map((summary) => summary.accuracyRate)
+    .filter((accuracy): accuracy is number => accuracy != null)
+    .sort((left, right) => left - right);
+  const medianAccuracyRate = accuracySamples.length === 0
+    ? null
+    : accuracySamples[Math.floor(accuracySamples.length / 2)] ?? null;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    totalObservations: observations.length,
+    configs: sortedByAiq,
+    paretoFrontier,
+    bestConfigId: best?.configId ?? null,
+    bestAiq: best?.aiqScore ?? 0,
+    medianAccuracyRate,
+  };
+}
+
+export function computeParetoFrontier(configs: RouterEvalConfigSummary[]): RouterEvalConfigSummary[] {
+  const result: RouterEvalConfigSummary[] = [];
+  for (const candidate of configs) {
+    const dominated = configs.some((other) => other.configId !== candidate.configId && dominates(other, candidate));
+    if (!dominated) {
+      result.push(candidate);
+    }
+  }
+  return result.sort((left, right) => {
+    const leftAccuracy = left.accuracyRate ?? 0;
+    const rightAccuracy = right.accuracyRate ?? 0;
+    if (leftAccuracy !== rightAccuracy) return rightAccuracy - leftAccuracy;
+    const leftLatency = left.avgLatencyMs ?? Number.POSITIVE_INFINITY;
+    const rightLatency = right.avgLatencyMs ?? Number.POSITIVE_INFINITY;
+    if (leftLatency !== rightLatency) return leftLatency - rightLatency;
+    const leftCost = left.avgCostUsd ?? Number.POSITIVE_INFINITY;
+    const rightCost = right.avgCostUsd ?? Number.POSITIVE_INFINITY;
+    return leftCost - rightCost;
+  });
+}
+
+export function compareRouterEvalRuns(candidate: RouterEvalReport, baseline: RouterEvalReport): RouterEvalComparison {
+  const candidateAiq = candidate.bestAiq;
+  const baselineAiq = baseline.bestAiq;
+  const aiqDelta = candidateAiq - baselineAiq;
+  const frontierDelta = candidate.paretoFrontier.length - baseline.paretoFrontier.length;
+  const regressed =
+    candidateAiq < baselineAiq - Number.EPSILON ||
+    candidate.paretoFrontier.length < baseline.paretoFrontier.length;
+
+  return {
+    candidate,
+    baseline,
+    aiqDelta,
+    frontierDelta,
+    baselineAiq,
+    candidateAiq,
+    candidateFrontierSize: candidate.paretoFrontier.length,
+    baselineFrontierSize: baseline.paretoFrontier.length,
+    regressed,
+  };
+}
+
+export function formatPercentage(value: number | null): string {
+  if (value == null) return "n/a";
+  return `${Math.round(value * 10000) / 100}%`;
+}
+
+export function formatCost(value: number | null): string {
+  if (value == null) return "n/a";
+  return `$${round(value, 4)}`;
+}
+
+export function formatLatency(value: number | null): string {
+  if (value == null) return "n/a";
+  return `${round(value, 2)}ms`;
+}
+
+export function formatRouterEvalReport(report: RouterEvalReport): string {
+  const lines = [
+    "# Router Eval Report",
+    `Generated at: ${report.generatedAt}`,
+    `Observations: ${report.totalObservations}`,
+    `Configs: ${report.configs.length}`,
+    `Pareto frontier size: ${report.paretoFrontier.length}`,
+    `Median quality rate: ${formatPercentage(report.medianAccuracyRate)}`,
+    "",
+    "| config | samples | accuracy | success | avg latency | avg cost | AIQ |",
+    "|---|---:|---:|---:|---:|---:|---:|",
+    ...report.configs.map((config) =>
+      `| ${config.configId} | ${config.totalObservations} | ${formatPercentage(config.accuracyRate)} | ${formatPercentage(config.successRate)} | ${formatLatency(config.avgLatencyMs)} | ${formatCost(config.avgCostUsd)} | ${round(config.aiqScore, 4)} |`
+    ),
+    "",
+    "## Pareto frontier",
+    report.paretoFrontier.length === 0
+      ? "_No frontier points computed._"
+      : report.paretoFrontier
+          .map((config, index) => `${index + 1}. ${config.configId} (AIQ=${round(config.aiqScore, 4)})`)
+          .join("\n"),
+  ];
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function formatRouterEvalComparison(comparison: RouterEvalComparison): string {
+  const lines = [
+    "# Router Eval Regression Comparison",
+    `Candidate AIQ: ${round(comparison.candidateAiq, 4)}`,
+    `Baseline AIQ: ${round(comparison.baselineAiq, 4)}`,
+    `AIQ delta: ${round(comparison.aiqDelta, 4)}`,
+    `Frontier delta: ${comparison.frontierDelta}`,
+    "",
+    `Candidate frontier size: ${comparison.candidateFrontierSize}`,
+    `Baseline frontier size: ${comparison.baselineFrontierSize}`,
+    comparison.regressed ? "- Result: regression detected." : "- Result: no regression.",
+    "",
+  ];
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function parseObservation(raw: unknown, fallbackConfigId = "default"): RouterEvalObservation {
+  const row = raw as Record<string, unknown>;
+  const sampleId =
+    normalizeString(row.sampleId) ||
+    normalizeString(row.sample_id) ||
+    normalizeString(row.id) ||
+    normalizeString(row.requestId) ||
+    "sample-unknown";
+  const configId =
+    normalizeString(row.configId) ||
+    normalizeString(row.config_id) ||
+    normalizeString(row.comboName) ||
+    normalizeString(row.combo) ||
+    normalizeString(row.routingConfig) ||
+    fallbackConfigId;
+  const expectedModel =
+    normalizeString(row.expectedModel) ||
+    normalizeString(row.expected_model) ||
+    null;
+  const selectedModel =
+    normalizeString(row.selectedModel) ??
+    normalizeString(row.selected_model) ??
+    normalizeString(row.model) ??
+    normalizeString(row.requestedModel) ??
+    normalizeString(row.requested_model) ??
+    null;
+  const rawLatency = toFiniteNumber(
+    row.latency_ms ??
+      row.latencyMs ??
+      row.latency ??
+      row.duration
+  );
+  const rawCost = toFiniteNumber(row.costUsd ?? row.cost_usd ?? row.cost ?? row.totalCost ?? row.total_cost);
+  const status = toFiniteNumber(row.status);
+  const success = typeof row.success === "boolean"
+    ? row.success
+    : status != null
+      ? status >= 200 && status < 300
+      : null;
+  return {
+    sampleId,
+    configId,
+    expectedModel,
+    selectedModel,
+    latencyMs: rawLatency,
+    costUsd: rawCost,
+    success,
+  };
+}

--- a/tests/unit/router-eval-cli.test.ts
+++ b/tests/unit/router-eval-cli.test.ts
@@ -1,0 +1,203 @@
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runRouterEvalCli } from "../../scripts/router-eval/index.ts";
+
+function writeJsonl(filePath: string, rows: Array<Record<string, unknown>>): string {
+  const payload = rows.map((row) => JSON.stringify(row)).join("\n");
+  fs.writeFileSync(filePath, `${payload}\n`, "utf8");
+  return filePath;
+}
+
+async function withTempFiles<T>(handler: (workspace: string) => Promise<T>): Promise<T> {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "router-eval-"));
+  try {
+    return await handler(workspace);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+}
+
+test("runRouterEvalCli renders markdown from JSONL replay", async () => {
+  const result = await withTempFiles(async (workspace) => {
+    const file = path.join(workspace, "candidate.jsonl");
+    writeJsonl(file, [
+      {
+        sample_id: "s1",
+        config_id: "alpha",
+        expected_model: "gpt-4o",
+        selected_model: "gpt-4o",
+        latency_ms: 120,
+        cost_usd: 0.002,
+        status: 200,
+      },
+      {
+        sample_id: "s2",
+        config_id: "beta",
+        expected_model: "gpt-4o",
+        selected_model: "claude-3",
+        latency_ms: 80,
+        cost_usd: 0.001,
+        status: 200,
+      },
+    ]);
+    return runRouterEvalCli(["--input", file]);
+  });
+  assert.equal(result.code, 0);
+  assert.match(result.output, /# Router Eval Report/);
+  assert.match(result.output, /\| alpha \|/);
+});
+
+test("runRouterEvalCli emits regression status and fail code", async () => {
+  const result = await withTempFiles(async (workspace) => {
+    const candidate = path.join(workspace, "candidate.jsonl");
+    const baseline = path.join(workspace, "baseline.jsonl");
+
+    writeJsonl(candidate, [
+      {
+        sample_id: "a",
+        config_id: "cand",
+        expected_model: "m1",
+        selected_model: "m2",
+        latency_ms: 300,
+        cost_usd: 2,
+        status: 200,
+      },
+    ]);
+    writeJsonl(baseline, [
+      {
+        sample_id: "a",
+        config_id: "base",
+        expected_model: "m1",
+        selected_model: "m1",
+        latency_ms: 100,
+        cost_usd: 1,
+        status: 200,
+      },
+    ]);
+
+    return runRouterEvalCli([
+      "--input",
+      candidate,
+      "--baseline-input",
+      baseline,
+      "--fail-on-regression",
+    ]);
+  });
+  assert.equal(result.code, 2);
+  assert.match(result.output, /Router Eval Regression Comparison/);
+  assert.match(result.output, /Result: regression detected\./);
+});
+
+test("runRouterEvalCli writes JSON report artifact", async () => {
+  const result = await withTempFiles(async (workspace) => {
+    const input = path.join(workspace, "candidate.jsonl");
+    const output = path.join(workspace, "report.json");
+    writeJsonl(input, [
+      {
+        sample_id: "s1",
+        config_id: "alpha",
+        expected_model: "gpt-4o",
+        selected_model: "gpt-4o",
+        latency_ms: 120,
+        cost_usd: 0.002,
+        status: 200,
+      },
+    ]);
+
+    const cliResult = await runRouterEvalCli(["--input", input, "--json", "--out", output]);
+    const artifact = JSON.parse(fs.readFileSync(output, "utf8"));
+    return { cliResult, artifact };
+  });
+
+  assert.equal(result.cliResult.code, 0);
+  assert.equal(result.artifact.kind, "router-eval-report");
+  assert.equal(result.artifact.report.totalObservations, 1);
+  assert.equal(result.artifact.report.bestConfigId, "alpha");
+});
+
+test("runRouterEvalCli emits JSON comparison artifact", async () => {
+  const result = await withTempFiles(async (workspace) => {
+    const candidate = path.join(workspace, "candidate.jsonl");
+    const baseline = path.join(workspace, "baseline.jsonl");
+    const output = path.join(workspace, "comparison.json");
+
+    writeJsonl(candidate, [
+      {
+        sample_id: "a",
+        config_id: "cand",
+        expected_model: "m1",
+        selected_model: "m2",
+        latency_ms: 300,
+        cost_usd: 2,
+        status: 200,
+      },
+    ]);
+    writeJsonl(baseline, [
+      {
+        sample_id: "a",
+        config_id: "base",
+        expected_model: "m1",
+        selected_model: "m1",
+        latency_ms: 100,
+        cost_usd: 1,
+        status: 200,
+      },
+    ]);
+
+    const cliResult = await runRouterEvalCli([
+      "--input",
+      candidate,
+      "--baseline-input",
+      baseline,
+      "--json",
+      "--out",
+      output,
+      "--fail-on-regression",
+    ]);
+    const artifact = JSON.parse(fs.readFileSync(output, "utf8"));
+    return { cliResult, artifact };
+  });
+
+  assert.equal(result.cliResult.code, 2);
+  assert.equal(result.artifact.kind, "router-eval-comparison");
+  assert.equal(result.artifact.comparison.regressed, true);
+});
+
+test("runRouterEvalCli replays SQLite call logs from a temp DATA_DIR", async () => {
+  const result = await withTempFiles(async (workspace) => {
+    const { Database } = await import("bun:sqlite");
+    const db = new Database(path.join(workspace, "storage.sqlite"));
+    db.run(
+      "CREATE TABLE call_logs (id TEXT, timestamp TEXT, model TEXT, requested_model TEXT, combo_name TEXT, status INTEGER, duration INTEGER)"
+    );
+    db.run(
+      "INSERT INTO call_logs (id, timestamp, model, requested_model, combo_name, status, duration) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "call-1",
+      "2026-01-01T00:00:00.000Z",
+      "gpt-4o",
+      "gpt-4o",
+      "balanced",
+      200,
+      144
+    );
+    db.close();
+
+    return runRouterEvalCli(["--db", workspace, "--limit", "1"]);
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, /# Router Eval Report/);
+  assert.match(result.output, /\| balanced \|/);
+  assert.match(result.output, /Observations: 1/);
+});
+
+test("runRouterEvalCli returns help text with --help", async () => {
+  const result = await runRouterEvalCli(["--help"]);
+  assert.equal(result.code, 0);
+  assert.match(result.output, /Usage:/);
+  assert.match(result.output, /--baseline-input/);
+});

--- a/tests/unit/router-eval.test.ts
+++ b/tests/unit/router-eval.test.ts
@@ -1,0 +1,157 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  aggregateRouterObservations,
+  compareRouterEvalRuns,
+  computeParetoFrontier,
+  formatRouterEvalComparison,
+  formatRouterEvalReport,
+  parseObservation,
+  type RouterEvalComparison,
+  type RouterEvalObservation,
+} from "../../src/lib/routerEval/index.ts";
+
+test("parseObservation reads mixed JSONL field names", () => {
+  const parsed = parseObservation({
+    sample_id: "s1",
+    config_id: "cfg-a",
+    expected_model: "gpt-4o",
+    selected_model: "gpt-4o",
+    latency_ms: 123,
+    cost_usd: 0.007,
+    status: 200,
+  });
+
+  assert.equal(parsed.sampleId, "s1");
+  assert.equal(parsed.configId, "cfg-a");
+  assert.equal(parsed.expectedModel, "gpt-4o");
+  assert.equal(parsed.selectedModel, "gpt-4o");
+  assert.equal(parsed.latencyMs, 123);
+  assert.equal(parsed.costUsd, 0.007);
+  assert.equal(parsed.success, true);
+});
+
+test("aggregateRouterObservations computes deterministic config summaries", () => {
+  const observations: RouterEvalObservation[] = [
+    {
+      sampleId: "a1",
+      configId: "alpha",
+      expectedModel: "gpt-4o",
+      selectedModel: "gpt-4o",
+      latencyMs: 100,
+      costUsd: 1,
+      success: true,
+    },
+    {
+      sampleId: "a2",
+      configId: "alpha",
+      expectedModel: "claude",
+      selectedModel: "gpt-4o",
+      latencyMs: 200,
+      costUsd: 2,
+      success: false,
+    },
+    {
+      sampleId: "b1",
+      configId: "beta",
+      expectedModel: "gpt-4o",
+      selectedModel: "gpt-4o",
+      latencyMs: 80,
+      costUsd: 4,
+      success: true,
+    },
+    {
+      sampleId: "b2",
+      configId: "beta",
+      expectedModel: "gpt-4o",
+      selectedModel: "gpt-4o",
+      latencyMs: 110,
+      costUsd: 5,
+      success: true,
+    },
+  ];
+
+  const report = aggregateRouterObservations(observations);
+
+  assert.equal(report.totalObservations, 4);
+  assert.equal(report.configs.length, 2);
+  assert.equal(report.bestConfigId, "beta");
+  assert.equal(report.configs[0]!.configId, "beta");
+  assert.ok(report.bestAiq >= 0);
+  assert.equal(report.paretoFrontier.length, 2);
+  assert.equal(report.configs[0]!.successRate, 1);
+});
+
+test("pareto frontier collapses dominated configs", () => {
+  const observations: RouterEvalObservation[] = [
+    {
+      sampleId: "x1",
+      configId: "fast-n-cheap",
+      expectedModel: "m1",
+      selectedModel: "m1",
+      latencyMs: 100,
+      costUsd: 1,
+      success: true,
+    },
+    {
+      sampleId: "x2",
+      configId: "slow-expensive",
+      expectedModel: "m1",
+      selectedModel: "m2",
+      latencyMs: 500,
+      costUsd: 100,
+      success: true,
+    },
+    {
+      sampleId: "x3",
+      configId: "mid-balanced",
+      expectedModel: "m1",
+      selectedModel: "m1",
+      latencyMs: 300,
+      costUsd: 10,
+      success: true,
+    },
+  ];
+
+  const report = aggregateRouterObservations(observations);
+  const frontier = computeParetoFrontier(report.configs);
+  assert.equal(frontier.length, 1);
+  assert.deepEqual(frontier.map((entry) => entry.configId), ["fast-n-cheap"]);
+});
+
+test("compareRouterEvalRuns reports regression signals and markdown", () => {
+  const candidate = aggregateRouterObservations([
+    {
+      sampleId: "c1",
+      configId: "cand",
+      expectedModel: "m1",
+      selectedModel: "m2",
+      latencyMs: 200,
+      costUsd: 2,
+      success: true,
+    },
+  ]);
+  const baseline = aggregateRouterObservations([
+    {
+      sampleId: "b1",
+      configId: "base",
+      expectedModel: "m1",
+      selectedModel: "m1",
+      latencyMs: 100,
+      costUsd: 1,
+      success: true,
+    },
+  ]);
+
+  const comparison: RouterEvalComparison = compareRouterEvalRuns(candidate, baseline);
+  assert.equal(comparison.regressed, true);
+  assert.ok(comparison.aiqDelta < 0);
+  const formatted = formatRouterEvalComparison(comparison);
+  const report = formatRouterEvalReport(candidate);
+
+  assert.match(formatted, /Regression Comparison/);
+  assert.match(formatted, /AIQ delta/);
+  assert.match(report, /Router Eval Report/);
+  assert.match(report, /\| config \| samples/);
+});


### PR DESCRIPTION
## Summary
- add Bun-based router-eval replay CLI and core aggregation/reporting library
- cover JSONL replay, JSON artifacts, baseline regression comparison, and SQLite call_logs replay
- fix Caddy gateway warnings and docs-sync OpenAPI path drift

## Validation
- bun run test:router-eval:bun
- /opt/homebrew/bin/oxlint src/lib/routerEval/index.ts scripts/router-eval/index.ts tests/unit/router-eval.test.ts tests/unit/router-eval-cli.test.ts scripts/check/check-docs-sync.mjs
- bun scripts/check/check-docs-sync.mjs
- caddy validate --config deploy/Caddyfile
- docker compose config --quiet