### PR TITLE
feat(autoCombo): latency/speed routing mode + backend cooldown generalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - **hygiene:** Add ADR.md with fleet hygiene decisions (ADR-001 baseline, ADR-002 e2e restoration, ADR-003 dual dependency automation)
 - **e2e:** Remove orphaned testIgnore entries (analytics-tabs, protocol-visibility, skills-marketplace) whose specs no longer exist
 
+- **routing (latency/speed mode):** add a dedicated **speed-optimized routing mode** that scores every provider×model pair in a combo against **TTFT, tokens-per-second, E2E latency, p95 latency, circuit-breaker health, failure rate, and latency stability (std-dev)** — and ranks them so the "fastest reliable pair" wins. The runtime `LatencyStrategyImpl` (`routerStrategy.ts`) and the new MCP tool `omniroute_pick_fastest_model` (`schemas/tools.ts` + `tools/advancedTools.ts`) now share a single pure core (`services/autoCombo/speedRanking.ts` → `rankBySpeed`), so the user-facing preview and the live router pick the same winner. The MCP tool returns the top-ranked pair plus the **full ranked list with per-factor scores and per-metric breakdowns**, and optionally applies the result to a target combo by switching its strategy to `auto` + `autoRoutingStrategy: "latency"`. Weights are tunable (`{ttft, tps, e2e, p95, health, reliability, stability}`), OPEN-circuit candidates are dropped by default but can be retained with `includeUnhealthy=true`, and stability + reliability multipliers prevent a flaky fast provider from beating a steady slower one. Regression guard: `open-sse/services/autoCombo/__tests__/speedRanking.test.ts`. Closes the speed-mode routing gap tracked in this issue.
+
 ### 🔧 Bug Fixes
 
 - **ci:** Pin scorecard workflow to ubuntu-24.04

--- a/open-sse/mcp-server/schemas/pickFastestModel.ts
+++ b/open-sse/mcp-server/schemas/pickFastestModel.ts
@@ -1,0 +1,110 @@
+import { z } from "zod";
+import type { McpToolDefinition } from "./toolDefinition.ts";
+
+export const pickFastestModelInput = z.object({
+  comboId: z
+    .string()
+    .optional()
+    .describe(
+      "Optional combo id or name to scope the ranking to. Omit to rank across all enabled combos."
+    ),
+  includeUnhealthy: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, OPEN-circuit candidates are scored (sorted to the bottom) instead of filtered out."
+    ),
+  weights: z
+    .object({
+      ttft: z.number().min(0).optional(),
+      tps: z.number().min(0).optional(),
+      e2e: z.number().min(0).optional(),
+      p95: z.number().min(0).optional(),
+      health: z.number().min(0).optional(),
+      reliability: z.number().min(0).optional(),
+      stability: z.number().min(0).optional(),
+    })
+    .partial()
+    .optional()
+    .describe("Optional speed-ranking weight overrides merged onto the defaults."),
+  applyToCombo: z
+    .boolean()
+    .optional()
+    .describe("When true + comboId present, switches the combo to auto/latency routing."),
+  limit: z.number().int().min(1).max(50).optional().describe("Ranked result limit."),
+});
+
+export const pickFastestModelOutput = z.object({
+  fastest: z
+    .object({
+      provider: z.string(),
+      model: z.string(),
+      score: z.number(),
+      reason: z.string(),
+    })
+    .nullable(),
+  ranked: z.array(
+    z.object({
+      provider: z.string(),
+      model: z.string(),
+      score: z.number(),
+      factors: z.object({
+        ttft: z.number(),
+        tps: z.number(),
+        e2e: z.number(),
+        p95: z.number(),
+        health: z.number(),
+        reliability: z.number(),
+        stability: z.number(),
+      }),
+      metrics: z.object({
+        avgTtftMs: z.number().nullable(),
+        avgTokensPerSecond: z.number().nullable(),
+        avgE2ELatencyMs: z.number().nullable(),
+        p95LatencyMs: z.number().nullable(),
+        latencyStdDev: z.number().nullable(),
+        failureRate: z.number(),
+        circuitBreakerState: z.enum(["CLOSED", "OPEN", "HALF_OPEN"]),
+      }),
+      reason: z.string(),
+    })
+  ),
+  weights: z.object({
+    ttft: z.number(),
+    tps: z.number(),
+    e2e: z.number(),
+    p95: z.number(),
+    health: z.number(),
+    reliability: z.number(),
+    stability: z.number(),
+  }),
+  comboScope: z.object({ id: z.string(), name: z.string() }).nullable(),
+  appliedToCombo: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      strategy: z.string(),
+      autoRoutingStrategy: z.string(),
+    })
+    .nullable(),
+});
+
+export const pickFastestModelTool: McpToolDefinition<
+  typeof pickFastestModelInput,
+  typeof pickFastestModelOutput
+> = {
+  name: "omniroute_pick_fastest_model",
+  description:
+    "Picks the fastest reliable provider-model pair from live telemetry and can apply latency routing to a combo.",
+  inputSchema: pickFastestModelInput,
+  outputSchema: pickFastestModelOutput,
+  scopes: ["read:combos", "read:health", "read:usage"],
+  auditLevel: "basic",
+  phase: 2,
+  sourceEndpoints: [
+    "/api/combos",
+    "/api/monitoring/health",
+    "/api/usage/quota",
+    "/api/usage/analytics",
+  ],
+};

--- a/open-sse/mcp-server/schemas/tools.ts
+++ b/open-sse/mcp-server/schemas/tools.ts
@@ -1,5 +1,5 @@
 /**
- * MCP Tool Schemas — Contracts for all 22 core and advanced OmniRoute MCP tools.
+ * MCP Tool Schemas — Contracts for all 23 core and advanced OmniRoute MCP tools.
  *
  * Defines input/output Zod schemas, descriptions, scopes, and audit levels
  * for both essential (Phase 1) and advanced (Phase 2) MCP tools.
@@ -11,6 +11,7 @@
 
 import { z } from "zod";
 import { toolSearchTool } from "./toolSearch.ts";
+import { pickFastestModelTool } from "./pickFastestModel.ts";
 import {
   AUTO_ROUTING_STRATEGY_VALUES,
   ROUTING_STRATEGY_VALUES,
@@ -22,6 +23,7 @@ import {
 // Re-exported here for backward compatibility (many modules import them from ./tools.ts).
 export type { AuditLevel, McpToolDefinition } from "./toolDefinition.ts";
 import type { McpToolDefinition } from "./toolDefinition.ts";
+export { pickFastestModelInput, pickFastestModelOutput } from "./pickFastestModel.ts";
 
 // ============ Phase 1: Essential Tools (8) ============
 
@@ -1466,6 +1468,7 @@ export const MCP_TOOLS = [
   agentSkillsListTool,
   agentSkillsGetTool,
   agentSkillsCoverageTool,
+  pickFastestModelTool,
 ] as const;
 
 export const MCP_ESSENTIAL_TOOLS = MCP_TOOLS.filter((t) => t.phase === 1);

--- a/open-sse/mcp-server/server.ts
+++ b/open-sse/mcp-server/server.ts
@@ -5,9 +5,7 @@ import {
   getComboModelString,
   getComboStepTarget,
 } from "../../src/lib/combos/steps.ts";
-
 import { registerToolSearchTool } from "./toolSearch/register.ts";
-
 import {
   MCP_TOOLS,
   getHealthInput,
@@ -28,6 +26,7 @@ import {
   getProviderMetricsInput,
   bestComboForTaskInput,
   explainRouteInput,
+  pickFastestModelInput,
   getSessionSnapshotInput,
   dbHealthCheckInput,
   syncPricingInput,
@@ -38,7 +37,6 @@ import {
   oneproxyStatsInput,
 } from "./schemas/tools.ts";
 import { startMcpHeartbeat } from "./runtimeHeartbeat.ts";
-
 import { z } from "zod";
 import { closeAuditDb, logToolCall } from "./audit.ts";
 import {
@@ -47,7 +45,6 @@ import {
   type McpToolExtraLike,
 } from "./scopeEnforcement.ts";
 import { getMcpHttpAuthHeadersForInternalFetch } from "./httpAuthContext.ts";
-
 import {
   handleSimulateRoute,
   handleSetBudgetGuard,
@@ -66,6 +63,7 @@ import {
   handleOneproxyRotate,
   handleOneproxyStats,
 } from "./tools/advancedTools.ts";
+import { handlePickFastestModel } from "./tools/pickFastestModel.ts";
 import { memoryTools } from "./tools/memoryTools.ts";
 import { skillTools } from "./tools/skillTools.ts";
 import { agentSkillTools } from "./tools/agentSkillTools.ts";
@@ -1087,6 +1085,8 @@ export function createMcpServer(): McpServer {
       handleExplainRoute(explainRouteInput.parse(args))
     )
   );
+
+  server.registerTool("omniroute_pick_fastest_model", { description: "Picks the fastest reliable provider-model pair from live telemetry.", inputSchema: pickFastestModelInput }, withScopeEnforcement("omniroute_pick_fastest_model", (args) => handlePickFastestModel(pickFastestModelInput.parse(args))));
 
   server.registerTool(
     "omniroute_get_session_snapshot",

--- a/open-sse/mcp-server/tools/pickFastestModel.ts
+++ b/open-sse/mcp-server/tools/pickFastestModel.ts
@@ -1,0 +1,293 @@
+import { logToolCall } from "../audit.ts";
+import { getMcpHttpAuthHeadersForInternalFetch } from "../httpAuthContext.ts";
+import { normalizeQuotaResponse } from "../../../src/shared/contracts/quota.ts";
+import { resolveOmniRouteBaseUrl } from "../../../src/shared/utils/resolveOmniRouteBaseUrl.ts";
+import {
+  getComboModelProvider,
+  getComboModelString,
+  getComboStepTarget,
+} from "../../../src/lib/combos/steps.ts";
+import type { AutoRoutingStrategyValue } from "../../../src/shared/constants/routingStrategies.ts";
+import { rankBySpeed, DEFAULT_SPEED_WEIGHTS } from "../../services/autoCombo/speedRanking.ts";
+import type { SpeedCandidate } from "../../services/autoCombo/speedRanking.ts";
+
+const OMNIROUTE_BASE_URL = resolveOmniRouteBaseUrl();
+const OMNIROUTE_API_KEY = process.env.OMNIROUTE_API_KEY || "";
+
+async function apiFetch(path: string, options: RequestInit = {}): Promise<unknown> {
+  const url = `${OMNIROUTE_BASE_URL}${path}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(OMNIROUTE_API_KEY ? { Authorization: `Bearer ${OMNIROUTE_API_KEY}` } : {}),
+    ...getMcpHttpAuthHeadersForInternalFetch(),
+    ...((options.headers as Record<string, string>) || {}),
+  };
+  const response = await fetch(url, { ...options, headers, signal: AbortSignal.timeout(30000) });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "Unknown error");
+    throw new Error(`API [${response.status}]: ${text}`);
+  }
+  return response.json();
+}
+
+type JsonRecord = Record<string, unknown>;
+interface ComboModel { provider: string; model: string; inputCostPer1M: number; }
+function isRecord(value: unknown): value is JsonRecord { return !!value && typeof value === "object" && !Array.isArray(value); }
+function toRecord(value: unknown): JsonRecord { return isRecord(value) ? value : {}; }
+function toArrayOfRecords(value: unknown): JsonRecord[] { return Array.isArray(value) ? value.filter(isRecord) : []; }
+function toString(value: unknown, fallback = ""): string { return typeof value === "string" ? value : fallback; }
+function toNumber(value: unknown, fallback = 0): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim().length > 0 ? Number(value) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+function getComboModels(combo: JsonRecord): ComboModel[] {
+  const directModels = toArrayOfRecords(combo.models);
+  const nestedModels = toArrayOfRecords(toRecord(combo.data).models);
+  const sourceModels = directModels.length > 0 ? directModels : nestedModels;
+  return sourceModels.map((model) => ({
+    provider: getComboModelProvider(model) || (getComboModelString(model) ? "unknown" : "combo"),
+    model: getComboModelString(model) || getComboStepTarget(model) || "",
+    inputCostPer1M: toNumber(model.inputCostPer1M, 3.0),
+  }));
+}
+function normalizeCombosResponse(raw: unknown): JsonRecord[] {
+  if (Array.isArray(raw)) return raw.filter(isRecord);
+  const source = toRecord(raw);
+  return Array.isArray(source.combos) ? source.combos.filter(isRecord) : [];
+}
+
+/**
+ * Speed-optimized "pick the fastest reliable provider×model" tool.
+ *
+ * Composes live telemetry from `/api/combos/metrics` (per-combo per-model
+ * avg latency + success rate), `/api/monitoring/health` (circuit-breaker
+ * state), `/api/usage/quota` (quota remaining) and `/api/usage/analytics`
+ * (per-provider p95 / errorRate) into SpeedCandidates, runs the same
+ * `rankBySpeed` engine that drives `LatencyStrategyImpl` and the latency-
+ * optimized playground preview, and returns:
+ *   - the top-ranked (fastest) provider×model pair,
+ *   - the full ranked list with per-factor scores (ttft / tps / e2e /
+ *     p95 / health / reliability / stability) so callers can show
+ *     "why this one wins" in dashboards,
+ *   - optionally applies the choice to a target combo by flipping its
+ *     strategy to "auto" + autoRoutingStrategy "latency", so the runtime
+ *     router will keep using this ranking.
+ */
+export async function handlePickFastestModel(args: {
+  comboId?: string;
+  /** When true, OPEN-circuit candidates are still scored (sorted to the bottom). */
+  includeUnhealthy?: boolean;
+  /** Optional weight overrides; merged onto DEFAULT_SPEED_WEIGHTS. */
+  weights?: Partial<{
+    ttft: number;
+    tps: number;
+    e2e: number;
+    p95: number;
+    health: number;
+    reliability: number;
+    stability: number;
+  }>;
+  /** When true + comboId present, sets the combo's autoRoutingStrategy to "latency". */
+  applyToCombo?: boolean;
+  /** Max number of ranked entries to return (default 10). */
+  limit?: number;
+}) {
+  const start = Date.now();
+  try {
+    // Pull all of the live telemetry we need in parallel.
+    const [combosRaw, healthRaw, quotaRaw, analyticsRaw] = await Promise.allSettled([
+      apiFetch("/api/combos"),
+      apiFetch("/api/monitoring/health"),
+      apiFetch("/api/usage/quota"),
+      apiFetch("/api/usage/analytics?period=session"),
+    ]);
+
+    const combos = combosRaw.status === "fulfilled" ? normalizeCombosResponse(combosRaw.value) : [];
+    const health = healthRaw.status === "fulfilled" ? toRecord(healthRaw.value) : {};
+    const quota =
+      quotaRaw.status === "fulfilled"
+        ? normalizeQuotaResponse(quotaRaw.value)
+        : normalizeQuotaResponse({});
+    const analytics = analyticsRaw.status === "fulfilled" ? toRecord(analyticsRaw.value) : {};
+    const analyticsByProvider = toRecord(toRecord(analytics.byProvider));
+    const analyticsTop = toRecord(analytics);
+
+    // Narrow to the requested combo, if provided.
+    const targetCombo = args.comboId
+      ? combos.find(
+          (combo) => toString(combo.id) === args.comboId || toString(combo.name) === args.comboId
+        )
+      : undefined;
+
+    const scopedCombos = targetCombo
+      ? [targetCombo]
+      : combos.filter((combo) => combo.enabled !== false);
+
+    if (scopedCombos.length === 0) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ error: "No matching combos available" }),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const breakers = toArrayOfRecords(health.circuitBreakers);
+    const providers = quota.providers;
+
+    // Assemble SpeedCandidates from the combo's models.
+    const speedCandidates: SpeedCandidate[] = [];
+    for (const combo of scopedCombos) {
+      const models = getComboModels(combo);
+      for (const model of models) {
+        if (!model.provider || !model.model) continue;
+        const cb = breakers.find((breaker) => toString(breaker.provider) === model.provider);
+        const q = providers.find((providerEntry) => providerEntry.provider === model.provider);
+        const perProvider = toRecord(analyticsByProvider[model.provider]);
+        const fallbackAnalytics = perProvider.requests
+          ? perProvider
+          : toRecord(analyticsTop.byProvider && analyticsTop.byProvider[model.provider]);
+        const cbState = toString(cb?.state, "CLOSED") as SpeedCandidate["circuitBreakerState"];
+        const p95 = toNumber(perProvider.p95LatencyMs ?? fallbackAnalytics.p95LatencyMs, NaN);
+        const errorRate = toNumber(perProvider.errorRate ?? fallbackAnalytics.errorRate, 0);
+
+        speedCandidates.push({
+          provider: model.provider,
+          model: model.model,
+          circuitBreakerState: cbState,
+          avgE2ELatencyMs: toNumber(perProvider.avgLatencyMs ?? fallbackAnalytics.avgLatencyMs, NaN),
+          p95LatencyMs: Number.isFinite(p95) ? p95 : 0,
+          avgTokensPerSecond: toNumber(perProvider.avgTokensPerSecond ?? fallbackAnalytics.tps, NaN),
+          avgTtftMs: toNumber(
+            perProvider.avgTtftMs ?? fallbackAnalytics.ttftMs ?? fallbackAnalytics.avgTtftMs,
+            NaN
+          ),
+          latencyStdDev: toNumber(perProvider.latencyStdDev ?? fallbackAnalytics.latencyStdDev, NaN),
+          errorRate: Number.isFinite(errorRate) ? errorRate : 0,
+          failureRate: Number.isFinite(errorRate) ? errorRate : 0,
+          quotaRemaining: q?.quotaUsed != null && q?.quotaTotal
+            ? Math.max(0, 100 - q.quotaUsed / q.quotaTotal * 100)
+            : 100,
+          quotaTotal: q?.quotaTotal ?? 100,
+          costPer1MTokens: model.inputCostPer1M ?? 0,
+        });
+      }
+    }
+
+    // Dedupe by provider×model (a model can appear across multiple combos).
+    const dedupeKey = (c: SpeedCandidate) => `${c.provider}::${c.model}`;
+    const deduped = new Map<string, SpeedCandidate>();
+    for (const candidate of speedCandidates) {
+      const key = dedupeKey(candidate);
+      const existing = deduped.get(key);
+      if (!existing) {
+        deduped.set(key, candidate);
+        continue;
+      }
+      // Prefer the candidate whose CB / quota numbers are most populated.
+      const existingScore = (existing.circuitBreakerState ? 1 : 0) + (existing.quotaRemaining != null ? 1 : 0);
+      const newScore = (candidate.circuitBreakerState ? 1 : 0) + (candidate.quotaRemaining != null ? 1 : 0);
+      if (newScore > existingScore) deduped.set(key, candidate);
+    }
+    const finalCandidates = [...deduped.values()];
+
+    if (finalCandidates.length === 0) {
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify({ error: "No provider×model candidates available to rank" }) },
+        ],
+        isError: true,
+      };
+    }
+
+    // Merge caller weight overrides on top of the defaults.
+    const weights = args.weights
+      ? { ...DEFAULT_SPEED_WEIGHTS, ...args.weights }
+      : DEFAULT_SPEED_WEIGHTS;
+
+    const ranked = rankBySpeed(finalCandidates, weights, {
+      includeUnhealthy: args.includeUnhealthy === true,
+    });
+
+    const limit = Math.min(Math.max(toNumber(args.limit, 10), 1), 50);
+    const trimmed = ranked.slice(0, limit);
+    const winner = trimmed[0];
+
+    // Optionally apply the winner's provider×model back to the target combo by
+    // flipping it into "auto" routing with the "latency" strategy.  We still
+    // let the runtime router pick the actual model within the combo's pool
+    // (this call does not mutate the combo's model list).
+    let appliedToCombo: JsonRecord | null = null;
+    if (args.applyToCombo && targetCombo && winner) {
+      const comboId = toString(targetCombo.id);
+      const comboData = toRecord(targetCombo.data);
+      const currentConfig = toRecord(
+        Object.keys(toRecord(targetCombo.config)).length > 0
+          ? targetCombo.config
+          : comboData.config
+      );
+      const currentAutoConfig = toRecord(currentConfig.auto);
+      const nextConfig = {
+        ...currentConfig,
+        auto: {
+          ...currentAutoConfig,
+          routerStrategy: "latency" as AutoRoutingStrategyValue,
+        },
+      };
+      const updatedCombo = toRecord(
+        await apiFetch(`/api/combos/${encodeURIComponent(comboId)}`, {
+          method: "PUT",
+          body: JSON.stringify({ strategy: "auto", config: nextConfig }),
+        })
+      );
+      const updatedConfig = toRecord(updatedCombo.config);
+      appliedToCombo = {
+        id: toString(updatedCombo.id, comboId),
+        name: toString(updatedCombo.name, toString(targetCombo.name, comboId)),
+        strategy: toString(updatedCombo.strategy, "auto"),
+        autoRoutingStrategy: toString(toRecord(updatedConfig.auto).routerStrategy, "latency"),
+      };
+    }
+
+    const result = {
+      fastest: winner
+        ? {
+            provider: winner.provider,
+            model: winner.model,
+            score: winner.score,
+            reason: winner.reason,
+          }
+        : null,
+      ranked: trimmed.map((entry) => ({
+        provider: entry.provider,
+        model: entry.model,
+        score: entry.score,
+        factors: entry.factors,
+        metrics: entry.metrics,
+        reason: entry.reason,
+      })),
+      weights,
+      comboScope: targetCombo
+        ? { id: toString(targetCombo.id), name: toString(targetCombo.name) }
+        : null,
+      appliedToCombo,
+    };
+
+    await logToolCall("omniroute_pick_fastest_model", args, result, Date.now() - start, true);
+    return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await logToolCall(
+      "omniroute_pick_fastest_model",
+      args,
+      null,
+      Date.now() - start,
+      false,
+      msg
+    );
+    return { content: [{ type: "text" as const, text: `Error: ${msg}` }], isError: true };
+  }
+}

--- a/open-sse/services/autoCombo/__tests__/speedRanking.test.ts
+++ b/open-sse/services/autoCombo/__tests__/speedRanking.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for the speed-optimized provider×model ranking engine.
+ *
+ * Covers the pure `rankBySpeed` function used by:
+ *   - the runtime `LatencyStrategyImpl` (routerStrategy.ts)
+ *   - the `omniroute_pick_fastest_model` MCP tool
+ *   - the latency-optimized playground preview (via the same shared core)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  rankBySpeed,
+  pickFastest,
+  DEFAULT_SPEED_WEIGHTS,
+} from "../speedRanking";
+import type { SpeedCandidate } from "../speedRanking";
+
+function candidate(overrides: Partial<SpeedCandidate> = {}): SpeedCandidate {
+  return {
+    provider: "anthropic",
+    model: "claude-sonnet",
+    circuitBreakerState: "CLOSED",
+    errorRate: 0,
+    failureRate: 0,
+    quotaRemaining: 100,
+    quotaTotal: 100,
+    costPer1MTokens: 3,
+    p95LatencyMs: 1000,
+    latencyStdDev: 100,
+    ...overrides,
+  };
+}
+
+describe("rankBySpeed — selection", () => {
+  it("returns an empty list when the pool is empty", () => {
+    expect(rankBySpeed([])).toEqual([]);
+  });
+
+  it("filters out OPEN circuit-breaker candidates by default", () => {
+    const pool: SpeedCandidate[] = [
+      candidate({ provider: "broken", model: "x", circuitBreakerState: "OPEN" }),
+      candidate({ provider: "ok", model: "y", avgTtftMs: 200 }),
+    ];
+    const ranked = rankBySpeed(pool);
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0].provider).toBe("ok");
+  });
+
+  it("keeps OPEN candidates when includeUnhealthy is set, sorted to the bottom", () => {
+    const pool: SpeedCandidate[] = [
+      candidate({ provider: "broken", model: "x", circuitBreakerState: "OPEN" }),
+      candidate({ provider: "ok", model: "y", avgTtftMs: 200, avgE2ELatencyMs: 1000 }),
+    ];
+    const ranked = rankBySpeed(pool, DEFAULT_SPEED_WEIGHTS, { includeUnhealthy: true });
+    expect(ranked).toHaveLength(2);
+    expect(ranked[0].provider).toBe("ok");
+    expect(ranked[1].provider).toBe("broken");
+  });
+});
+
+describe("rankBySpeed — metric weighting", () => {
+  it("picks the lower-TTFT provider×model when TTFT dominates", () => {
+    const fast: SpeedCandidate = candidate({
+      provider: "fast",
+      model: "m",
+      avgTtftMs: 120,
+      avgE2ELatencyMs: 1000,
+      avgTokensPerSecond: 80,
+      p95LatencyMs: 1100,
+    });
+    const slow: SpeedCandidate = candidate({
+      provider: "slow",
+      model: "m",
+      avgTtftMs: 900,
+      avgE2ELatencyMs: 6000,
+      avgTokensPerSecond: 20,
+      p95LatencyMs: 7000,
+    });
+    const ranked = rankBySpeed([slow, fast]);
+    expect(ranked[0].provider).toBe("fast");
+  });
+
+  it("penalizes high failure rate so a flaky fast provider loses to a steady slower one", () => {
+    const flakyFast: SpeedCandidate = candidate({
+      provider: "flaky",
+      model: "m",
+      avgTtftMs: 250,
+      avgE2ELatencyMs: 1500,
+      avgTokensPerSecond: 90,
+      p95LatencyMs: 1700,
+      errorRate: 0.3,
+      failureRate: 0.3,
+    });
+    const steadySlow: SpeedCandidate = candidate({
+      provider: "steady",
+      model: "m",
+      avgTtftMs: 400,
+      avgE2ELatencyMs: 2200,
+      avgTokensPerSecond: 70,
+      p95LatencyMs: 2500,
+      errorRate: 0.01,
+      failureRate: 0.01,
+    });
+    const ranked = rankBySpeed([flakyFast, steadySlow]);
+    expect(ranked[0].provider).toBe("steady");
+  });
+
+  it("penalizes high latency stdDev so a bursty fast provider loses to a steady slow one", () => {
+    const bursty: SpeedCandidate = candidate({
+      provider: "bursty",
+      model: "m",
+      avgTtftMs: 100,
+      avgE2ELatencyMs: 900,
+      avgTokensPerSecond: 100,
+      p95LatencyMs: 950,
+      latencyStdDev: 1500,
+    });
+    const steady: SpeedCandidate = candidate({
+      provider: "steady",
+      model: "m",
+      avgTtftMs: 350,
+      avgE2ELatencyMs: 1500,
+      avgTokensPerSecond: 60,
+      p95LatencyMs: 1600,
+      latencyStdDev: 50,
+    });
+    const ranked = rankBySpeed([bursty, steady]);
+    expect(ranked[0].provider).toBe("steady");
+  });
+
+  it("rewards higher tokens-per-second when everything else ties", () => {
+    const base = {
+      avgTtftMs: 300,
+      avgE2ELatencyMs: 1500,
+      p95LatencyMs: 1600,
+    };
+    const lowTps: SpeedCandidate = candidate({ provider: "low", model: "m", ...base, avgTokensPerSecond: 20 });
+    const highTps: SpeedCandidate = candidate({ provider: "high", model: "m", ...base, avgTokensPerSecond: 200 });
+    const ranked = rankBySpeed([lowTps, highTps]);
+    expect(ranked[0].provider).toBe("high");
+  });
+});
+
+describe("rankBySpeed — factor breakdown", () => {
+  it("emits per-factor values in [0..1] and an explanation", () => {
+    const ranked = rankBySpeed([
+      candidate({
+        provider: "a",
+        model: "m",
+        avgTtftMs: 100,
+        avgE2ELatencyMs: 1000,
+        avgTokensPerSecond: 100,
+        p95LatencyMs: 1100,
+        latencyStdDev: 50,
+      }),
+    ]);
+    expect(ranked).toHaveLength(1);
+    const factors = ranked[0].factors;
+    for (const value of Object.values(factors)) {
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(1);
+    }
+    expect(ranked[0].reason).toMatch(/SpeedRanking\[/);
+    expect(ranked[0].reason).toMatch(/ttft=100ms/);
+  });
+
+  it("falls back to 0.5 per missing metric so new providers are not crushed", () => {
+    const ranked = rankBySpeed([candidate({ provider: "fresh", model: "m" })]);
+    expect(ranked).toHaveLength(1);
+    // No telemetry at all → weighted sum lands near 0.5 with reliability multiplier 1
+    expect(ranked[0].factors.reliability).toBe(1);
+    expect(ranked[0].factors.health).toBe(1);
+    expect(ranked[0].factors.ttft).toBe(0.5);
+    expect(ranked[0].factors.tps).toBe(0.5);
+  });
+});
+
+describe("rankBySpeed — weight overrides", () => {
+  it("respects caller weight overrides (e.g. heavy TTFT bias)", () => {
+    const fastTtft: SpeedCandidate = candidate({
+      provider: "fast",
+      model: "m",
+      avgTtftMs: 100,
+      avgE2ELatencyMs: 5000,
+      avgTokensPerSecond: 5,
+      p95LatencyMs: 6000,
+    });
+    const slowTtft: SpeedCandidate = candidate({
+      provider: "slow",
+      model: "m",
+      avgTtftMs: 800,
+      avgE2ELatencyMs: 1200,
+      avgTokensPerSecond: 120,
+      p95LatencyMs: 1300,
+    });
+
+    const normal = rankBySpeed([fastTtft, slowTtft]);
+    // Normal weights still pick slowTtft because TPS/E2E dominate over TTFT gaps.
+    expect(normal[0].provider).toBe("slow");
+
+    const heavyTtft = rankBySpeed([fastTtft, slowTtft], {
+      ...DEFAULT_SPEED_WEIGHTS,
+      ttft: 0.7,
+      tps: 0.05,
+      e2e: 0.05,
+      p95: 0.05,
+      health: 0.05,
+      reliability: 0.05,
+      stability: 0.05,
+    });
+    expect(heavyTtft[0].provider).toBe("fast");
+  });
+});
+
+describe("pickFastest", () => {
+  it("returns null on an empty pool", () => {
+    expect(pickFastest([])).toBeNull();
+  });
+
+  it("returns the top-ranked candidate", () => {
+    const fast = candidate({ provider: "fast", model: "m", avgTtftMs: 100 });
+    const slow = candidate({ provider: "slow", model: "m", avgTtftMs: 900 });
+    const winner = pickFastest([slow, fast]);
+    expect(winner?.provider).toBe("fast");
+  });
+});

--- a/open-sse/services/autoCombo/routerStrategy.ts
+++ b/open-sse/services/autoCombo/routerStrategy.ts
@@ -14,6 +14,8 @@ import type { ProviderCandidate, ScoredProvider } from "./scoring.ts";
 import { scorePool } from "./scoring.ts";
 import { getTaskFitness } from "./taskFitness.ts";
 import { clamp01 } from "../../utils/number.ts";
+import { rankBySpeed } from "./speedRanking.ts";
+import type { SpeedCandidate } from "./speedRanking.ts";
 
 export interface SlaRoutingPolicy {
   targetP95Ms?: number;
@@ -48,6 +50,36 @@ export interface RouterStrategy {
 }
 
 // ── RulesStrategy: wraps 6-factor scoring engine ────────────────────────────
+
+function toSpeedCandidate(c: ProviderCandidate): SpeedCandidate {
+  return {
+    // Identity
+    provider: c.provider,
+    model: c.model,
+    // Resource state
+    quotaRemaining: c.quotaRemaining,
+    quotaTotal: c.quotaTotal,
+    circuitBreakerState: c.circuitBreakerState,
+    // Costs
+    costPer1MTokens: c.costPer1MTokens,
+    // Latency metrics
+    p95LatencyMs: c.p95LatencyMs,
+    avgTtftMs: c.avgTtftMs,
+    avgE2ELatencyMs: c.avgE2ELatencyMs,
+    avgTokensPerSecond: c.avgTokensPerSecond,
+    latencyStdDev: c.latencyStdDev,
+    // Reliability
+    errorRate: c.errorRate,
+    failureRate: c.failureRate,
+    // Tier signals (forwarded so weights stay available for downstream tuning)
+    accountTier: c.accountTier,
+    quotaResetIntervalSecs: c.quotaResetIntervalSecs,
+    contextAffinity: c.contextAffinity,
+    resetWindowAffinity: c.resetWindowAffinity,
+    connectionPoolSize: c.connectionPoolSize,
+    connectionId: c.connectionId,
+  };
+}
 
 class RulesStrategyImpl implements RouterStrategy {
   readonly name = "rules";
@@ -100,101 +132,35 @@ class CostStrategyImpl implements RouterStrategy {
 
 // ── LatencyStrategy: prioritize low latency + reliability ───────────────────
 
-function positiveMetric(value: unknown): number | null {
-  const numericValue = Number(value);
-  return Number.isFinite(numericValue) && numericValue > 0 ? numericValue : null;
-}
-
-function boundedRate(value: unknown): number {
-  const numericValue = Number(value);
-  return Number.isFinite(numericValue) && numericValue >= 0 ? Math.min(1, numericValue) : 0;
-}
-
-function maxPositiveMetric(
-  candidates: ProviderCandidate[],
-  readMetric: (candidate: ProviderCandidate) => unknown,
-  fallback = 1
-): number {
-  return Math.max(
-    ...candidates.map((candidate) => positiveMetric(readMetric(candidate)) ?? 0),
-    fallback
-  );
-}
-
-function latencyMetricScore(value: number | null, maxValue: number): number {
-  if (value == null) return 0.5;
-  return inverseNormalized(value, maxValue);
-}
-
-function throughputMetricScore(value: number | null, maxValue: number): number {
-  if (value == null) return 0.5;
-  return clamp01(value / Math.max(maxValue, 0.000_001));
-}
-
 class LatencyStrategyImpl implements RouterStrategy {
   readonly name = "latency";
   readonly description =
     "Prioritizes the fastest reliable provider-model pair using TTFT, TPS, E2E latency, health, fail rate, and stability";
 
   select(pool: ProviderCandidate[], context: RoutingContext): RoutingDecision {
-    const healthy = pool.filter((c) => c.circuitBreakerState !== "OPEN");
-    const candidates = healthy.length > 0 ? healthy : pool;
-    if (candidates.length === 0) throw new Error("[LatencyStrategy] No candidates available");
+    const ranked = rankBySpeed(pool.map(toSpeedCandidate));
+    const winner = ranked[0];
+    if (!winner) {
+      throw new Error("[LatencyStrategy] No candidates available after speed ranking");
+    }
 
-    const maxP95 = maxPositiveMetric(candidates, (candidate) => candidate.p95LatencyMs);
-    const maxTtft = maxPositiveMetric(
-      candidates,
-      (candidate) => candidate.avgTtftMs ?? candidate.p95LatencyMs
-    );
-    const maxE2E = maxPositiveMetric(
-      candidates,
-      (candidate) => candidate.avgE2ELatencyMs ?? candidate.p95LatencyMs
-    );
-    const maxTps = maxPositiveMetric(candidates, (candidate) => candidate.avgTokensPerSecond);
-    const maxStdDev = maxPositiveMetric(candidates, (candidate) => candidate.latencyStdDev, 0.001);
-
-    const scored = candidates
-      .map((candidate) => {
-        const p95 = positiveMetric(candidate.p95LatencyMs);
-        const ttft = positiveMetric(candidate.avgTtftMs) ?? p95;
-        const e2e = positiveMetric(candidate.avgE2ELatencyMs) ?? p95;
-        const tps = positiveMetric(candidate.avgTokensPerSecond);
-        const failureRate = boundedRate(candidate.failureRate ?? candidate.errorRate);
-        const healthScore = getHealthScore(candidate);
-        const p95Score = latencyMetricScore(p95, maxP95);
-        const ttftScore = latencyMetricScore(ttft, maxTtft);
-        const e2eScore = latencyMetricScore(e2e, maxE2E);
-        const throughputScore = throughputMetricScore(tps, maxTps);
-        const reliabilityScore = 1 - failureRate;
-        const stabilityScore = latencyMetricScore(
-          positiveMetric(candidate.latencyStdDev),
-          maxStdDev
-        );
-        const rawScore =
-          ttftScore * 0.25 +
-          throughputScore * 0.2 +
-          e2eScore * 0.18 +
-          p95Score * 0.12 +
-          reliabilityScore * 0.15 +
-          healthScore * 0.05 +
-          stabilityScore * 0.05;
-        const reliabilityMultiplier = Math.max(0.05, reliabilityScore * reliabilityScore);
-        const score = rawScore * reliabilityMultiplier * Math.max(0.25, healthScore);
-
-        return { candidate, score, ttft, e2e, tps, failureRate };
-      })
-      .sort((a, b) => b.score - a.score);
-
-    const best = scored[0];
-    if (!best) throw new Error("[LatencyStrategy] No candidates available");
-
+    const w = winner;
+    const wMetrics = winner.metrics;
     return {
-      provider: best.candidate.provider,
-      model: best.candidate.model,
+      provider: w.provider,
+      model: w.model,
       strategy: this.name,
-      reason: `LatencyStrategy: ttft=${best.ttft ?? "n/a"}ms, tps=${best.tps ?? "n/a"}, e2e=${best.e2e ?? "n/a"}ms, p95=${best.candidate.p95LatencyMs}ms, failRate=${(best.failureRate * 100).toFixed(2)}%`,
-      candidatesConsidered: candidates.length,
-      finalScore: best.score,
+      reason:
+        `LatencyStrategy(score=${winner.score.toFixed(3)}): ` +
+        `ttft=${wMetrics.avgTtftMs?.toFixed(0) ?? "n/a"}ms ` +
+        `tps=${wMetrics.avgTokensPerSecond?.toFixed(1) ?? "n/a"} ` +
+        `e2e=${wMetrics.avgE2ELatencyMs?.toFixed(0) ?? wMetrics.p95LatencyMs?.toFixed(0) ?? "n/a"}ms ` +
+        `p95=${wMetrics.p95LatencyMs?.toFixed(0) ?? "n/a"}ms ` +
+        `failRate=${((wMetrics.failureRate ?? 0) * 100).toFixed(2)}% ` +
+        `stability=${wMetrics.latencyStdDev?.toFixed(0) ?? "n/a"}ms ` +
+        `cb=${wMetrics.circuitBreakerState ?? "n/a"}`,
+      candidatesConsidered: ranked.length,
+      finalScore: winner.score,
     };
   }
 }

--- a/open-sse/services/autoCombo/speedRanking.ts
+++ b/open-sse/services/autoCombo/speedRanking.ts
@@ -1,0 +1,336 @@
+/**
+ * Speed-optimized Provider×Model Ranking
+ *
+ * Pure, framework-free scoring function that ranks provider×model candidates by
+ * the speed/reliability combination most likely to make a request feel "fast":
+ *
+ *   - lower avg Time-To-First-Token (TTFT)        — perceived responsiveness
+ *   - higher avg tokens-per-second (TPS)          — generation throughput
+ *   - lower avg end-to-end (E2E) latency          — full completion time
+ *   - lower p95 latency                           — tail-risk backup metric
+ *   - higher circuit-breaker health               — must be reachable
+ *   - lower failure / error rate                  — speed without flake
+ *   - lower latency standard deviation (stability)— consistent, not bursty
+ *
+ * Every metric is optional; missing telemetry is treated as the pool median
+ * (i.e. 0.5 in [0..1]) so a brand-new provider/model does not get crushed, but
+ * also does not get a free pass on a metric we have no data for.  This mirrors
+ * the behavior of the existing `LatencyStrategyImpl` and is intentional — the
+ * function is the canonical ranking for the "fastest reliable provider-model"
+ * UX in the playground + MCP `omniroute_pick_fastest_model` tool, and is
+ * reused by the runtime `LatencyStrategyImpl` so the runtime router picks the
+ * same winner as the user-facing preview.
+ *
+ * Optional weights override defaults so callers (tests, dashboards, future
+ * `modePacks.speed-first`) can rebalance without duplicating the math.
+ */
+
+import type { ProviderCandidate } from "./scoring.ts";
+
+/** Optional per-candidate telemetry surfaced by the ranking. */
+export interface SpeedCandidate extends ProviderCandidate {
+  /** Numeric health score [0..1]; computed from circuitBreakerState when missing. */
+  health?: number;
+  /** Percentage quota remaining in [0..100]. Falls back to quotaRemaining. */
+  quotaRemainingPct?: number;
+  /** Numeric capacity score [0..1] in case the caller wants to expose it. */
+  capacityScore?: number;
+  /** Cached cost-per-1k tokens (denormalized from costPer1MTokens). */
+  costPer1k?: number;
+  /** Optional quality score for the candidate (e.g. eval benchmark). */
+  qualityScore?: number;
+  /** Optional strategic boost applied for premium/internal models. */
+  strategicBoost?: number;
+  /** Optional SLO-violation penalty that should be subtracted from the raw score. */
+  sloPenalty?: number;
+}
+
+/** Per-factor contribution of a single candidate (each value clamped to [0..1]). */
+export interface SpeedFactors {
+  ttft: number;
+  tps: number;
+  e2e: number;
+  p95: number;
+  health: number;
+  reliability: number;
+  stability: number;
+}
+
+/** Result of ranking a pool of candidates. */
+export interface SpeedRankedCandidate {
+  provider: string;
+  model: string;
+  /** Final composite score in [0..1]; higher is faster+more-reliable. */
+  score: number;
+  factors: SpeedFactors;
+  /** Raw telemetry we observed for the candidate (in provider-native units). */
+  metrics: {
+    avgTtftMs: number | null;
+    avgTokensPerSecond: number | null;
+    avgE2ELatencyMs: number | null;
+    p95LatencyMs?: number | null;
+    latencyStdDev: number | null;
+    failureRate: number;
+    circuitBreakerState: SpeedCandidate["circuitBreakerState"];
+  };
+  /** Human-readable explanation of why this candidate earned its score. */
+  reason: string;
+}
+
+/** Caller-tunable weights; defaults are documented at each property. */
+export interface SpeedRankingWeights {
+  /** Weight for TTFT (default 0.25). */
+  ttft: number;
+  /** Weight for tokens/sec (default 0.20). */
+  tps: number;
+  /** Weight for end-to-end latency (default 0.18). */
+  e2e: number;
+  /** Weight for p95 latency fallback (default 0.12). */
+  p95: number;
+  /** Weight for circuit-breaker health (default 0.05). */
+  health: number;
+  /** Weight for reliability = 1 - failureRate (default 0.15). */
+  reliability: number;
+  /** Weight for latency stability / low std-dev (default 0.05). */
+  stability: number;
+}
+
+/**
+ * Default weights — these sum to 1.0 and bias toward perceived speed (TTFT +
+ * TPS together account for 45% of the score) while still penalizing unsafe
+ * providers.  They are deliberately exported so the playground UI can render
+ * the formula and tests can pin it.
+ */
+export const DEFAULT_SPEED_WEIGHTS: SpeedRankingWeights = {
+  ttft: 0.25,
+  tps: 0.2,
+  e2e: 0.18,
+  p95: 0.12,
+  health: 0.05,
+  reliability: 0.15,
+  stability: 0.05,
+};
+
+/** Human-readable label for each weight key — used in `reason` strings. */
+const FACTOR_LABEL: Record<keyof SpeedRankingWeights, string> = {
+  ttft: "ttft",
+  tps: "tps",
+  e2e: "e2e",
+  p95: "p95",
+  health: "health",
+  reliability: "reliability",
+  stability: "stability",
+};
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function positiveFinite(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function toBoundedRate(value: number | null | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return 0;
+  return Math.min(1, value);
+}
+
+/**
+ * Pool-relative maximum for "lower is better" metrics.  Returns at least
+ * `floor` so a candidate with the only positive measurement does not divide
+ * by zero.
+ */
+function poolMax<T>(
+  values: ReadonlyArray<T>,
+  readMetric: (value: T) => number | null,
+  floor = 1
+): number {
+  let max = floor;
+  for (const value of values) {
+    const v = readMetric(value);
+    if (v != null && v > max) max = v;
+  }
+  return max;
+}
+
+/**
+ * Pool-relative maximum for "higher is better" metrics.  Returns at least
+ * `floor` so a missing metric does not yield Infinity downstream.
+ */
+function poolMaxHigherBetter<T>(
+  values: ReadonlyArray<T>,
+  readMetric: (value: T) => number | null,
+  floor = 0.000_001
+): number {
+  let max = floor;
+  for (const value of values) {
+    const v = readMetric(value);
+    if (v != null && v > max) max = v;
+  }
+  return max;
+}
+
+/** 1 - (value / max), clamped to [0..1]. Missing → 0.5 (pool median). */
+function lowerIsBetter(value: number | null | undefined, max: number): number {
+  if (value == null) return 0.5;
+  if (!Number.isFinite(value) || value < 0) return 0;
+  if (!Number.isFinite(max) || max <= 0) return 1;
+  return clamp01(1 - value / max);
+}
+
+/** value / max, clamped to [0..1]. Missing → 0.5. */
+function higherIsBetter(value: number | null | undefined, max: number): number {
+  if (value == null) return 0.5;
+  if (!Number.isFinite(value) || value < 0) return 0;
+  if (!Number.isFinite(max) || max <= 0) return 0;
+  return clamp01(value / max);
+}
+
+function healthScoreFor(state: SpeedCandidate["circuitBreakerState"]): number {
+  if (state === "CLOSED") return 1;
+  if (state === "HALF_OPEN") return 0.5;
+  return 0; // OPEN — caller is expected to filter these out beforehand, but be defensive.
+}
+
+/**
+ * Rank candidates for the speed-optimized routing mode.
+ *
+ * @param candidates Pool of provider×model candidates (typically the candidates
+ *   inside an auto combo's provider pool, or any list assembled by the
+ *   playground / MCP tool).
+ * @param weights Optional weight overrides — defaults to {@link DEFAULT_SPEED_WEIGHTS}.
+ * @param options.includeUnhealthy If false (default), OPEN circuit-breaker
+ *   candidates are dropped before scoring. If true, they are scored with a
+ *   health factor of 0 and a reliability factor of 0 so they sort to the
+ *   bottom without changing the rest of the ranking.
+ * @returns The full ranked list, highest score first.  The first entry is the
+ *   "fastest reliable provider-model pair" for this pool.
+ */
+export function rankBySpeed(
+  candidates: ReadonlyArray<SpeedCandidate>,
+  weights: SpeedRankingWeights = DEFAULT_SPEED_WEIGHTS,
+  options: { includeUnhealthy?: boolean } = {}
+): SpeedRankedCandidate[] {
+  if (candidates.length === 0) return [];
+
+  const pool = options.includeUnhealthy
+    ? [...candidates]
+    : candidates.filter((c) => c.circuitBreakerState !== "OPEN");
+  if (pool.length === 0) return [];
+
+  // Pre-compute pool-relative maxima so each metric is normalized within the
+  // observable range.  Using the pool max (not a hard-coded SLO) lets the
+  // ranking work when every candidate is "fast" — the fastest one still wins.
+  const maxTtft = poolMax(pool, (c) => positiveFinite(c.avgTtftMs) ?? positiveFinite(c.p95LatencyMs));
+  const maxE2e = poolMax(
+    pool,
+    (c) => positiveFinite(c.avgE2ELatencyMs) ?? positiveFinite(c.p95LatencyMs)
+  );
+  const maxP95 = poolMax(pool, (c) => positiveFinite(c.p95LatencyMs));
+  const maxTps = poolMaxHigherBetter(pool, (c) => positiveFinite(c.avgTokensPerSecond));
+  const maxStdDev = poolMax(pool, (c) => positiveFinite(c.latencyStdDev), 0.001);
+
+  const ranked = pool.map((candidate) => {
+    // Use the metric only when it is explicitly observed on the candidate;
+    // fall back to `null` rather than substituting p95 so a brand-new
+    // candidate (no telemetry at all) is treated as the pool median (0.5)
+    // rather than as "fastest" via a p95 default of 0.
+    const p95 = positiveFinite(candidate.p95LatencyMs);
+    const ttft = positiveFinite(candidate.avgTtftMs);
+    const e2e = positiveFinite(candidate.avgE2ELatencyMs);
+    const tps = positiveFinite(candidate.avgTokensPerSecond);
+    const stdDev = positiveFinite(candidate.latencyStdDev);
+    const failureRate = toBoundedRate(
+      candidate.failureRate ?? (typeof candidate.errorRate === "number" ? candidate.errorRate : 0)
+    );
+
+    const factors: SpeedFactors = {
+      ttft: lowerIsBetter(ttft, maxTtft),
+      tps: higherIsBetter(tps, maxTps),
+      e2e: lowerIsBetter(e2e, maxE2e),
+      p95: lowerIsBetter(p95, maxP95),
+      health: healthScoreFor(candidate.circuitBreakerState),
+      reliability: clamp01(1 - failureRate),
+      stability: lowerIsBetter(stdDev, maxStdDev),
+    };
+
+    // Composite weighted score (computed first; multiplicative penalties applied below).
+    const weightedSum =
+      factors.ttft * weights.ttft +
+      factors.tps * weights.tps +
+      factors.e2e * weights.e2e +
+      factors.p95 * weights.p95 +
+      factors.health * weights.health +
+      factors.reliability * weights.reliability +
+      factors.stability * weights.stability;
+
+    // Multiplicative penalties: an unreliable or unhealthy provider-model can
+    // still be the "fastest on paper", but we downweight it so a flaky fast
+    // option does not beat a slightly-slower steady one.  The 0.25 floor on
+    // the health multiplier preserves an OPEN breaker as a last-resort option
+    // when `includeUnhealthy` is true (a closed pool would otherwise skip it).
+    // The reliability multiplier uses a steep (0.25 + 0.75·reliability)² curve
+    // so a 30% failure-rate provider (reliability 0.7) earns ≈0.57× while a
+    // 1% failure-rate provider (reliability 0.99) earns ≈0.99× — enough to
+    // overcome the speed advantage of a fast-but-flaky pair.  The stability
+    // multiplier uses the same curve against the std-dev factor so a 1500ms
+    // std-dev bursty provider loses to a 50ms std-dev steady one.
+    const reliabilityMultiplier = Math.max(
+      0.05,
+      Math.pow(0.25 + 0.75 * factors.reliability, 2)
+    );
+    const stabilityMultiplier = Math.max(
+      0.05,
+      Math.pow(0.25 + 0.75 * factors.stability, 2)
+    );
+    const healthMultiplier = Math.max(0.25, factors.health);
+    const score = clamp01(
+      weightedSum * reliabilityMultiplier * stabilityMultiplier * healthMultiplier
+    );
+
+    const reasonParts: string[] = [];
+    reasonParts.push(
+      `ttft=${ttft == null ? "n/a" : `${Math.round(ttft)}ms`}`,
+      `tps=${tps == null ? "n/a" : tps.toFixed(1)}`,
+      `e2e=${e2e == null ? "n/a" : `${Math.round(e2e)}ms`}`,
+      `p95=${p95 == null ? "n/a" : `${Math.round(p95)}ms`}`,
+      `failRate=${(failureRate * 100).toFixed(2)}%`,
+      `cb=${candidate.circuitBreakerState}`
+    );
+
+    return {
+      provider: candidate.provider,
+      model: candidate.model,
+      score,
+      factors,
+      metrics: {
+        avgTtftMs: ttft,
+        avgTokensPerSecond: tps,
+        avgE2ELatencyMs: e2e,
+        p95LatencyMs: p95,
+        latencyStdDev: stdDev,
+        failureRate,
+        circuitBreakerState: candidate.circuitBreakerState,
+      },
+      reason: `SpeedRanking[${FACTOR_LABEL.ttft}=${factors.ttft.toFixed(2)}, ${FACTOR_LABEL.tps}=${factors.tps.toFixed(2)}, ${FACTOR_LABEL.e2e}=${factors.e2e.toFixed(2)}, ${FACTOR_LABEL.p95}=${factors.p95.toFixed(2)}, ${FACTOR_LABEL.reliability}=${factors.reliability.toFixed(2)}, ${FACTOR_LABEL.health}=${factors.health.toFixed(2)}, ${FACTOR_LABEL.stability}=${factors.stability.toFixed(2)}] → ${reasonParts.join(", ")}`,
+    };
+  });
+
+  return ranked.sort((a, b) => b.score - a.score);
+}
+
+/**
+ * Convenience selector — returns the top-ranked candidate or `null` when the
+ * pool is empty.  Used by the runtime `LatencyStrategyImpl` and the MCP
+ * `omniroute_pick_fastest_model` tool when only the winner is needed.
+ */
+export function pickFastest(
+  candidates: ReadonlyArray<SpeedCandidate>,
+  weights: SpeedRankingWeights = DEFAULT_SPEED_WEIGHTS
+): SpeedRankedCandidate | null {
+  const ranked = rankBySpeed(candidates, weights);
+  return ranked.length > 0 ? ranked[0] : null;
+}

--- a/src/app/api/v1/relay/chat/completions/backendFailureState.ts
+++ b/src/app/api/v1/relay/chat/completions/backendFailureState.ts
@@ -1,0 +1,49 @@
+interface FailureEntry {
+  until: number;
+  reason: string;
+}
+
+const failures = new Map<string, FailureEntry>();
+
+export interface ActiveBackendFailure {
+  remainingMs: number;
+  reason: string;
+}
+
+export function getActiveBackendFailure(
+  backendId: string,
+  now = Date.now()
+): ActiveBackendFailure | null {
+  const entry = failures.get(backendId);
+  if (!entry) return null;
+  if (entry.until <= now) {
+    failures.delete(backendId);
+    return null;
+  }
+
+  return {
+    remainingMs: entry.until - now,
+    reason: entry.reason,
+  };
+}
+
+export function recordBackendFailure(
+  backendId: string,
+  reason: string,
+  now = Date.now(),
+  cooldownMs: number
+): void {
+  if (cooldownMs <= 0) {
+    failures.delete(backendId);
+    return;
+  }
+  failures.set(backendId, { until: now + cooldownMs, reason });
+}
+
+export function clearBackendFailure(backendId: string): void {
+  failures.delete(backendId);
+}
+
+export function resetBackendFailures(): void {
+  failures.clear();
+}

--- a/src/app/api/v1/relay/chat/completions/bifrostCooldown.ts
+++ b/src/app/api/v1/relay/chat/completions/bifrostCooldown.ts
@@ -1,14 +1,12 @@
-interface CooldownEntry {
-  until: number;
-  reason: string;
-}
+import {
+  clearBackendFailure,
+  getActiveBackendFailure,
+  recordBackendFailure,
+  resetBackendFailures,
+  type ActiveBackendFailure,
+} from "./backendFailureState.ts";
 
-const cooldowns = new Map<string, CooldownEntry>();
-
-export interface ActiveBifrostCooldown {
-  remainingMs: number;
-  reason: string;
-}
+export type ActiveBifrostCooldown = ActiveBackendFailure;
 
 export function getBifrostFailureCooldownMs(env: NodeJS.ProcessEnv = process.env): number {
   const parsed = Number.parseInt(env.OMNIROUTE_BIFROST_FAILURE_COOLDOWN_MS || "", 10);
@@ -19,17 +17,7 @@ export function getActiveBifrostCooldown(
   baseUrl: string,
   now = Date.now()
 ): ActiveBifrostCooldown | null {
-  const entry = cooldowns.get(baseUrl);
-  if (!entry) return null;
-  if (entry.until <= now) {
-    cooldowns.delete(baseUrl);
-    return null;
-  }
-
-  return {
-    remainingMs: entry.until - now,
-    reason: entry.reason,
-  };
+  return getActiveBackendFailure(baseUrl, now);
 }
 
 export function recordBifrostFailure(
@@ -38,17 +26,13 @@ export function recordBifrostFailure(
   now = Date.now(),
   cooldownMs = getBifrostFailureCooldownMs()
 ): void {
-  if (cooldownMs <= 0) {
-    cooldowns.delete(baseUrl);
-    return;
-  }
-  cooldowns.set(baseUrl, { until: now + cooldownMs, reason });
+  recordBackendFailure(baseUrl, reason, now, cooldownMs);
 }
 
 export function clearBifrostFailure(baseUrl: string): void {
-  cooldowns.delete(baseUrl);
+  clearBackendFailure(baseUrl);
 }
 
 export function resetBifrostCooldowns(): void {
-  cooldowns.clear();
+  resetBackendFailures();
 }

--- a/tests/unit/api/v1/bifrost-cooldown.test.ts
+++ b/tests/unit/api/v1/bifrost-cooldown.test.ts
@@ -7,9 +7,16 @@ import {
   recordBifrostFailure,
   resetBifrostCooldowns,
 } from "../../../../src/app/api/v1/relay/chat/completions/bifrostCooldown.ts";
+import {
+  clearBackendFailure,
+  getActiveBackendFailure,
+  recordBackendFailure,
+  resetBackendFailures,
+} from "../../../../src/app/api/v1/relay/chat/completions/backendFailureState.ts";
 
 afterEach(() => {
   resetBifrostCooldowns();
+  resetBackendFailures();
 });
 
 test("bifrost cooldown defaults to a short retry suppression window", () => {
@@ -42,4 +49,30 @@ test("bifrost cooldown can be disabled or cleared", () => {
   clearBifrostFailure("http://bifrost.local");
 
   assert.equal(getActiveBifrostCooldown("http://bifrost.local", 1001), null);
+});
+
+test("backend failure state is isolated by backend id", () => {
+  recordBackendFailure("bifrost:http://bifrost.local", "timeout", 1000, 500);
+  recordBackendFailure("openai", "rate-limit", 1000, 1000);
+
+  assert.deepEqual(getActiveBackendFailure("bifrost:http://bifrost.local", 1100), {
+    remainingMs: 400,
+    reason: "timeout",
+  });
+  assert.deepEqual(getActiveBackendFailure("openai", 1100), {
+    remainingMs: 900,
+    reason: "rate-limit",
+  });
+});
+
+test("backend failure state can be disabled, cleared, and expired", () => {
+  recordBackendFailure("bifrost", "timeout", 1000, 0);
+  assert.equal(getActiveBackendFailure("bifrost", 1001), null);
+
+  recordBackendFailure("bifrost", "timeout", 1000, 500);
+  clearBackendFailure("bifrost");
+  assert.equal(getActiveBackendFailure("bifrost", 1001), null);
+
+  recordBackendFailure("bifrost", "timeout", 1000, 500);
+  assert.equal(getActiveBackendFailure("bifrost", 1501), null);
 });


### PR DESCRIPTION
Ports upstream diegosouzapw/OmniRoute PRs:
- #6011: feat(autoCombo) latency/speed-optimized routing + omniroute_pick_fastest_model MCP tool
- #6004: Generalize backend failure cooldown state

Test plan:
- [ ] Run npm run test:unit
- [ ] Verify autoCombo latency mode selects fastest provider