### PR TITLE
feat(providers): add provider plugin manifest system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **hygiene:** Add CodeRabbit review config (.coderabbit.yaml) and Gemini context (.gemini/config.json, .gemini/prompts.md)
 - **hygiene:** Add ADR.md with fleet hygiene decisions (ADR-001 baseline, ADR-002 e2e restoration, ADR-003 dual dependency automation)
 - **e2e:** Remove orphaned testIgnore entries (analytics-tabs, protocol-visibility, skills-marketplace) whose specs no longer exist
+- **feat(api):** expose a read-only provider plugin manifest at `GET /api/v1/provider-plugin-manifest` for sidecar/relay discovery. (thanks @KooshaPari)
 - **feat(server):** support reverse-proxy subpath deployment via OMNIROUTE_BASE_PATH (basePath-aware auth redirects). (thanks @SillyHippy)
 - **feat(api-keys):** track devices/connections per API key — an in-memory, TTL-evicted device fingerprint tracker (SHA-256 of masked IP + truncated user-agent) wired non-blocking into the chat path and surfaced via `GET /api/keys/[id]/devices` with a dashboard device-count chip. (thanks @mugnimaestra)
 - **feat(proxy):** add Webshare proxy pool import and sync — a `WebshareProvider` (`FreeProxyProvider`) that paginates `proxy.webshare.io/api/v2/proxy/list/` gated on `FREE_PROXY_WEBSHARE_API_KEY`, SSRF-guards imported hosts, and tombstones retired proxy IDs via `pruneStaleFreeProxies()`. (thanks @ricatix)

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -18,6 +18,7 @@ Complete reference for all OmniRoute API endpoints.
 - [Embeddings](#embeddings)
 - [Image Generation](#image-generation)
 - [List Models](#list-models)
+- [Provider Plugin Manifest](#provider-plugin-manifest)
 - [Compatibility Endpoints](#compatibility-endpoints)
 - [Files API](#files-api)
 - [Batches API](#batches-api)
@@ -175,6 +176,22 @@ claude-3-omniroute-no-thinking/<provider>/<model>
 ```
 
 Selecting this id (e.g. in a Claude Code config that always attaches a `thinking` block) resolves back to the real `<provider>/<model>` with reasoning suppressed — `thinking:{type:"disabled"}` on the `/v1/messages` path, or the `reasoning`/`reasoning_effort` fields dropped on the `/v1/chat/completions` path. The variant is only listed for Claude-family models that support thinking **and** honor `disabled` (so e.g. adaptive-only models that reject `disabled` are excluded). Operators can force the variant on or off per model via `ModelSpec.noThinkingAlias`.
+
+---
+
+## Provider Plugin Manifest
+
+```bash
+GET /api/v1/provider-plugin-manifest
+```
+
+Returns the JSON-safe provider plugin manifest used by Bifrost, CLIProxyAPI, and
+future sidecar routers. The response is generated from the TypeScript provider
+registry and intentionally excludes OAuth client secrets, runtime environment
+resolution, executor functions, request headers, and account data.
+
+Use this endpoint when a sidecar runs out-of-process and cannot import
+`open-sse/config/providerPluginManifestRegistry.ts` directly.
 
 ---
 

--- a/docs/reference/PROVIDER_PLUGIN_MANIFEST.md
+++ b/docs/reference/PROVIDER_PLUGIN_MANIFEST.md
@@ -1,0 +1,81 @@
+---
+title: "Provider Plugin Manifest"
+version: 3.8.42
+lastUpdated: 2026-07-01
+---
+
+# Provider Plugin Manifest
+
+`open-sse/config/providerPluginManifest.ts` defines the JSON-safe provider
+plugin contract. `open-sse/config/providerPluginManifestRegistry.ts` binds that
+contract to the current provider registry for sidecars such as Bifrost,
+CLIProxyAPI, or a future Go/Rust router. The TypeScript registry remains the
+source of truth, but sidecars can consume the manifest without importing
+executor code, OAuth defaults, headers, or process environment state.
+
+The same manifest is available over HTTP at
+`GET /api/v1/provider-plugin-manifest` for sidecars that run out-of-process.
+
+OmniRoute advertises that URL to Bifrost and CLIProxyAPI via the
+`X-OmniRoute-Provider-Manifest-Url` request header. Set
+`OMNIROUTE_PROVIDER_MANIFEST_URL` when the sidecar needs a public or container
+network URL instead of the local request origin.
+
+## Goal
+
+Move provider metadata toward a plugin contract so the hot request path can
+eventually be owned by a lower-latency sidecar while OmniRoute keeps the
+TypeScript route as the policy gate and fallback. The manifest is additive: it
+does not change request routing by itself.
+
+## Contract
+
+The manifest contains:
+
+- provider id and alias
+- upstream format and executor name
+- auth type, auth header, and optional auth prefix
+- static endpoint metadata
+- sidecar eligibility and explicit reasons when a provider should stay on TS
+- JSON-safe model metadata such as context length, vision/reasoning flags, and
+  unsupported params
+- capability tags including `apikey`, `oauth`, `custom-executor`,
+  `passthrough-models`, `responses`, and `sidecar-candidate`
+
+The manifest intentionally excludes:
+
+- OAuth client secrets and default secret values
+- runtime environment resolution
+- request headers and public credential helpers
+- dynamic URL builders
+- executor functions
+- session pool internals
+
+## Sidecar Use
+
+Sidecars should treat `sidecar.eligible` as a conservative candidate signal, not
+as an unconditional routing decision. The first import target should be
+API-key, static-endpoint providers using the default executor. Providers with
+custom web executors, OAuth/session flows, dynamic URL builders, or pool config
+stay on the TypeScript fallback path until a sidecar implements equivalent
+behavior and telemetry proves parity.
+
+Suggested migration phases:
+
+1. Generate and validate the provider plugin manifest from the TS registry.
+2. Teach Bifrost or CLIProxyAPI to import the manifest for API-key/static
+   providers.
+3. Route eligible providers through the sidecar behind `OMNIROUTE_RELAY_BACKEND`
+   while keeping TS fallback enabled.
+4. Promote providers only when success rate, p99 latency, streaming behavior,
+   and unsupported-param handling match the TS path.
+5. Add sidecar-native plugins for custom executors one provider family at a
+   time.
+
+## Why Not Embed Providers Directly In Next
+
+The Next frontend should not own provider execution. It should call the API
+boundary. The backend can then decide whether to use the TypeScript executor,
+Bifrost, CLIProxyAPI, or a future native sidecar. This keeps request signing,
+allowlist checks, DB policy, and fallback behavior centralized before any
+sidecar handoff.

--- a/open-sse/config/providerPluginManifest.ts
+++ b/open-sse/config/providerPluginManifest.ts
@@ -1,0 +1,186 @@
+import type { RegistryEntry, RegistryModel } from "./providers/shared.ts";
+
+export type ProviderPluginCapability =
+  | "apikey"
+  | "custom-executor"
+  | "oauth"
+  | "passthrough-models"
+  | "responses"
+  | "sidecar-candidate";
+
+export interface ProviderPluginModel {
+  id: string;
+  name: string;
+  contextLength?: number;
+  maxOutputTokens?: number;
+  toolCalling?: boolean;
+  supportsReasoning?: boolean;
+  supportsVision?: boolean;
+  unsupportedParams?: readonly string[];
+  targetFormat?: string;
+}
+
+export interface ProviderPluginManifestEntry {
+  id: string;
+  alias?: string;
+  format: string;
+  executor: string;
+  auth: {
+    type: string;
+    header: string;
+    prefix?: string;
+  };
+  endpoints: {
+    baseUrl?: string;
+    baseUrls?: string[];
+    responsesBaseUrl?: string;
+    chatPath?: string;
+    modelsUrl?: string;
+  };
+  capabilities: ProviderPluginCapability[];
+  passthroughModels: boolean;
+  defaultContextLength?: number;
+  timeoutMs?: number;
+  models: ProviderPluginModel[];
+  sidecar: {
+    eligible: boolean;
+    reasons: string[];
+  };
+}
+
+export interface ProviderPluginManifest {
+  schemaVersion: 1;
+  generatedFrom: "open-sse/config/providers";
+  providers: ProviderPluginManifestEntry[];
+}
+
+const SIDECAR_COMPATIBLE_EXECUTORS = new Set(["default"]);
+
+function compactObject<T extends Record<string, unknown>>(value: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as Partial<T>;
+}
+
+function mapModel(model: RegistryModel): ProviderPluginModel {
+  return compactObject({
+    id: model.id,
+    name: model.name,
+    contextLength: model.contextLength,
+    maxOutputTokens: model.maxOutputTokens,
+    toolCalling: model.toolCalling,
+    supportsReasoning: model.supportsReasoning,
+    supportsVision: model.supportsVision,
+    unsupportedParams: model.unsupportedParams,
+    targetFormat: model.targetFormat,
+  }) as ProviderPluginModel;
+}
+
+function sidecarEligibility(entry: RegistryEntry): { eligible: boolean; reasons: string[] } {
+  const reasons: string[] = [];
+
+  if (!SIDECAR_COMPATIBLE_EXECUTORS.has(entry.executor)) {
+    reasons.push(`custom executor: ${entry.executor}`);
+  }
+  if (entry.authType !== "apikey" && entry.authType !== "optional" && entry.authType !== "none") {
+    reasons.push(`auth type requires TS handling: ${entry.authType}`);
+  }
+  if (!entry.baseUrl && !entry.baseUrls?.length && !entry.responsesBaseUrl) {
+    reasons.push("no static upstream endpoint");
+  }
+  if (typeof entry.urlBuilder === "function") {
+    reasons.push("dynamic URL builder");
+  }
+  if (entry.oauth) {
+    reasons.push("oauth metadata");
+  }
+  if (entry.poolConfig) {
+    reasons.push("session pool config");
+  }
+
+  return {
+    eligible: reasons.length === 0,
+    reasons,
+  };
+}
+
+function capabilitiesFor(entry: RegistryEntry, eligible: boolean): ProviderPluginCapability[] {
+  const capabilities = new Set<ProviderPluginCapability>();
+
+  if (entry.authType === "apikey" || entry.authType === "optional") {
+    capabilities.add("apikey");
+  }
+  if (entry.authType === "oauth" || entry.oauth) {
+    capabilities.add("oauth");
+  }
+  if (entry.responsesBaseUrl) {
+    capabilities.add("responses");
+  }
+  if (entry.passthroughModels) {
+    capabilities.add("passthrough-models");
+  }
+  if (entry.executor !== "default") {
+    capabilities.add("custom-executor");
+  }
+  if (eligible) {
+    capabilities.add("sidecar-candidate");
+  }
+
+  return [...capabilities].sort();
+}
+
+export function createProviderPluginManifestEntry(
+  entry: RegistryEntry,
+): ProviderPluginManifestEntry {
+  const sidecar = sidecarEligibility(entry);
+
+  return {
+    id: entry.id,
+    ...(entry.alias ? { alias: entry.alias } : {}),
+    format: entry.format,
+    executor: entry.executor,
+    auth: compactObject({
+      type: entry.authType,
+      header: entry.authHeader,
+      prefix: entry.authPrefix,
+    }) as ProviderPluginManifestEntry["auth"],
+    endpoints: compactObject({
+      baseUrl: entry.baseUrl,
+      baseUrls: entry.baseUrls,
+      responsesBaseUrl: entry.responsesBaseUrl,
+      chatPath: entry.chatPath,
+      modelsUrl: entry.modelsUrl,
+    }) as ProviderPluginManifestEntry["endpoints"],
+    capabilities: capabilitiesFor(entry, sidecar.eligible),
+    passthroughModels: entry.passthroughModels === true,
+    ...(typeof entry.defaultContextLength === "number"
+      ? { defaultContextLength: entry.defaultContextLength }
+      : {}),
+    ...(typeof entry.timeoutMs === "number" ? { timeoutMs: entry.timeoutMs } : {}),
+    models: (entry.models ?? []).map(mapModel),
+    sidecar,
+  };
+}
+
+export function generateProviderPluginManifestFromRegistry(
+  registry: Record<string, RegistryEntry>,
+): ProviderPluginManifest {
+  return {
+    schemaVersion: 1,
+    generatedFrom: "open-sse/config/providers",
+    providers: Object.values(registry)
+      .map(createProviderPluginManifestEntry)
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  };
+}
+
+export function getProviderPluginManifestEntryFromRegistry(
+  registry: Record<string, RegistryEntry>,
+  provider: string,
+): ProviderPluginManifestEntry | null {
+  const entry =
+    registry[provider] ||
+    Object.values(registry).find((candidate) => candidate.alias === provider);
+
+  return entry ? createProviderPluginManifestEntry(entry) : null;
+}

--- a/open-sse/config/providerPluginManifestRegistry.ts
+++ b/open-sse/config/providerPluginManifestRegistry.ts
@@ -1,0 +1,31 @@
+import { REGISTRY } from "./providers/index.ts";
+import {
+  generateProviderPluginManifestFromRegistry,
+  getProviderPluginManifestEntryFromRegistry,
+  type ProviderPluginManifestEntry,
+} from "./providerPluginManifest.ts";
+
+export function generateProviderPluginManifest() {
+  return generateProviderPluginManifestFromRegistry(REGISTRY);
+}
+
+export function getProviderPluginManifestEntry(provider: string) {
+  return getProviderPluginManifestEntryFromRegistry(REGISTRY, provider);
+}
+
+export function getProviderPluginManifestEntryForModel(
+  model: string | undefined,
+): ProviderPluginManifestEntry | null {
+  if (!model) return null;
+
+  const providerPrefix = model.includes("/") ? model.split("/", 1)[0] : "";
+  if (providerPrefix) {
+    const prefixed = getProviderPluginManifestEntry(providerPrefix);
+    if (prefixed) return prefixed;
+  }
+
+  const manifest = generateProviderPluginManifest();
+  return manifest.providers.find((provider) =>
+    provider.models.some((candidate) => candidate.id === model),
+  ) ?? null;
+}

--- a/open-sse/config/providerPluginManifestUrl.ts
+++ b/open-sse/config/providerPluginManifestUrl.ts
@@ -1,0 +1,26 @@
+export const PROVIDER_PLUGIN_MANIFEST_HEADER = "X-OmniRoute-Provider-Manifest-Url";
+export const PROVIDER_PLUGIN_MANIFEST_PATH = "/api/v1/provider-plugin-manifest";
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/$/, "");
+}
+
+export function resolveProviderPluginManifestUrl(origin?: string | null): string {
+  const configured = process.env.OMNIROUTE_PROVIDER_MANIFEST_URL?.trim();
+  if (configured) return configured;
+
+  if (origin) {
+    return `${trimTrailingSlash(origin)}${PROVIDER_PLUGIN_MANIFEST_PATH}`;
+  }
+
+  const host = process.env.HOST || "127.0.0.1";
+  const port = process.env.PORT || process.env.DASHBOARD_PORT || process.env.API_PORT || "20128";
+  const protocol = process.env.OMNIROUTE_PUBLIC_PROTOCOL || "http";
+  return `${protocol}://${host}:${port}${PROVIDER_PLUGIN_MANIFEST_PATH}`;
+}
+
+export function getProviderPluginManifestHeader(origin?: string | null): Record<string, string> {
+  return {
+    [PROVIDER_PLUGIN_MANIFEST_HEADER]: resolveProviderPluginManifestUrl(origin),
+  };
+}

--- a/src/app/api/v1/provider-plugin-manifest/route.ts
+++ b/src/app/api/v1/provider-plugin-manifest/route.ts
@@ -1,0 +1,24 @@
+import { CORS_HEADERS } from "@/shared/utils/cors";
+import { generateProviderPluginManifest } from "@omniroute/open-sse/config/providerPluginManifestRegistry.ts";
+
+const JSON_HEADERS = {
+  ...CORS_HEADERS,
+  "Content-Type": "application/json",
+  "Cache-Control": "public, max-age=60",
+} as const;
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      ...CORS_HEADERS,
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    },
+  });
+}
+
+export async function GET() {
+  return new Response(JSON.stringify(generateProviderPluginManifest()), {
+    headers: JSON_HEADERS,
+  });
+}

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -43,6 +43,7 @@
   "tap": {
     "testFiles": [
       "tests/unit/account-fallback-anthropic-quota.test.ts",
+      "tests/unit/account-fallback-retry-after-json.test.ts",
       "tests/unit/account-fallback-route-restriction-403.test.ts",
       "tests/unit/account-fallback-service.test.ts",
       "tests/unit/api-key-rotator-health.test.ts",
@@ -193,10 +194,13 @@
       "tests/unit/chatcore-upstream-timeouts.test.ts",
       "tests/unit/circuit-breaker-registry-cap.test.ts",
       "tests/unit/circuit-breaker-stream-controller-4602.test.ts",
+      "tests/unit/clinepass-provider.test.ts",
+      "tests/unit/codex-session-affinity-reset-aware-5903.test.ts",
       "tests/unit/combo-account-allowlist-3266.test.ts",
       "tests/unit/combo-headroom-strategy.test.ts",
       "tests/unit/combo-model-lockout-honors-reset-1308.test.ts",
       "tests/unit/combo-param-validation-fallback-4519.test.ts",
+      "tests/unit/combo-priority-quota-exhaustion-cutoff-5923.test.ts",
       "tests/unit/combo-quota-share-cooldown-wait.test.ts",
       "tests/unit/combo-selected-connection-success.test.ts",
       "tests/unit/combo-stream-readiness-fallback.test.ts",

--- a/tests/unit/api/v1/provider-plugin-manifest-route.test.ts
+++ b/tests/unit/api/v1/provider-plugin-manifest-route.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  GET,
+  OPTIONS,
+} from "../../../../src/app/api/v1/provider-plugin-manifest/route.ts";
+
+test("provider plugin manifest route returns JSON-safe manifest", async () => {
+  const response = await GET();
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("Content-Type"), "application/json");
+  assert.equal(body.schemaVersion, 1);
+  assert.equal(body.generatedFrom, "open-sse/config/providers");
+  assert.ok(body.providers.length > 100);
+  assert.ok(body.providers.some((provider: { id: string }) => provider.id === "openai"));
+
+  const serialized = JSON.stringify(body);
+  assert.equal(serialized.includes("clientSecret"), false);
+});
+
+test("provider plugin manifest route handles CORS preflight", async () => {
+  const response = await OPTIONS();
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("Access-Control-Allow-Methods"), "GET, OPTIONS");
+  assert.equal(response.headers.get("Access-Control-Allow-Headers"), "*");
+});

--- a/tests/unit/provider-plugin-manifest-url.test.ts
+++ b/tests/unit/provider-plugin-manifest-url.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  PROVIDER_PLUGIN_MANIFEST_HEADER,
+  resolveProviderPluginManifestUrl,
+  getProviderPluginManifestHeader,
+} from "../../open-sse/config/providerPluginManifestUrl.ts";
+
+test("provider manifest URL uses explicit env override", () => {
+  const previous = process.env.OMNIROUTE_PROVIDER_MANIFEST_URL;
+  process.env.OMNIROUTE_PROVIDER_MANIFEST_URL = "http://sidecar.local/manifest.json";
+  try {
+    assert.equal(
+      resolveProviderPluginManifestUrl("http://127.0.0.1:20128"),
+      "http://sidecar.local/manifest.json",
+    );
+  } finally {
+    if (previous === undefined) {
+      delete process.env.OMNIROUTE_PROVIDER_MANIFEST_URL;
+    } else {
+      process.env.OMNIROUTE_PROVIDER_MANIFEST_URL = previous;
+    }
+  }
+});
+
+test("provider manifest URL derives from request origin", () => {
+  assert.equal(
+    resolveProviderPluginManifestUrl("http://127.0.0.1:20128/"),
+    "http://127.0.0.1:20128/api/v1/provider-plugin-manifest",
+  );
+});
+
+test("provider manifest header exposes stable header name", () => {
+  assert.deepEqual(getProviderPluginManifestHeader("http://localhost:20128"), {
+    [PROVIDER_PLUGIN_MANIFEST_HEADER]:
+      "http://localhost:20128/api/v1/provider-plugin-manifest",
+  });
+});

--- a/tests/unit/provider-plugin-manifest.test.ts
+++ b/tests/unit/provider-plugin-manifest.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  generateProviderPluginManifestFromRegistry,
+  getProviderPluginManifestEntryFromRegistry,
+} from "../../open-sse/config/providerPluginManifest.ts";
+import type { RegistryEntry } from "../../open-sse/config/providers/shared.ts";
+
+const registryFixture: Record<string, RegistryEntry> = {
+  openai: {
+    id: "openai",
+    alias: "openai",
+    format: "openai",
+    executor: "default",
+    baseUrl: "https://api.openai.com/v1/chat/completions",
+    authType: "apikey",
+    authHeader: "bearer",
+    defaultContextLength: 128000,
+    models: [
+      { id: "gpt-4.1", name: "GPT-4.1", contextLength: 1047576 },
+      {
+        id: "o3",
+        name: "O3",
+        contextLength: 200000,
+        unsupportedParams: ["temperature", "top_p"],
+      },
+    ],
+  },
+  anthropic: {
+    id: "anthropic",
+    alias: "anthropic",
+    format: "claude",
+    executor: "default",
+    baseUrl: "https://api.anthropic.com/v1/messages",
+    authType: "apikey",
+    authHeader: "x-api-key",
+    headers: {
+      "Anthropic-Version": "2023-06-01",
+    },
+    models: [{ id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6" }],
+  },
+  "claude-web": {
+    id: "claude-web",
+    alias: "cw",
+    format: "openai",
+    executor: "claude-web",
+    baseUrl: "https://claude.ai/api/organizations",
+    authType: "apikey",
+    authHeader: "cookie",
+    models: [{ id: "claude-sonnet-4.6", name: "Claude 4.6 Sonnet (web)" }],
+  },
+  claude: {
+    id: "claude",
+    alias: "claude",
+    format: "claude",
+    executor: "default",
+    baseUrl: "https://api.anthropic.com/v1/messages",
+    authType: "oauth",
+    authHeader: "x-api-key",
+    oauth: {
+      clientIdDefault: "public-client",
+      clientSecretDefault: "secret-that-must-not-export",
+      tokenUrl: "https://console.anthropic.com/oauth/token",
+    },
+    models: [{ id: "claude-opus-4.7", name: "Claude Opus 4.7" }],
+  },
+};
+
+test("provider plugin manifest is JSON-safe and stable enough for sidecars", () => {
+  const manifest = generateProviderPluginManifestFromRegistry(registryFixture);
+  const roundTripped = JSON.parse(JSON.stringify(manifest));
+
+  assert.equal(roundTripped.schemaVersion, 1);
+  assert.equal(roundTripped.generatedFrom, "open-sse/config/providers");
+  assert.equal(roundTripped.providers.length, 4);
+  assert.deepEqual(
+    roundTripped.providers.map((provider: { id: string }) => provider.id),
+    [...roundTripped.providers.map((provider: { id: string }) => provider.id)].sort(),
+  );
+});
+
+test("manifest exposes API-key default-executor providers as sidecar candidates", () => {
+  const openai = getProviderPluginManifestEntryFromRegistry(registryFixture, "openai");
+
+  assert.ok(openai);
+  assert.equal(openai.sidecar.eligible, true);
+  assert.deepEqual(openai.sidecar.reasons, []);
+  assert.ok(openai.capabilities.includes("apikey"));
+  assert.ok(openai.capabilities.includes("sidecar-candidate"));
+  assert.equal(openai.endpoints.baseUrl, "https://api.openai.com/v1/chat/completions");
+  assert.ok(openai.models.some((model) => model.id === "gpt-4.1"));
+});
+
+test("manifest keeps custom web executors on the TypeScript fallback path", () => {
+  const claudeWeb = getProviderPluginManifestEntryFromRegistry(registryFixture, "cw");
+
+  assert.ok(claudeWeb);
+  assert.equal(claudeWeb.id, "claude-web");
+  assert.equal(claudeWeb.sidecar.eligible, false);
+  assert.ok(claudeWeb.capabilities.includes("custom-executor"));
+  assert.ok(claudeWeb.sidecar.reasons.some((reason) => reason.includes("claude-web")));
+});
+
+test("manifest does not export OAuth client secrets or dynamic functions", () => {
+  const manifest = generateProviderPluginManifestFromRegistry(registryFixture);
+  const serialized = JSON.stringify(manifest);
+
+  assert.equal(serialized.includes("clientSecret"), false);
+  assert.equal(serialized.includes("clientSecretDefault"), false);
+  assert.equal(serialized.includes("clientSecretEnv"), false);
+
+  const parsed = JSON.parse(serialized);
+  for (const provider of parsed.providers) {
+    assert.notEqual(typeof provider.endpoints?.urlBuilder, "function");
+    assert.equal("oauth" in provider, false);
+    assert.equal("headers" in provider, false);
+    assert.equal("extraHeaders" in provider, false);
+    assert.equal("requestDefaults" in provider, false);
+  }
+});


### PR DESCRIPTION
Port of diegosouzapw/OmniRoute#6001.

## What

Exposes a read-only **provider plugin manifest** at `GET /api/v1/provider-plugin-manifest` so out-of-process sidecars and relays can discover provider metadata (models, executor kind, auth mode, endpoints) as a stable plugin contract — without importing executor/OAuth/header code.

## Files

- `open-sse/config/providerPluginManifest.ts` — pure manifest builder over the provider `REGISTRY` (no secrets, no dynamic functions exported)
- `open-sse/config/providerPluginManifestRegistry.ts` — `generateProviderPluginManifest()`
- `open-sse/config/providerPluginManifestUrl.ts` — manifest URL/header resolution
- `src/app/api/v1/provider-plugin-manifest/route.ts` — `GET` + CORS `OPTIONS`
- docs (`PROVIDER_PLUGIN_MANIFEST.md`, `API_REFERENCE.md`), `stryker.conf.json`, and 9 unit tests

## Notes

The upstream #6001 diff only carried the HTTP surface; the underlying manifest modules were introduced upstream on `release/v3.8.44` (PR #5870) and were missing from this fork, so they are materialized here to make the endpoint functional.

## Tests

```
node --import tsx/esm --test tests/unit/provider-plugin-manifest.test.ts \
  tests/unit/provider-plugin-manifest-url.test.ts \
  tests/unit/api/v1/provider-plugin-manifest-route.test.ts
# 9 pass / 0 fail
```

Manifest guards verified: no OAuth client secrets or dynamic functions exported; API-key default-executor providers surface as sidecar candidates; custom web executors stay on the TS fallback path.

Co-authored-by: KooshaPari <kooshapari@gmail.com>