### PR TITLE
docs(env): document SUBSTRATE_HTTP_URL for MCP dispatch tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -624,6 +624,12 @@ NEXT_PUBLIC_ENABLE_SOCKS5_PROXY=true
 # Path to substrate driver binary. When unset, uses `cargo run -q -p driver-cli --`.
 # SUBSTRATE_BIN=/path/to/substrate/driver-cli
 
+# Substrate HTTP server URL for MCP dispatch tools (dispatch/plan/health).
+# Used by: open-sse/mcp-server/tools/dispatchTools.ts
+# Start substrate HTTP driver: cd repos/substrate && cargo run -p driver-http
+# Default port: 8000. Leave unset to disable MCP dispatch tools.
+# SUBSTRATE_HTTP_URL=http://localhost:8000
+
 # Model catalog sync interval in hours.
 # Used by: src/shared/services/modelSyncScheduler.ts — periodic model refresh.
 # Default: 24


### PR DESCRIPTION
Completes Task #20. `open-sse/mcp-server/tools/dispatchTools.ts` already reads `process.env.SUBSTRATE_HTTP_URL` (dispatch/plan/health tools); this documents the required env in `.env.example` so operators can enable the Substrate MCP dispatch bridge.

- Start driver: `cd repos/substrate && cargo run -p driver-http` (default port 8000)
- Leave unset to keep the 3 dispatch tools disabled (clear error path already present).