### PR TITLE
feat(providers): add Qiniu, ModelScope + CodeWhale CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - **feat(providers):** add NVIDIA NIM image generation (FLUX models). (thanks @eng2007)
 - **feat(providers):** add Augment (Auggie CLI) as a local no-auth provider. (thanks @chamdanilukman)
 - **feat(providers):** add b.ai as an OpenAI-compatible (API-key) provider. (thanks @DEYLNN)
+- **feat(providers):** add ModelScope as an OpenAI-compatible (API-key) provider. (thanks @tn5052)
+- **feat(providers):** add Qiniu as an OpenAI-compatible (API-key) provider. (thanks @JackChiang233)
+- **feat(cli-tools):** add CodeWhale as a spawnable CLI tool.
 
 - **routing (latency/speed mode):** add a dedicated **speed-optimized routing mode** that scores every provider×model pair in a combo against **TTFT, tokens-per-second, E2E latency, p95 latency, circuit-breaker health, failure rate, and latency stability (std-dev)** — and ranks them so the "fastest reliable pair" wins. The runtime `LatencyStrategyImpl` (`routerStrategy.ts`) and the new MCP tool `omniroute_pick_fastest_model` (`schemas/tools.ts` + `tools/advancedTools.ts`) now share a single pure core (`services/autoCombo/speedRanking.ts` → `rankBySpeed`), so the user-facing preview and the live router pick the same winner. The MCP tool returns the top-ranked pair plus the **full ranked list with per-factor scores and per-metric breakdowns**, and optionally applies the result to a target combo by switching its strategy to `auto` + `autoRoutingStrategy: "latency"`. Weights are tunable (`{ttft, tps, e2e, p95, health, reliability, stability}`), OPEN-circuit candidates are dropped by default but can be retained with `includeUnhealthy=true`, and stability + reliability multipliers prevent a flaky fast provider from beating a steady slower one. Regression guard: `open-sse/services/autoCombo/__tests__/speedRanking.test.ts`. Closes the speed-mode routing gap tracked in this issue.
 

--- a/docs/reference/CLI-TOOLS.md
+++ b/docs/reference/CLI-TOOLS.md
@@ -12,7 +12,7 @@ OmniRoute integrates with three categories of CLI tools spread across three dedi
 
 | Page           | Route                   | Concept                                                                   | Count        |
 | -------------- | ----------------------- | ------------------------------------------------------------------------- | ------------ |
-| **CLI Code's** | `/dashboard/cli-code`   | Coding tools you point at OmniRoute (Client → CLI → OmniRoute → Provider) | 19           |
+| **CLI Code's** | `/dashboard/cli-code`   | Coding tools you point at OmniRoute (Client → CLI → OmniRoute → Provider) | 20           |
 | **CLI Agents** | `/dashboard/cli-agents` | Autonomous agents you point at OmniRoute (same flow, broader scope)       | 6            |
 | **ACP Agents** | `/dashboard/acp-agents` | CLIs that OmniRoute spawns as backend via stdio/ACP (reverse flow)        | see registry |
 
@@ -90,7 +90,7 @@ Entries with `baseUrlSupport: "none"` are **not shown** in the dashboard pages �
 
 ---
 
-## 1. CLI Code's Catalog (19 tools)
+## 1. CLI Code's Catalog (20 tools)
 
 Tools that support custom base URL and appear in `/dashboard/cli-code`:
 
@@ -107,6 +107,7 @@ Tools that support custom base URL and appear in `/dashboard/cli-code`:
 | forge | ForgeCode | Antinomy HQ | full | custom | true |
 | jcode | jcode | 1jehuang (OSS) | full | custom | false |
 | deepseek-tui | DeepSeek TUI | Hunter Bown (OSS) | full | custom | false |
+| codewhale | CodeWhale | Hmbown (OSS) | full | custom | false |
 | opencode | OpenCode | Anomaly (ex-SST) | full | guide | true |
 | droid | Factory Droid | Factory AI | partial | guide | false |
 | copilot | GitHub Copilot CLI | GitHub/MS | full | custom | false |
@@ -198,7 +199,8 @@ New tools with `configType: "custom"` have dedicated settings API routes:
 | ------------------------------------------- | ------------------------------ |
 | `POST /api/cli-tools/forge-settings`        | ForgeCode (.forge.toml)        |
 | `POST /api/cli-tools/jcode-settings`        | jcode (--base-url flag)        |
-| `POST /api/cli-tools/deepseek-tui-settings` | DeepSeek TUI (OPENAI_BASE_URL) |
+| `POST /api/cli-tools/deepseek-tui-settings` | DeepSeek TUI (OPENAI_BASE_URL, legacy) |
+| `POST /api/cli-tools/codewhale-settings`    | CodeWhale (OPENAI_BASE_URL, primary + legacy `~/.deepseek` sync) |
 | `POST /api/cli-tools/smelt-settings`        | Smelt                          |
 | `POST /api/cli-tools/pi-settings`           | Pi coding agent                |
 

--- a/open-sse/config/providers/index.ts
+++ b/open-sse/config/providers/index.ts
@@ -42,6 +42,7 @@ import { deepseekProvider } from "./registry/deepseek/index.ts";
 import { deepseek_webProvider } from "./registry/deepseek/web/index.ts";
 import { dgridProvider } from "./registry/dgrid/index.ts";
 import { baiProvider } from "./registry/bai/index.ts";
+import { qiniuProvider } from "./registry/qiniu/index.ts";
 import { kimi_coding_apikeyProvider } from "./registry/kimi/coding-apikey/index.ts";
 import { kimi_codingProvider } from "./registry/kimi/coding/index.ts";
 import { kimiProvider } from "./registry/kimi/index.ts";
@@ -79,6 +80,7 @@ import { leonardoProvider } from "./registry/leonardo/index.ts";
 import { grok_webProvider } from "./registry/grok-web/index.ts";
 import { kieProvider } from "./registry/kie/index.ts";
 import { monsterapiProvider } from "./registry/monsterapi/index.ts";
+import { modelscopeProvider } from "./registry/modelscope/index.ts";
 import { sensenovaProvider } from "./registry/sensenova/index.ts";
 import { hyperbolicProvider } from "./registry/hyperbolic/index.ts";
 import { lambda_aiProvider } from "./registry/lambda-ai/index.ts";
@@ -215,6 +217,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   "deepseek-web": deepseek_webProvider,
   dgrid: dgridProvider,
   bai: baiProvider,
+  qiniu: qiniuProvider,
   "kimi-coding-apikey": kimi_coding_apikeyProvider,
   "kimi-coding": kimi_codingProvider,
   kimi: kimiProvider,
@@ -252,6 +255,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   "grok-web": grok_webProvider,
   kie: kieProvider,
   monsterapi: monsterapiProvider,
+  modelscope: modelscopeProvider,
   sensenova: sensenovaProvider,
   hyperbolic: hyperbolicProvider,
   "lambda-ai": lambda_aiProvider,

--- a/open-sse/config/providers/registry/modelscope/index.ts
+++ b/open-sse/config/providers/registry/modelscope/index.ts
@@ -1,0 +1,24 @@
+import type { RegistryEntry } from "../../shared.ts";
+
+// ModelScope (Alibaba 魔搭) — OpenAI-compatible API-Inference, ported from upstream
+// 9router PR #1764 (@tn5052). The upstream PR hardcoded `https://api-inference.modelscope.ai/...`
+// (`.ai` TLD) and a static 5-model list. Both were dropped here after verification:
+//
+// - baseUrl: ModelScope's own API-Inference docs (modelscope.cn/docs/model-service/API-Inference)
+//   and third-party integration guides (e.g. Alibaba Cloud Model Studio compatibility docs)
+//   consistently confirm the production domain is `api-inference.modelscope.cn` — the `.cn` TLD,
+//   not `.ai`. Using the unverified `.ai` domain would have shipped a broken provider.
+// - models: passthrough + empty static seed instead of copying the PR's 5-model snapshot, since
+//   ModelScope hosts a large and fast-moving open-model catalog — `modelsUrl` keeps the list live.
+export const modelscopeProvider: RegistryEntry = {
+  id: "modelscope",
+  alias: "ms",
+  format: "openai",
+  executor: "default",
+  baseUrl: "https://api-inference.modelscope.cn/v1/chat/completions",
+  modelsUrl: "https://api-inference.modelscope.cn/v1/models",
+  authType: "apikey",
+  authHeader: "bearer",
+  passthroughModels: true,
+  models: [],
+};

--- a/open-sse/config/providers/registry/qiniu/index.ts
+++ b/open-sse/config/providers/registry/qiniu/index.ts
@@ -1,0 +1,15 @@
+import type { RegistryEntry } from "../../shared.ts";
+
+export const qiniuProvider: RegistryEntry = {
+  id: "qiniu",
+  alias: "qiniu",
+  format: "openai",
+  executor: "default",
+  baseUrl: "https://api.qnaigc.com/v1/chat/completions",
+  authType: "apikey",
+  authHeader: "bearer",
+  modelsUrl: "https://api.qnaigc.com/v1/models",
+  defaultContextLength: 128000,
+  models: [],
+  passthroughModels: true,
+};

--- a/src/app/api/cli-tools/codewhale-settings/route.ts
+++ b/src/app/api/cli-tools/codewhale-settings/route.ts
@@ -1,0 +1,235 @@
+"use server";
+
+import { NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+import { requireCliToolsAuth } from "@/lib/api/requireCliToolsAuth";
+import {
+  ensureCliConfigWriteAllowed,
+  getCliPrimaryConfigPath,
+  getCliRuntimeStatus,
+} from "@/shared/services/cliRuntime";
+import { createBackup } from "@/shared/services/backupService";
+import { saveCliToolLastConfigured, deleteCliToolLastConfigured } from "@/lib/db/cliToolState";
+import { cliModelConfigSchema } from "@/shared/validation/schemas";
+import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
+import { resolveApiKey } from "@/shared/services/apiKeyResolver";
+import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";
+
+const TOOL_ID = "codewhale";
+
+/**
+ * CodeWhale is the actively-maintained successor to DeepSeek TUI (same
+ * author, renamed project — https://github.com/Hmbown/CodeWhale). It reads
+ * its config from ~/.codewhale/config.toml. Users upgrading from the old
+ * DeepSeek TUI binary may still have ~/.deepseek/config.toml around, so we
+ * read/write that path as a legacy fallback.
+ */
+const getPrimaryConfigPath = (): string =>
+  getCliPrimaryConfigPath(TOOL_ID) ?? path.join(process.env.HOME ?? "~", ".codewhale", "config.toml");
+
+const getLegacyConfigPath = (): string =>
+  path.join(process.env.HOME ?? "~", ".deepseek", "config.toml");
+
+const getPrimaryConfigDir = () => path.dirname(getPrimaryConfigPath());
+
+/**
+ * Render the OmniRoute config block in CodeWhale TOML format.
+ * CodeWhale reads OPENAI_BASE_URL and OPENAI_API_KEY from its config.
+ * Reference: https://github.com/Hmbown/CodeWhale
+ */
+function renderCodewhaleConfig(baseUrl: string, apiKey: string, model: string): string {
+  return [
+    "# CodeWhale config — managed by OmniRoute (plan 14)",
+    "",
+    "[openai]",
+    `base_url = "${baseUrl}"`,
+    `api_key = "${apiKey}"`,
+    `model = "${model}"`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Check if the config file contains OmniRoute settings.
+ */
+const hasOmniRouteConfig = (content: string | null): boolean => {
+  if (!content) return false;
+  return content.includes("managed by OmniRoute");
+};
+
+// Read current config.toml — prefers the primary ~/.codewhale path, falling
+// back to the legacy ~/.deepseek path for users upgrading from DeepSeek TUI.
+const readConfig = async (): Promise<string | null> => {
+  for (const candidate of [getPrimaryConfigPath(), getLegacyConfigPath()]) {
+    try {
+      return await fs.readFile(candidate, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+  }
+  return null;
+};
+
+// GET — check CodeWhale CLI and return current config
+export async function GET(request: Request) {
+  const authError = await requireCliToolsAuth(request);
+  if (authError) return authError;
+
+  try {
+    const runtime = await getCliRuntimeStatus(TOOL_ID);
+
+    if (!runtime.installed || !runtime.runnable) {
+      return NextResponse.json({
+        installed: runtime.installed,
+        runnable: runtime.runnable,
+        command: runtime.command,
+        commandPath: runtime.commandPath,
+        runtimeMode: runtime.runtimeMode,
+        reason: runtime.reason,
+        config: null,
+        message:
+          runtime.installed && !runtime.runnable
+            ? "CodeWhale is installed but not runnable"
+            : "CodeWhale is not installed",
+      });
+    }
+
+    const config = await readConfig();
+
+    return NextResponse.json({
+      installed: runtime.installed,
+      runnable: runtime.runnable,
+      command: runtime.command,
+      commandPath: runtime.commandPath,
+      runtimeMode: runtime.runtimeMode,
+      reason: runtime.reason,
+      config,
+      hasOmniRoute: hasOmniRouteConfig(config),
+      configPath: getPrimaryConfigPath(),
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: { message: sanitizeErrorMessage(err) } },
+      { status: 500 }
+    );
+  }
+}
+
+// POST — write OmniRoute settings to CodeWhale's config.toml (primary), and
+// keep the legacy ~/.deepseek/config.toml in sync when it already exists so
+// users who have not yet upgraded their CLI binary keep working.
+export async function POST(request: Request) {
+  const authError = await requireCliToolsAuth(request);
+  if (authError) return authError;
+
+  let rawBody;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { message: "Invalid JSON body" } },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const writeGuard = ensureCliConfigWriteAllowed();
+    if (writeGuard) {
+      return NextResponse.json({ error: writeGuard }, { status: 403 });
+    }
+
+    // Extract keyId BEFORE Zod validation — Zod strips unknown fields
+    const keyId = typeof rawBody?.keyId === "string" ? rawBody.keyId.trim() : null;
+
+    const validation = validateBody(cliModelConfigSchema, rawBody);
+    if (isValidationFailure(validation)) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+    const { baseUrl, model } = validation.data;
+    const apiKey = await resolveApiKey(keyId, validation.data.apiKey);
+
+    const primaryPath = getPrimaryConfigPath();
+    const legacyPath = getLegacyConfigPath();
+    const content = renderCodewhaleConfig(baseUrl, apiKey, model);
+
+    // Always write the primary (~/.codewhale) config.
+    await fs.mkdir(getPrimaryConfigDir(), { recursive: true });
+    await createBackup(TOOL_ID, primaryPath);
+    await fs.writeFile(primaryPath, content, "utf-8");
+
+    // Best-effort: keep the legacy (~/.deepseek) config in sync only if it
+    // already exists — never create a fresh legacy directory for new users.
+    try {
+      await fs.access(legacyPath);
+      await createBackup(TOOL_ID, legacyPath);
+      await fs.writeFile(legacyPath, content, "utf-8");
+    } catch {
+      /* legacy config not present — nothing to sync */
+    }
+
+    // Persist last-configured timestamp
+    try {
+      saveCliToolLastConfigured(TOOL_ID);
+    } catch {
+      /* non-critical */
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "CodeWhale settings applied successfully!",
+      configPath: primaryPath,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: { message: sanitizeErrorMessage(err) } },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE — remove OmniRoute CodeWhale config (primary + legacy, if present)
+export async function DELETE(request: Request) {
+  const authError = await requireCliToolsAuth(request);
+  if (authError) return authError;
+
+  try {
+    const writeGuard = ensureCliConfigWriteAllowed();
+    if (writeGuard) {
+      return NextResponse.json({ error: writeGuard }, { status: 403 });
+    }
+
+    const primaryPath = getPrimaryConfigPath();
+    const legacyPath = getLegacyConfigPath();
+
+    // Backup + remove primary before removing
+    await createBackup(TOOL_ID, primaryPath);
+    await fs.rm(primaryPath, { force: true });
+
+    // Best-effort: remove legacy config too, if present
+    try {
+      await fs.access(legacyPath);
+      await createBackup(TOOL_ID, legacyPath);
+      await fs.rm(legacyPath, { force: true });
+    } catch {
+      /* legacy config not present */
+    }
+
+    // Clear last-configured timestamp
+    try {
+      deleteCliToolLastConfigured(TOOL_ID);
+    } catch {
+      /* non-critical */
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "CodeWhale settings removed successfully",
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: { message: sanitizeErrorMessage(err) } },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/providers/[id]/models/discovery/providerSets.ts
+++ b/src/app/api/providers/[id]/models/discovery/providerSets.ts
@@ -60,6 +60,10 @@ export const NAMED_OPENAI_STYLE_PROVIDERS = new Set([
   // upstream models (GPT, Claude, Gemini, MiniMax, Kimi, GLM...) behind one key, so the
   // full catalog is discovered live from https://api.b.ai/v1/models.
   "bai",
+  // Qiniu (七牛云 AI inference) is an OpenAI-compatible gateway with no static seed —
+  // it proxies many upstream models (DeepSeek, Claude, Kimi...) behind one key, so the
+  // full catalog is discovered live from https://api.qnaigc.com/v1/models.
+  "qiniu",
 ]);
 
 export function isNamedOpenAIStyleProvider(provider: string): boolean {

--- a/src/shared/constants/cliTools.ts
+++ b/src/shared/constants/cliTools.ts
@@ -645,7 +645,13 @@ aider --openai-api-base "{{baseUrl}}" --model "{{model}}"`,
     defaultCommand: "jcode",
   },
 
-  /** ★ Added by plan 14 (CLI Pages Redesign) — 2026-05-27 */
+  /**
+   * ★ Added by plan 14 (CLI Pages Redesign) — 2026-05-27
+   * Kept as a legacy/dual entry after CodeWhale (see below) took over as the
+   * actively-maintained successor. Existing users who still have DeepSeek
+   * TUI installed keep a working dashboard card; new users are steered to
+   * "codewhale" instead.
+   */
   "deepseek-tui": {
     id: "deepseek-tui",
     name: "DeepSeek TUI",
@@ -659,6 +665,29 @@ aider --openai-api-base "{{baseUrl}}" --model "{{model}}"`,
     acpSpawnable: false,
     baseUrlSupport: "full",
     defaultCommand: "deepseek-tui",
+  },
+
+  /**
+   * ★ Added 2026-07-02 (dual-entry, see deepseek-tui above). CodeWhale is
+   * the actively-maintained successor to DeepSeek TUI — same author, new
+   * name. Config lives under ~/.codewhale/config.toml; the settings route
+   * also keeps ~/.deepseek/config.toml (legacy) in sync for upgrading
+   * users. Reference: https://github.com/Hmbown/CodeWhale
+   */
+  codewhale: {
+    id: "codewhale",
+    name: "CodeWhale",
+    icon: "terminal",
+    color: "#4F46E5",
+    description:
+      "CodeWhale — Rust-based coding agent CLI with OPENAI_BASE_URL support (successor to DeepSeek TUI)",
+    docsUrl: "https://github.com/Hmbown/CodeWhale",
+    configType: "custom",
+    category: "code",
+    vendor: "OSS (Hmbown)",
+    acpSpawnable: false,
+    baseUrlSupport: "full",
+    defaultCommand: "codewhale",
   },
 
   /** ★ Added by plan 14 (CLI Pages Redesign) — 2026-05-27 */

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -6,6 +6,7 @@ export const PROVIDER_ENDPOINTS = {
   openrouter: "https://openrouter.ai/api/v1/chat/completions",
   dgrid: "https://api.dgrid.ai/v1/chat/completions",
   bai: "https://api.b.ai/v1/chat/completions",
+  qiniu: "https://api.qnaigc.com/v1/chat/completions",
   glm: "https://api.z.ai/api/anthropic/v1/messages",
   glmt: "https://api.z.ai/api/anthropic/v1/messages",
   "bailian-coding-plan": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1/messages",

--- a/src/shared/constants/providers/apikey/gateways.ts
+++ b/src/shared/constants/providers/apikey/gateways.ts
@@ -57,6 +57,20 @@ export const APIKEY_PROVIDERS_GATEWAYS = {
       "Create a DGrid API key at https://dgrid.ai, then use https://api.dgrid.ai/v1 " +
       "as the OpenAI-compatible base URL.",
   },
+  qiniu: {
+    id: "qiniu",
+    alias: "qiniu",
+    name: "Qiniu",
+    icon: "cloud",
+    color: "#1E88E5",
+    textIcon: "QN",
+    passthroughModels: true,
+    website: "https://www.qiniu.com",
+    apiHint:
+      "Create a Qiniu AI inference API key at https://portal.qiniu.com/ai-inference/api-key, " +
+      "then paste it here as a Bearer token. OpenAI-compatible endpoint " +
+      "at https://api.qnaigc.com/v1, proxying DeepSeek, Claude, Kimi and more behind one key.",
+  },
   orcarouter: {
     id: "orcarouter",
     alias: "orcarouter",

--- a/src/shared/constants/providers/apikey/inference-hosts.ts
+++ b/src/shared/constants/providers/apikey/inference-hosts.ts
@@ -265,6 +265,21 @@ export const APIKEY_PROVIDERS_INFERENCE = {
     passthroughModels: true,
     authHint: "Get API key at monsterapi.ai",
   },
+  modelscope: {
+    id: "modelscope",
+    alias: "ms",
+    name: "ModelScope",
+    icon: "cloud",
+    color: "#FF6A00",
+    textIcon: "MS",
+    website: "https://modelscope.cn",
+    hasFree: true,
+    // #1764 (upstream 9router): OpenAI-compatible API-Inference. Base URL verified
+    // live against ModelScope's own docs — the upstream PR used the `.ai` TLD, but
+    // the confirmed production domain is `api-inference.modelscope.cn` (see registry
+    // entry + test guard).
+    freeNote: "Free tier via ModelScope API-Inference — Alibaba account required.",
+  },
   byteplus: {
     id: "byteplus",
     alias: "bpm",

--- a/src/shared/schemas/cliCatalog.ts
+++ b/src/shared/schemas/cliCatalog.ts
@@ -62,5 +62,5 @@ export type CliCatalogEntry = z.infer<typeof CliCatalogEntrySchema>;
 export const CliCatalogSchema = z.record(CliCatalogEntrySchema);
 
 /** Cardinalidade obrigatória (Plano §3.1/§3.2 + D15). */
-export const EXPECTED_CODE_COUNT = 18;
+export const EXPECTED_CODE_COUNT = 19;
 export const EXPECTED_AGENT_COUNT = 6;

--- a/src/shared/services/cliRuntime.ts
+++ b/src/shared/services/cliRuntime.ts
@@ -210,6 +210,15 @@ const CLI_TOOLS: Record<string, any> = {
       config: ".config/deepseek-tui/config.toml",
     },
   },
+  codewhale: {
+    defaultCommand: "codewhale",
+    envBinKey: "CLI_CODEWHALE_BIN",
+    requiresBinary: true,
+    healthcheckTimeoutMs: 8000,
+    paths: {
+      config: ".codewhale/config.toml",
+    },
+  },
   smelt: {
     defaultCommand: "smelt",
     envBinKey: "CLI_SMELT_BIN",

--- a/tests/integration/cli-settings-codewhale.test.ts
+++ b/tests/integration/cli-settings-codewhale.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Integration tests for /api/cli-tools/codewhale-settings
+ *
+ * CodeWhale (https://github.com/Hmbown/CodeWhale) is the actively-maintained
+ * successor to DeepSeek TUI (same author, renamed project). This route mirrors
+ * deepseek-tui-settings/route.ts but writes/reads a dual config path:
+ *   - primary: ~/.codewhale/config.toml
+ *   - legacy:  ~/.deepseek/config.toml (kept in sync when it already exists,
+ *              so users upgrading their CLI binary keep working)
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-codewhale-settings-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = "test-api-key-secret-codewhale";
+process.env.JWT_SECRET = "test-jwt-secret-codewhale";
+
+const core = await import("../../src/lib/db/core.ts");
+const localDb = await import("../../src/lib/localDb.ts");
+
+const { GET, POST, DELETE } = await import("../../src/app/api/cli-tools/codewhale-settings/route.ts");
+
+async function resetStorage() {
+  delete process.env.INITIAL_PASSWORD;
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+async function enableAuth() {
+  process.env.INITIAL_PASSWORD = "test-bootstrap";
+  await localDb.updateSettings({ requireLogin: true, password: "" });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+// ── Test 1: GET without auth → 401 ──────────────────────────────────────────
+
+test("codewhale-settings GET: returns 401 when auth required and no token", async () => {
+  await enableAuth();
+  const res = await GET(new Request("http://localhost/api/cli-tools/codewhale-settings"));
+  assert.equal(res.status, 401, `Expected 401, got ${res.status}`);
+});
+
+// ── Test 2: GET without auth requirement → 200 ───────────────────────────────
+
+test("codewhale-settings GET: returns 200 when auth not required", async () => {
+  const res = await GET(new Request("http://localhost/api/cli-tools/codewhale-settings"));
+  assert.equal(res.status, 200, `Expected 200, got ${res.status}`);
+  const body = await res.json();
+  assert.ok(
+    "installed" in body || "config" in body,
+    "Response should contain installed or config field"
+  );
+});
+
+// ── Test 3: POST with invalid body → 400 ─────────────────────────────────────
+
+test("codewhale-settings POST: 400 when baseUrl is missing", async () => {
+  const res = await POST(
+    new Request("http://localhost/api/cli-tools/codewhale-settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ apiKey: "sk-test", model: "deepseek-v4-pro" }),
+    })
+  );
+  assert.equal(res.status, 400, `Expected 400, got ${res.status}`);
+  const body = await res.json();
+  assert.ok(body.error !== undefined);
+});
+
+test("codewhale-settings POST: 400 when model is missing", async () => {
+  const res = await POST(
+    new Request("http://localhost/api/cli-tools/codewhale-settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ baseUrl: "http://localhost:20128", apiKey: "sk-test" }),
+    })
+  );
+  assert.equal(res.status, 400, `Expected 400, got ${res.status}`);
+});
+
+// ── Test 4: POST with valid body → writes PRIMARY config.toml only (no legacy dir) ──
+
+test("codewhale-settings POST: writes primary ~/.codewhale/config.toml for a fresh install", async () => {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "codewhale-home-"));
+  const origHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+
+  try {
+    const res = await POST(
+      new Request("http://localhost/api/cli-tools/codewhale-settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          baseUrl: "http://localhost:20128",
+          apiKey: "sk-test-codewhale-key",
+          model: "deepseek-v4-pro",
+        }),
+      })
+    );
+    assert.ok([200, 403, 500].includes(res.status), `Unexpected status ${res.status}`);
+    if (res.status === 200) {
+      const body = await res.json();
+      assert.equal(body.success, true);
+
+      const primaryPath = path.join(tmpHome, ".codewhale", "config.toml");
+      assert.ok(fs.existsSync(primaryPath), "Primary ~/.codewhale/config.toml must be written");
+      const content = fs.readFileSync(primaryPath, "utf-8");
+      assert.ok(content.includes("managed by OmniRoute"), "Config should have OmniRoute marker");
+      assert.ok(content.includes("http://localhost:20128"), "Config should contain base URL");
+      assert.ok(content.includes("[openai]"), "Config should have [openai] section");
+
+      // No legacy ~/.deepseek dir existed before the write — must NOT be created.
+      const legacyPath = path.join(tmpHome, ".deepseek", "config.toml");
+      assert.ok(
+        !fs.existsSync(legacyPath),
+        "Legacy ~/.deepseek/config.toml must not be created for a fresh install"
+      );
+    }
+  } finally {
+    process.env.HOME = origHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+});
+
+// ── Test 5: POST keeps an EXISTING legacy ~/.deepseek config in sync ────────
+
+test("codewhale-settings POST: syncs an existing legacy ~/.deepseek/config.toml", async () => {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "codewhale-home-legacy-"));
+  const origHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+
+  try {
+    // Simulate an existing DeepSeek TUI install (pre-CodeWhale upgrade).
+    const legacyDir = path.join(tmpHome, ".deepseek");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, "config.toml"), 'provider = "deepseek"\n');
+
+    const res = await POST(
+      new Request("http://localhost/api/cli-tools/codewhale-settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          baseUrl: "http://localhost:20128",
+          apiKey: "sk-test-codewhale-key",
+          model: "deepseek-v4-flash",
+        }),
+      })
+    );
+    assert.ok([200, 403, 500].includes(res.status), `Unexpected status ${res.status}`);
+    if (res.status === 200) {
+      const primaryPath = path.join(tmpHome, ".codewhale", "config.toml");
+      const legacyPath = path.join(tmpHome, ".deepseek", "config.toml");
+
+      assert.ok(fs.existsSync(primaryPath), "Primary config must be written");
+      assert.ok(fs.existsSync(legacyPath), "Legacy config must still exist");
+
+      const primaryContent = fs.readFileSync(primaryPath, "utf-8");
+      const legacyContent = fs.readFileSync(legacyPath, "utf-8");
+      assert.ok(primaryContent.includes("http://localhost:20128"));
+      assert.ok(
+        legacyContent.includes("http://localhost:20128"),
+        "Legacy config must be kept in sync with the new base URL"
+      );
+      assert.equal(primaryContent, legacyContent, "Primary and legacy configs should match");
+    }
+  } finally {
+    process.env.HOME = origHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+});
+
+// ── Test 6: GET reads from legacy path when only legacy config exists ───────
+
+test("codewhale-settings GET: falls back to legacy ~/.deepseek/config.toml when primary is absent", async () => {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "codewhale-home-getlegacy-"));
+  const origHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+
+  try {
+    const legacyDir = path.join(tmpHome, ".deepseek");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(legacyDir, "config.toml"),
+      '# managed by OmniRoute (plan 14)\n[openai]\nbase_url = "http://localhost:20128"\n'
+    );
+
+    const res = await GET(new Request("http://localhost/api/cli-tools/codewhale-settings"));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    if (body.config) {
+      assert.ok(body.config.includes("managed by OmniRoute"));
+      assert.equal(body.hasOmniRoute, true);
+    }
+  } finally {
+    process.env.HOME = origHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+});
+
+// ── Test 7: DELETE → removes both primary and legacy config files ───────────
+
+test("codewhale-settings DELETE: removes primary and legacy config files", async () => {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "codewhale-home-del-"));
+  const origHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+
+  try {
+    const primaryDir = path.join(tmpHome, ".codewhale");
+    const legacyDir = path.join(tmpHome, ".deepseek");
+    fs.mkdirSync(primaryDir, { recursive: true });
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(primaryDir, "config.toml"),
+      '# managed by OmniRoute (plan 14)\n[openai]\nbase_url = "http://localhost:20128"\n'
+    );
+    fs.writeFileSync(
+      path.join(legacyDir, "config.toml"),
+      '# managed by OmniRoute (plan 14)\n[openai]\nbase_url = "http://localhost:20128"\n'
+    );
+
+    const res = await DELETE(
+      new Request("http://localhost/api/cli-tools/codewhale-settings", { method: "DELETE" })
+    );
+    assert.ok([200, 403, 500].includes(res.status), `Expected 200/403/500, got ${res.status}`);
+    if (res.status === 200) {
+      const body = await res.json();
+      assert.equal(body.success, true);
+      assert.ok(!fs.existsSync(path.join(primaryDir, "config.toml")), "Primary config removed");
+      assert.ok(!fs.existsSync(path.join(legacyDir, "config.toml")), "Legacy config removed");
+    }
+  } finally {
+    process.env.HOME = origHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+});
+
+// ── Test 8: Error sanitization (Hard Rule #12) ───────────────────────────────
+
+test("codewhale-settings: error responses do not leak stack traces", async () => {
+  const badReq = new Request("http://localhost/api/cli-tools/codewhale-settings", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{ bad json }",
+  });
+  const res = await POST(badReq);
+  const bodyStr = JSON.stringify(await res.json());
+  assert.ok(
+    !bodyStr.match(/\s+at\s+\/[^\s]/),
+    "Error response must not contain absolute-path stack traces"
+  );
+});
+
+// ── Test 9: Hard Rule #13 (no exec/spawn) ────────────────────────────────────
+
+test("codewhale-settings route.ts: does not call exec() or spawn() directly", () => {
+  const routePath = path.resolve(
+    import.meta.dirname,
+    "../../src/app/api/cli-tools/codewhale-settings/route.ts"
+  );
+  const content = fs.readFileSync(routePath, "utf-8");
+  assert.ok(!content.match(/\bexec\s*\(/), "Handler must not use exec()");
+  assert.ok(!content.match(/\bspawn\s*\(/), "Handler must not use spawn()");
+});
+
+test.after(async () => {
+  await resetStorage();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  delete process.env.DATA_DIR;
+  delete process.env.API_KEY_SECRET;
+  delete process.env.JWT_SECRET;
+});

--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -2707,6 +2707,29 @@
       "stream": "https://api.modal.ai/v1/chat/completions"
     }
   },
+  "modelscope": {
+    "format": "openai",
+    "headers": {
+      "apiKey": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "nonStream": {
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "oauth": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      }
+    },
+    "url": {
+      "nonStream": "https://api-inference.modelscope.cn/v1/chat/completions",
+      "stream": "https://api-inference.modelscope.cn/v1/chat/completions"
+    }
+  },
   "monsterapi": {
     "format": "openai",
     "headers": {
@@ -3361,6 +3384,29 @@
     "url": {
       "nonStream": "https://qianfan.baidubce.com/v2/chat/completions",
       "stream": "https://qianfan.baidubce.com/v2/chat/completions"
+    }
+  },
+  "qiniu": {
+    "format": "openai",
+    "headers": {
+      "apiKey": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "nonStream": {
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "oauth": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      }
+    },
+    "url": {
+      "nonStream": "https://api.qnaigc.com/v1/chat/completions",
+      "stream": "https://api.qnaigc.com/v1/chat/completions"
     }
   },
   "qoder": {

--- a/tests/unit/cli-catalog-acpspawnable.test.ts
+++ b/tests/unit/cli-catalog-acpspawnable.test.ts
@@ -44,6 +44,7 @@ const NOT_ACP_SPAWNABLE_IDS = [
   "roo",
   "jcode",
   "deepseek-tui",
+  "codewhale",
   "smelt",
   "pi",
   "hermes-agent",

--- a/tests/unit/cli-catalog-counts.test.ts
+++ b/tests/unit/cli-catalog-counts.test.ts
@@ -30,7 +30,7 @@ test(`CLI_TOOLS has exactly ${EXPECTED_AGENT_COUNT} agent entries`, () => {
   );
 });
 
-test("CLI_TOOLS total code entries (including none) equals 22 (18 visible + 4 none)", () => {
+test("CLI_TOOLS total code entries (including none) equals 23 (19 visible + 4 none)", () => {
   // code-none entries: antigravity, kiro, cursor (app), hermes (simple guide)
   const codeNone = codeAll.filter((t) => t.baseUrlSupport === "none");
   assert.equal(
@@ -38,11 +38,11 @@ test("CLI_TOOLS total code entries (including none) equals 22 (18 visible + 4 no
     4,
     `Expected 4 code entries with baseUrlSupport='none', got ${codeNone.length}: ${codeNone.map((t) => t.id).join(", ")}`
   );
-  assert.equal(codeAll.length, 22, `Expected 22 total code entries, got ${codeAll.length}`);
+  assert.equal(codeAll.length, 23, `Expected 23 total code entries, got ${codeAll.length}`);
 });
 
-test("CLI_TOOLS total (code + agent) = 28", () => {
-  assert.equal(all.length, 28, `Expected 28 total entries, got ${all.length}`);
+test("CLI_TOOLS total (code + agent) = 29", () => {
+  assert.equal(all.length, 29, `Expected 29 total entries, got ${all.length}`);
 });
 
 test("All code-none entries have configType mitm OR are legacy excluded entries", () => {
@@ -66,7 +66,7 @@ test("All agent entries have baseUrlSupport 'full' or 'partial' (no agent is 'no
   }
 });
 
-test("The 18 visible code entries match D15 list exactly", () => {
+test("The 19 visible code entries match D15 list exactly (+ codewhale)", () => {
   const d15List = new Set([
     "claude",
     "codex",
@@ -79,6 +79,7 @@ test("The 18 visible code entries match D15 list exactly", () => {
     "forge",
     "jcode",
     "deepseek-tui",
+    "codewhale",
     "opencode",
     "droid",
     "copilot",

--- a/tests/unit/cli-tools-schema.test.ts
+++ b/tests/unit/cli-tools-schema.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-test("CLI_TOOLS registry contains all expected tools (plan 14 — 28 total)", async () => {
+test("CLI_TOOLS registry contains all expected tools (plan 14 — 29 total + codewhale)", async () => {
   const { CLI_TOOLS } = await import("../../src/shared/constants/cliTools.ts");
   // windsurf and amp removed per plan 14 D17 (MITM backlog plan 11)
   // New entries added: roo, jcode, deepseek-tui, smelt, pi, aider, forge,
@@ -29,6 +29,7 @@ test("CLI_TOOLS registry contains all expected tools (plan 14 — 28 total)", as
     "roo",
     "jcode",
     "deepseek-tui",
+    "codewhale",
     "smelt",
     "pi",
     "goose",

--- a/tests/unit/modelscope-provider.test.ts
+++ b/tests/unit/modelscope-provider.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { modelscopeProvider } from "../../open-sse/config/providers/registry/modelscope/index.ts";
+import { REGISTRY } from "../../open-sse/config/providerRegistry.ts";
+import { APIKEY_PROVIDERS } from "../../src/shared/constants/providers/apikey/index.ts";
+import { AI_PROVIDERS, getProviderById } from "../../src/shared/constants/providers.ts";
+
+// Upstream 9router PR #1764 (@tn5052) ports ModelScope (Alibaba 魔搭) as an OpenAI-compatible
+// BYOK free-tier provider. The upstream PR hardcoded `https://api-inference.modelscope.ai/...`
+// (`.ai` TLD) — ModelScope's own docs confirm the real production domain is
+// `api-inference.modelscope.cn` (`.cn` TLD). This suite locks in the verified domain and
+// guards against a regression back to the unverified `.ai` domain.
+
+test("providers-shape: modelscope is registered in APIKEY_PROVIDERS metadata", () => {
+  assert.ok("modelscope" in APIKEY_PROVIDERS, "modelscope missing from APIKEY_PROVIDERS");
+  const meta = (APIKEY_PROVIDERS as Record<string, Record<string, unknown>>).modelscope;
+  assert.equal(meta.id, "modelscope");
+  assert.equal(meta.alias, "ms");
+  assert.equal(meta.name, "ModelScope");
+  assert.equal(meta.website, "https://modelscope.cn");
+  assert.equal(meta.hasFree, true);
+});
+
+test("providers-shape: modelscope is a canonical AI_PROVIDERS entry resolvable by id", () => {
+  assert.ok("modelscope" in AI_PROVIDERS, "modelscope missing from AI_PROVIDERS");
+  const provider = getProviderById("modelscope");
+  assert.ok(provider, "getProviderById('modelscope') returned nothing");
+  assert.equal(provider?.id, "modelscope");
+});
+
+test("registry resolution: modelscope resolves in the provider REGISTRY as OpenAI-compatible", () => {
+  assert.ok("modelscope" in REGISTRY, "modelscope missing from REGISTRY");
+  const entry = REGISTRY.modelscope;
+  assert.equal(entry.format, "openai");
+  assert.equal(entry.executor, "default");
+  assert.equal(entry.authType, "apikey");
+  assert.equal(entry.authHeader, "bearer");
+  assert.equal(entry, modelscopeProvider);
+});
+
+test("registry resolution: modelscope uses passthrough models with an empty static seed list", () => {
+  assert.equal(modelscopeProvider.passthroughModels, true);
+  assert.deepEqual(modelscopeProvider.models, []);
+  assert.equal(
+    modelscopeProvider.modelsUrl,
+    "https://api-inference.modelscope.cn/v1/models",
+    "modelsUrl must point at the verified .cn domain"
+  );
+});
+
+test("baseUrl guard: modelscope targets the verified api-inference.modelscope.cn domain (not .ai)", () => {
+  assert.equal(
+    modelscopeProvider.baseUrl,
+    "https://api-inference.modelscope.cn/v1/chat/completions"
+  );
+  assert.ok(
+    modelscopeProvider.baseUrl.includes("api-inference.modelscope.cn"),
+    `baseUrl must use the verified .cn domain, got: ${modelscopeProvider.baseUrl}`
+  );
+  assert.ok(
+    !modelscopeProvider.baseUrl.includes("modelscope.ai"),
+    "baseUrl must not regress to the upstream PR's unverified .ai domain"
+  );
+});

--- a/tests/unit/providers-constants-split.test.ts
+++ b/tests/unit/providers-constants-split.test.ts
@@ -1,7 +1,7 @@
 // Characterization of the providers.ts catalog split (god-file decomposition): the host became a
 // barrel that re-exports 10 data catalogs now living under constants/providers/*, and APIKEY is
 // merged from 6 semantic family files (apikey/<family>.ts). Locks: the public surface (every catalog
-// + helpers still exported), the spread-merge integrity (159 APIKEY entries, no loss/dup), and that
+// + helpers still exported), the spread-merge integrity (161 APIKEY entries, no loss/dup), and that
 // load-time Zod validation still runs. Pure-data move → behavior must be identical.
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -31,12 +31,12 @@ test("barrel still exports every catalog + key helpers", () => {
   }
 });
 
-test("APIKEY_PROVIDERS merges the 6 family files into 159 entries (no loss / no dup)", async () => {
+test("APIKEY_PROVIDERS merges the 6 family files into 161 entries (no loss / no dup)", async () => {
   const keys = Object.keys((P as Record<string, object>).APIKEY_PROVIDERS);
-  assert.equal(keys.length, 159);
-  assert.equal(new Set(keys).size, 159, "duplicate keys after spread-merge");
+  assert.equal(keys.length, 161);
+  assert.equal(new Set(keys).size, 161, "duplicate keys after spread-merge");
   // the merged object's entry-count equals the sum of the 6 semantic family files; families are a
-  // strict partition (every provider in exactly one), so the sum must be exactly 159.
+  // strict partition (every provider in exactly one), so the sum must be exactly 161.
   const families: [string, string][] = [
     ["gateways", "APIKEY_PROVIDERS_GATEWAYS"],
     ["frontier-labs", "APIKEY_PROVIDERS_FRONTIER"],
@@ -56,7 +56,7 @@ test("APIKEY_PROVIDERS merges the 6 family files into 159 entries (no loss / no 
       seen.add(k);
     }
   }
-  assert.equal(famTotal, 159, "families must partition all 159 providers");
+  assert.equal(famTotal, 161, "families must partition all 161 providers");
 });
 
 test("AI_PROVIDERS Proxy aggregates all sections; lookups resolve", () => {

--- a/tests/unit/qiniu-provider.test.ts
+++ b/tests/unit/qiniu-provider.test.ts
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const { APIKEY_PROVIDERS } = await import("../../src/shared/constants/providers.ts");
+const { PROVIDER_ENDPOINTS } = await import("../../src/shared/constants/config.ts");
+const { REGISTRY: providerRegistry } = await import("../../open-sse/config/providerRegistry.ts");
+const { isValidModel } = await import("../../src/shared/constants/models.ts");
+
+const QINIU_CHAT_URL = "https://api.qnaigc.com/v1/chat/completions";
+const QINIU_MODELS_URL = "https://api.qnaigc.com/v1/models";
+
+test("Qiniu is registered as an API-key provider", () => {
+  const entry = APIKEY_PROVIDERS.qiniu;
+  assert.ok(entry, "APIKEY_PROVIDERS.qiniu must be defined");
+  assert.equal(entry.id, "qiniu");
+  assert.equal(entry.alias, "qiniu");
+  assert.equal(entry.name, "Qiniu");
+  assert.equal(entry.website, "https://www.qiniu.com");
+  assert.equal(entry.passthroughModels, true);
+});
+
+test("Qiniu exposes the OpenAI-compatible chat completions endpoint", () => {
+  assert.equal(PROVIDER_ENDPOINTS.qiniu, QINIU_CHAT_URL);
+});
+
+test("Qiniu registry entry uses OpenAI format with bearer API-key auth", () => {
+  const entry = providerRegistry.qiniu;
+  assert.ok(entry, "providerRegistry.qiniu must be defined");
+  assert.equal(entry.id, "qiniu");
+  assert.equal(entry.alias, "qiniu");
+  assert.equal(entry.format, "openai");
+  assert.equal(entry.executor, "default");
+  assert.equal(entry.authType, "apikey");
+  assert.equal(entry.authHeader, "bearer");
+  assert.equal(entry.baseUrl, QINIU_CHAT_URL);
+  assert.equal(entry.modelsUrl, QINIU_MODELS_URL);
+  assert.equal(entry.passthroughModels, true);
+});
+
+test("Qiniu ships no static model seed — relies fully on passthrough + live catalog", () => {
+  const models = providerRegistry.qiniu.models;
+  assert.deepEqual(models, []);
+});
+
+test("Qiniu accepts any model id via passthrough models (DeepSeek/Claude/Kimi behind one key)", () => {
+  assert.equal(isValidModel("qiniu", "deepseek-v3"), true);
+  assert.equal(isValidModel("qiniu", "deepseek-v3.2"), true);
+  assert.equal(isValidModel("qiniu", "claude-sonnet-4-5"), true);
+  assert.equal(isValidModel("qiniu", "kimi-k2"), true);
+});
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-qiniu-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const modelsRoute = await import("../../src/app/api/providers/[id]/models/route.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+interface ModelsBody {
+  provider: string;
+  connectionId: string;
+  models: Array<{ id: string }>;
+  source?: string;
+}
+
+test("Qiniu import fetches the live /v1/models catalog", async () => {
+  await resetStorage();
+  const connection = await providersDb.createProviderConnection({
+    provider: "qiniu",
+    authType: "apikey",
+    name: "qiniu-live",
+    apiKey: "qiniu-key",
+  });
+
+  let fetched = false;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    if (String(url) === QINIU_MODELS_URL) {
+      fetched = true;
+      return Response.json({
+        object: "list",
+        data: [{ id: "deepseek-v3" }, { id: "deepseek-v4" }, { id: "kimi-k2" }],
+      });
+    }
+    return new Response("not found", { status: 404 });
+  };
+
+  try {
+    const response = await modelsRoute.GET(
+      new Request(`http://localhost/api/providers/${connection.id}/models?refresh=true`),
+      { params: { id: connection.id } }
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as ModelsBody;
+    assert.equal(body.provider, "qiniu");
+    assert.equal(body.source, "api", "should serve the live upstream catalog");
+    assert.ok(fetched, `should have probed ${QINIU_MODELS_URL}`);
+    const ids = body.models.map((model) => model.id);
+    assert.ok(ids.includes("deepseek-v3"), `live catalog model missing: ${ids.join(",")}`);
+    assert.ok(ids.includes("kimi-k2"), `live catalog model missing: ${ids.join(",")}`);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("Qiniu import falls back to an empty local catalog when live fetch fails", async () => {
+  await resetStorage();
+  const connection = await providersDb.createProviderConnection({
+    provider: "qiniu",
+    authType: "apikey",
+    name: "qiniu-fallback",
+    apiKey: "qiniu-key-2",
+  });
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response("bad gateway", { status: 502 });
+
+  try {
+    const response = await modelsRoute.GET(
+      new Request(`http://localhost/api/providers/${connection.id}/models?refresh=true`),
+      { params: { id: connection.id } }
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as ModelsBody;
+    assert.equal(body.provider, "qiniu");
+    assert.equal(body.source, "local_catalog", "import must not break when upstream is down");
+    assert.deepEqual(
+      body.models.map((model) => model.id),
+      []
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
Ports upstream diegosouzapw/OmniRoute PRs:
- #5966: Qiniu Cloud provider (OpenAI-compatible, API-key)
- #5965: ModelScope provider (OpenAI-compatible, API-key)
- #5996: CodeWhale CLI tool (spawnable, dual entry alongside deepseek-tui)

All additive. Provider/CLI count assertions recomputed against the fork base after rebase (APIKEY 161, CLI code 19, CLI total 29).

Test plan:
- [x] tests/unit/qiniu-provider.test.ts
- [x] tests/unit/modelscope-provider.test.ts
- [x] tests/unit/providers-constants-split.test.ts (APIKEY=161)
- [x] tests/unit/cli-catalog-counts.test.ts / cli-tools-schema.test.ts (CodeWhale)