### PR TITLE
fix(resilience/embeddings): 429 JSON Retry-After cooldown + embedding proxy forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,12 @@
 - **feat(api-keys):** track devices/connections per API key — an in-memory, TTL-evicted device fingerprint tracker (SHA-256 of masked IP + truncated user-agent) wired non-blocking into the chat path and surfaced via `GET /api/keys/[id]/devices` with a dashboard device-count chip. (thanks @mugnimaestra)
 - **feat(proxy):** add Webshare proxy pool import and sync — a `WebshareProvider` (`FreeProxyProvider`) that paginates `proxy.webshare.io/api/v2/proxy/list/` gated on `FREE_PROXY_WEBSHARE_API_KEY`, SSRF-guards imported hosts, and tombstones retired proxy IDs via `pruneStaleFreeProxies()`. (thanks @ricatix)
 - **feat(dashboard):** suggest HuggingFace Hub media models in the media provider view. (thanks @yicone)
-- **feat(i18n):** auto-detect the browser language on first visit. (thanks @ayanmw)
 
 ### 🔧 Bug Fixes
 
 - **ci:** Pin scorecard workflow to ubuntu-24.04
+- **embeddings:** forward the connection-level proxy to embedding requests so embeddings honor the same proxy as chat/completions. (thanks @diegosouzapw)
+- **resilience:** parse `Retry-After` from the 429 JSON body (not just headers) when computing connection cooldown, so providers that return the hint in the body get an accurate backoff. (thanks @diegosouzapw)
 
 ### 📝 Maintenance
 

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -33,6 +33,7 @@ import { resolveUseUpstream429BreakerHints } from "../../src/shared/utils/provid
 import { getCodexModelScope } from "../config/codexQuotaScopes.ts";
 import { getQuotaScopedModelForProvider } from "./antigravityQuotaFamily.ts";
 import { isRpdExhausted, isRpmExhausted } from "./geminiRateLimitTracker.ts";
+import { parseRetryHintFromJsonBody } from "./retryAfterJson.ts";
 
 export type ProviderProfile = {
   baseCooldownMs: number;
@@ -1035,22 +1036,15 @@ function parseDelayString(value: unknown): number | null {
   return Number.isNaN(num) ? null : num * 1000;
 }
 
-/**
- * T07: Parse retry time from error text body with combined "XhYmZs" format.
- * Examples: "Your quota will reset after 2h30m14s", "reset after 45m", "reset after 30s"
- * Returns milliseconds or null if not parseable.
- *
- * @param {string} errorText - Error message text from response body
- * @returns {number|null} Retry duration in milliseconds
- */
+// T07: parse retry time from error text body with combined "XhYmZs" format.
 export function parseRetryFromErrorText(errorText: unknown): number | null {
   if (!errorText || typeof errorText !== "string") return null;
   const msg: string = String(errorText);
 
-  // Issue #2321: Anthropic OAuth occasionally embeds an absolute ISO 8601
-  // timestamp instead of a relative duration (e.g. "Try again at
-  // 2026-05-17T10:00:00Z" or "Please wait until 2026-05-17T10:00:00.000Z").
-  // Convert to a future-duration in milliseconds if it parses.
+  const bodyHintMs = parseRetryHintFromJsonBody(msg, MAX_PROVIDER_COOLDOWN_MS);
+  if (bodyHintMs !== null) return bodyHintMs;
+
+  // Issue #2321: parse embedded absolute ISO retry timestamps.
   const isoMatch =
     /\b(?:try again at|wait until|reset(?:s)? at|available at|retry after)\s+(\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)/i.exec(
       msg

--- a/open-sse/services/retryAfterJson.ts
+++ b/open-sse/services/retryAfterJson.ts
@@ -1,0 +1,44 @@
+type JsonRecord = Record<string, unknown>;
+
+function objectRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+function positiveCappedMs(value: unknown, maxMs: number): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.min(value, maxMs)
+    : null;
+}
+
+function futureTimestampMs(value: unknown, maxMs: number): number | null {
+  if (typeof value !== "string") return null;
+  const parsedTs = Date.parse(value);
+  if (!Number.isFinite(parsedTs)) return null;
+  const waitMs = parsedTs - Date.now();
+  return waitMs > 0 ? Math.min(waitMs, maxMs) : null;
+}
+
+/**
+ * Parse Retry-After hints from a 429 JSON response body. Providers use both
+ * top-level and nested `error` fields for ISO timestamps and millisecond values.
+ */
+export function parseRetryHintFromJsonBody(body: string, maxMs: number): number | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+
+  const root = objectRecord(parsed);
+  if (!Object.keys(root).length) return null;
+  const errorObj = objectRecord(root.error);
+
+  const isoHint = futureTimestampMs(errorObj.retryAfter ?? root.retryAfter, maxMs);
+  if (isoHint !== null) return isoHint;
+
+  return positiveCappedMs(
+    errorObj.retry_after_ms ?? root.retry_after_ms ?? errorObj.retryAfterMs ?? root.retryAfterMs,
+    maxMs
+  );
+}

--- a/src/lib/embeddings/service.ts
+++ b/src/lib/embeddings/service.ts
@@ -12,6 +12,8 @@ import * as log from "@/sse/utils/logger";
 import { toJsonErrorPayload } from "@/shared/utils/upstreamError";
 import { getProviderCredentials, clearRecoveredProviderState } from "@/sse/services/auth";
 import { getProviderNodes, getComboByName, getCombos, getDatabaseSettings } from "@/lib/localDb";
+import { resolveProxyForConnection } from "@/lib/db/settings";
+import { runWithProxyContext } from "@omniroute/open-sse/utils/proxyFetch.ts";
 import { handleComboChat } from "@omniroute/open-sse/services/combo.ts";
 import { resolveBareModelToConnectionDefault } from "@omniroute/open-sse/services/model.ts";
 import { findEmbeddingComboDimensionConflict } from "./familyGuard";
@@ -220,20 +222,41 @@ export async function createEmbeddingResponse(
     connectionDefaultModel
   );
 
-  const result = await handleEmbedding({
-    body: effectiveModel !== resolvedModel ? { ...body, model: `${provider}/${effectiveModel}` } : body,
-    // getProviderCredentials returns a richer connection object; handleEmbedding
-    // only reads apiKey/accessToken, both present at runtime. Bridge the wider
-    // selection type to the handler's narrow credential shape.
-    credentials: credentials as { apiKey?: string; accessToken?: string } | null,
-    log,
-    resolvedProvider: providerConfig,
-    resolvedModel: effectiveModel,
-    clientRawRequest: options.clientRawRequest || null,
-    apiKeyId: options.apiKeyId || null,
-    apiKeyName: options.apiKeyName || null,
-    connectionId: options.connectionId || null,
-  });
+  // Resolve the connection-level proxy so the upstream embedding request honors
+  // the same per-connection pinning as chat, image generation, and count_tokens
+  // (#1904-style behavior). Without this, embeddings silently fall back to the
+  // global/env proxy and ignore a connection's pinned proxy. Ported from
+  // upstream decolua/9router#1701.
+  let proxyInfo: Awaited<ReturnType<typeof resolveProxyForConnection>> | null = null;
+  const connectionIdForProxy = (credentials as { connectionId?: string } | null)?.connectionId;
+  if (connectionIdForProxy) {
+    try {
+      proxyInfo = await resolveProxyForConnection(connectionIdForProxy);
+    } catch (err) {
+      log.error("EMBED", `Failed to resolve proxy for connection ${connectionIdForProxy}: ${err}`);
+    }
+  }
+
+  const runEmbedding = () =>
+    handleEmbedding({
+      body:
+        effectiveModel !== resolvedModel ? { ...body, model: `${provider}/${effectiveModel}` } : body,
+      // getProviderCredentials returns a richer connection object; handleEmbedding
+      // only reads apiKey/accessToken, both present at runtime. Bridge the wider
+      // selection type to the handler's narrow credential shape.
+      credentials: credentials as { apiKey?: string; accessToken?: string } | null,
+      log,
+      resolvedProvider: providerConfig,
+      resolvedModel: effectiveModel,
+      clientRawRequest: options.clientRawRequest || null,
+      apiKeyId: options.apiKeyId || null,
+      apiKeyName: options.apiKeyName || null,
+      connectionId: options.connectionId || null,
+    });
+
+  const result = connectionIdForProxy
+    ? await runWithProxyContext(proxyInfo?.proxy || null, runEmbedding)
+    : await runEmbedding();
 
   const responseHeaders = new Headers(result.headers);
 

--- a/tests/unit/account-fallback-retry-after-json.test.ts
+++ b/tests/unit/account-fallback-retry-after-json.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { parseRetryFromErrorText } = await import("../../open-sse/services/accountFallback.ts");
+
+test("parseRetryFromErrorText reads nested ISO retryAfter from a 429 JSON body", () => {
+  const futureIso = new Date(Date.now() + 120_000).toISOString();
+  const waitMs = parseRetryFromErrorText(JSON.stringify({ error: { retryAfter: futureIso } }));
+  assert.ok(waitMs !== null, "expected a parsed wait time, got null");
+  assert.ok(Math.abs((waitMs as number) - 120_000) <= 2_000, `expected ~120000ms, got ${waitMs}`);
+});
+
+test("parseRetryFromErrorText reads top-level retryAfter when nested field is absent", () => {
+  const futureIso = new Date(Date.now() + 60_000).toISOString();
+  const waitMs = parseRetryFromErrorText(JSON.stringify({ retryAfter: futureIso }));
+  assert.ok(waitMs !== null, "expected a parsed wait time, got null");
+  assert.ok(Math.abs((waitMs as number) - 60_000) <= 2_000, `expected ~60000ms, got ${waitMs}`);
+});
+
+test("parseRetryFromErrorText reads millisecond retry hints from 429 JSON bodies", () => {
+  assert.equal(parseRetryFromErrorText(JSON.stringify({ retry_after_ms: 45_000 })), 45_000);
+  assert.equal(
+    parseRetryFromErrorText(JSON.stringify({ error: { retry_after_ms: 12_000 } })),
+    12_000
+  );
+  assert.equal(parseRetryFromErrorText(JSON.stringify({ retryAfterMs: 8_000 })), 8_000);
+});
+
+test("parseRetryFromErrorText ignores past ISO retryAfter values in JSON bodies", () => {
+  const pastIso = new Date(Date.now() - 60_000).toISOString();
+  assert.equal(parseRetryFromErrorText(JSON.stringify({ error: { retryAfter: pastIso } })), null);
+});

--- a/tests/unit/embeddings-proxy-forwarding.test.ts
+++ b/tests/unit/embeddings-proxy-forwarding.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+
+// Isolate the DB to a temp dir BEFORE importing any module that opens it.
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-embed-proxy-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+const { createEmbeddingResponse } = await import("../../src/lib/embeddings/service.ts");
+const { resolveProxyForRequest } = await import("../../open-sse/utils/proxyFetch.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+async function withHttpServer(handler: http.RequestListener, fn: (baseUrl: string) => Promise<void>) {
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  try {
+    await fn(`http://127.0.0.1:${(address as { port: number }).port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+test("embeddings forward the connection-level (key) pinned proxy to the upstream fetch", async () => {
+  // T14 Proxy Fast-Fail performs a real TCP reachability check before running
+  // the request inside the proxy context, so the "proxy" must be a real,
+  // reachable local listener (its actual response body is irrelevant here —
+  // the assertion is about which proxy context the upstream fetch observes).
+  await withHttpServer(
+    (_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    },
+    async (proxyBaseUrl) => {
+      const proxyUrl = new URL(proxyBaseUrl);
+
+      const connection = await providersDb.createProviderConnection({
+        provider: "mistral",
+        authType: "apikey",
+        name: "Test Mistral Proxy",
+        apiKey: "mistral-test-key",
+      });
+
+      // Pin a proxy at the connection ("key") level — the most specific level,
+      // exactly like a user would configure per-connection in the dashboard.
+      await settingsDb.setProxyForLevel("key", (connection as any).id, {
+        type: "http",
+        host: proxyUrl.hostname,
+        port: Number(proxyUrl.port),
+      });
+
+      let capturedProxySource: string | null = null;
+      let capturedProxyUrl: string | null = null;
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = async (input: RequestInfo | URL) => {
+        const targetUrl = typeof input === "string" ? input : (input as URL).toString();
+        const resolved = resolveProxyForRequest(targetUrl);
+        capturedProxySource = resolved.source;
+        capturedProxyUrl = resolved.proxyUrl;
+        return new Response(
+          JSON.stringify({
+            data: [{ object: "embedding", embedding: [0.1, 0.2], index: 0 }],
+            usage: { prompt_tokens: 3, total_tokens: 3 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      };
+
+      try {
+        const res = await createEmbeddingResponse({
+          model: "mistral/mistral-embed",
+          input: "hello world",
+        });
+        assert.equal(res.status, 200, "embedding request should succeed");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      // The upstream fetch must have run inside the AsyncLocalStorage proxy
+      // context carrying the connection's pinned proxy — not "direct" (no
+      // context) and not the env-var proxy fallback.
+      assert.equal(
+        capturedProxySource,
+        "context",
+        `expected the embeddings upstream fetch to run inside a proxy context, got source="${capturedProxySource}"`
+      );
+      assert.ok(
+        capturedProxyUrl && capturedProxyUrl.includes(`${proxyUrl.hostname}:${proxyUrl.port}`),
+        `expected the connection's pinned proxy to be forwarded, got "${capturedProxyUrl}"`
+      );
+    }
+  );
+});


### PR DESCRIPTION
Bundled port of two small upstream diegosouzapw/OmniRoute resilience fixes into the KooshaPari fork. Both apply cleanly; disjoint file sets; each is its own commit.

## Ported PRs

- **#5974 — fix(resilience): parse Retry-After from 429 JSON body for cooldown** — new `open-sse/services/retryAfterJson.ts` extracts a `Retry-After`/reset hint from the 429 **response body** (not just headers), so providers that return the backoff hint in JSON get an accurate connection cooldown instead of the default. (thanks @diegosouzapw)
- **#5975 — fix(embeddings): forward connection-level proxy to embedding requests** — embedding requests now honor the same connection-level (per-key) proxy as chat/completions. (thanks @diegosouzapw)

## Verification

- `npm run typecheck:core` — clean.
- New unit tests pass (5): `account-fallback-retry-after-json.test.ts`, `embeddings-proxy-forwarding.test.ts`.
- No new routes, no DB/localDb changes, no child-process spawn surfaces.
