### PR TITLE
feat(routing): port MiniMax M3 reasoning extraction + perf-snapshot routing (#6050, #6040)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,8 @@ _TBD_
 
 - **providers (CLI profile auto-sync):** opt-in CLI profile auto-sync toggles, including Claude Code auto-sync, so generated CLI profiles can track provider changes automatically. ([#5755](https://github.com/diegosouzapw/OmniRoute/pull/5755) — thanks @diegosouzapw)
 
+- **feat(minimax):** surface MiniMax M3 `<think>` reasoning as `reasoning_content` on OpenAI-format provider tiers. (thanks @zmf963)
+
 ### 🔧 Bug Fixes
 
 - **fix(opencode):** stop fabricating `User-Agent: opencode/local` and `x-opencode-client: cli` headers when the client sends none — the executor-dedup refactor ([#5720](https://github.com/diegosouzapw/OmniRoute/pull/5720)) accidentally re-introduced header fabrication, violating the forward-only contract (inventing opencode-internal values risks upstream rejection). Restored to forward-only: those headers are emitted only when a real client source is present. Regression guard: `tests/unit/opencode-executor.test.ts`. (thanks @diegosouzapw)

--- a/open-sse/handlers/responseSanitizer/reasoning.ts
+++ b/open-sse/handlers/responseSanitizer/reasoning.ts
@@ -129,7 +129,13 @@ export function isTextualReasoningTagNativeRoute(providerId: string, modelId: st
   return (
     /deepseek[-_/]?r1\b/.test(routeId) ||
     /r1[-_/]?distill\b/.test(routeId) ||
-    /(?:^|[/:_-])qwq(?:[/._:-]|$)/.test(routeId)
+    /(?:^|[/:_-])qwq(?:[/._:-]|$)/.test(routeId) ||
+    // 9router#2231: MiniMax M3 leaks raw <think>...</think> into `content` on its
+    // OpenAI-format provider tiers (trae, huggingchat, bazaarlink, ollama-cloud,
+    // opencode, cline, opencode-zen, codebuddy-cn). The direct minimax/minimax-cn
+    // tiers stay on Anthropic's Messages format (targetFormat: "claude") and
+    // already surface reasoning natively, so they are excluded here.
+    (providerId !== "minimax" && providerId !== "minimax-cn" && /minimax[-_]?m3\b/.test(routeId))
   );
 }
 

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -46,11 +46,7 @@ import { extractSessionAffinityKey } from "@/sse/services/auth";
 import { getHiddenModelsByProvider } from "@/models";
 import { resolveModelLockoutSettings } from "../../src/lib/resilience/modelLockoutSettings";
 import { fetchCodexQuota } from "./codexQuotaFetcher.ts";
-import {
-  evaluateQuotaCutoff,
-  getQuotaFetcher,
-  type QuotaInfo,
-} from "./quotaPreflight.ts";
+import { evaluateQuotaCutoff, getQuotaFetcher, type QuotaInfo } from "./quotaPreflight.ts";
 import * as semaphore from "./rateLimitSemaphore.ts";
 import { getCircuitBreaker } from "../../src/shared/utils/circuitBreaker";
 import { fisherYatesShuffle, getNextFromDeck } from "../../src/shared/utils/shuffleDeck";
@@ -439,6 +435,9 @@ export async function buildAutoCandidates(
       const historicalP95Latency = Number(historicalModelMetric?.p95LatencyMs);
       const historicalStdDev = Number(historicalModelMetric?.latencyStdDev);
       const historicalSuccessRate = Number(historicalModelMetric?.successRate); // 0..1
+      const historicalAvgTtft = Number(historicalModelMetric?.avgTtftMs);
+      const historicalAvgE2E = Number(historicalModelMetric?.avgE2ELatencyMs);
+      const historicalAvgTokensPerSecond = Number(historicalModelMetric?.avgTokensPerSecond);
 
       const p95LatencyMs = hasHistoricalSignal
         ? Number.isFinite(historicalP95Latency) && historicalP95Latency > 0
@@ -540,6 +539,20 @@ export async function buildAutoCandidates(
         circuitBreakerState,
         costPer1MTokens,
         p95LatencyMs,
+        avgTtftMs:
+          hasHistoricalSignal && Number.isFinite(historicalAvgTtft) && historicalAvgTtft > 0
+            ? historicalAvgTtft
+            : undefined,
+        avgE2ELatencyMs:
+          hasHistoricalSignal && Number.isFinite(historicalAvgE2E) && historicalAvgE2E > 0
+            ? historicalAvgE2E
+            : undefined,
+        avgTokensPerSecond:
+          hasHistoricalSignal &&
+          Number.isFinite(historicalAvgTokensPerSecond) &&
+          historicalAvgTokensPerSecond > 0
+            ? historicalAvgTokensPerSecond
+            : undefined,
         latencyStdDev,
         errorRate,
         accountTier: "standard" as const,

--- a/open-sse/services/combo/types.ts
+++ b/open-sse/services/combo/types.ts
@@ -101,6 +101,9 @@ export type HistoricalLatencyStatsEntry = {
   p95LatencyMs?: number;
   latencyStdDev?: number;
   successRate?: number;
+  avgTtftMs?: number | null;
+  avgE2ELatencyMs?: number;
+  avgTokensPerSecond?: number | null;
 };
 
 export type AutoProviderCandidate = ProviderCandidate & {

--- a/src/lib/usage/usageHistory.ts
+++ b/src/lib/usage/usageHistory.ts
@@ -732,6 +732,9 @@ export interface ModelLatencyStatsEntry {
   successfulRequests: number;
   successRate: number; // 0..1
   avgLatencyMs: number;
+  avgTtftMs: number | null;
+  avgE2ELatencyMs: number;
+  avgTokensPerSecond: number | null;
   p50LatencyMs: number;
   p95LatencyMs: number;
   p99LatencyMs: number;
@@ -767,12 +770,14 @@ export async function getModelLatencyStats(
     model: string | null;
     success: number | null;
     latency_ms: number | null;
+    ttft_ms: number | null;
+    tokens_output: number | null;
   };
 
   const rows = db
     .prepare(
       `
-      SELECT provider, model, success, latency_ms
+      SELECT provider, model, success, latency_ms, ttft_ms, tokens_output
       FROM usage_history
       WHERE timestamp >= @sinceIso
         AND provider IS NOT NULL
@@ -792,6 +797,8 @@ export async function getModelLatencyStats(
       successfulRequests: number;
       successfulLatencies: number[];
       allLatencies: number[];
+      successfulTtfts: number[];
+      successfulTokensPerSecond: number[];
     }
   >();
 
@@ -809,6 +816,8 @@ export async function getModelLatencyStats(
         successfulRequests: 0,
         successfulLatencies: [],
         allLatencies: [],
+        successfulTtfts: [],
+        successfulTokensPerSecond: [],
       });
     }
 
@@ -820,9 +829,22 @@ export async function getModelLatencyStats(
     if (isSuccess) bucket.successfulRequests += 1;
 
     const latency = toNumber(row.latency_ms);
+    const ttft = toNumber(row.ttft_ms);
     if (latency > 0) {
       bucket.allLatencies.push(latency);
-      if (isSuccess) bucket.successfulLatencies.push(latency);
+      if (isSuccess) {
+        bucket.successfulLatencies.push(latency);
+
+        if (ttft > 0) {
+          bucket.successfulTtfts.push(ttft);
+        }
+
+        const outputTokens = toNumber(row.tokens_output);
+        const generationMs = Math.max(latency - Math.max(ttft, 0), 1);
+        if (outputTokens > 0) {
+          bucket.successfulTokensPerSecond.push(outputTokens / (generationMs / 1000));
+        }
+      }
     }
   }
 
@@ -837,6 +859,15 @@ export async function getModelLatencyStats(
 
     const sorted = [...baseLatencies].sort((a, b) => a - b);
     const avg = sorted.reduce((acc, n) => acc + n, 0) / sorted.length;
+    const avgTtft =
+      bucket.successfulTtfts.length > 0
+        ? bucket.successfulTtfts.reduce((acc, n) => acc + n, 0) / bucket.successfulTtfts.length
+        : null;
+    const avgTokensPerSecond =
+      bucket.successfulTokensPerSecond.length > 0
+        ? bucket.successfulTokensPerSecond.reduce((acc, n) => acc + n, 0) /
+          bucket.successfulTokensPerSecond.length
+        : null;
     const successRate =
       bucket.totalRequests > 0 ? bucket.successfulRequests / bucket.totalRequests : 0;
 
@@ -848,6 +879,10 @@ export async function getModelLatencyStats(
       successfulRequests: bucket.successfulRequests,
       successRate,
       avgLatencyMs: Math.round(avg),
+      avgTtftMs: avgTtft === null ? null : Math.round(avgTtft),
+      avgE2ELatencyMs: Math.round(avg),
+      avgTokensPerSecond:
+        avgTokensPerSecond === null ? null : Math.round(avgTokensPerSecond * 10) / 10,
       p50LatencyMs: Math.round(percentile(sorted, 0.5)),
       p95LatencyMs: Math.round(percentile(sorted, 0.95)),
       p99LatencyMs: Math.round(percentile(sorted, 0.99)),

--- a/tests/unit/responsesanitizer-reasoning-split.test.ts
+++ b/tests/unit/responsesanitizer-reasoning-split.test.ts
@@ -22,8 +22,10 @@ import assert from "node:assert/strict";
 
 import {
   extractThinkingFromContent,
+  isTextualReasoningTagNativeRoute,
   shouldParseTextualReasoningTags,
 } from "../../open-sse/handlers/responseSanitizer/reasoning.ts";
+import { sanitizeOpenAIResponse } from "../../open-sse/handlers/responseSanitizer.ts";
 
 describe("responseSanitizer/reasoning — extractThinkingFromContent", () => {
   it("leaves tag-free content untouched (thinking = null)", () => {
@@ -47,6 +49,84 @@ describe("responseSanitizer/reasoning — shouldParseTextualReasoningTags", () =
   });
   it("returns false when provider/model are missing", () => {
     assert.equal(shouldParseTextualReasoningTags(undefined, undefined), false);
+  });
+});
+
+// ── MiniMax M3 textual reasoning-tag route (9router#2231) ──────────────────────
+//
+// MiniMax M3 leaks raw <think>...</think> into `content` instead of a separate
+// reasoning_content field on the 8 OpenAI-format provider tiers below. The two
+// direct minimax/minimax-cn tiers stay on Anthropic's Messages format
+// (targetFormat: "claude") and already surface reasoning natively — they must
+// stay unaffected.
+describe("responseSanitizer/reasoning — MiniMax M3 textual reasoning-tag route", () => {
+  const affectedRoutes: Array<[string, string]> = [
+    ["trae", "minimax-m3"],
+    ["huggingchat", "minimaxai/minimax-m3"],
+    ["bazaarlink", "minimax-m3"],
+    ["ollama-cloud", "minimax-m3"],
+    ["opencode", "minimax-m3-free"],
+    ["cline", "minimax/minimax-m3"],
+    ["opencode-zen", "minimax-m3"],
+    ["codebuddy-cn", "minimax-m3"],
+  ];
+
+  for (const [provider, model] of affectedRoutes) {
+    it(`isTextualReasoningTagNativeRoute("${provider}", "${model}") === true`, () => {
+      assert.equal(isTextualReasoningTagNativeRoute(provider, model), true);
+    });
+  }
+
+  it("shouldParseTextualReasoningTags is true for a mixed-case MiniMax M3 model id (huggingchat)", () => {
+    assert.equal(shouldParseTextualReasoningTags("huggingchat", "MiniMaxAI/MiniMax-M3"), true);
+  });
+
+  it("extracts <think>...</think> from delta.content into reasoning_content on an affected route", () => {
+    const chunk = {
+      choices: [{ index: 0, delta: { content: "<think>reasoning here</think>final answer" } }],
+    };
+    const sanitized = sanitizeOpenAIResponse(chunk, {
+      parseTextualReasoningTags: shouldParseTextualReasoningTags("trae", "minimax-m3"),
+    }) as { choices: Array<{ delta: { content: string; reasoning_content?: string } }> };
+
+    const delta = sanitized.choices[0].delta;
+    assert.equal(delta.content, "final answer");
+    assert.equal(delta.reasoning_content, "reasoning here");
+  });
+
+  it("leaves <think> tags untouched in content when the route is not tag-native (pre-fix behavior)", () => {
+    const chunk = {
+      choices: [{ index: 0, delta: { content: "<think>reasoning here</think>final answer" } }],
+    };
+    const sanitized = sanitizeOpenAIResponse(chunk, {
+      parseTextualReasoningTags: shouldParseTextualReasoningTags("openai", "gpt-4"),
+    }) as { choices: Array<{ delta: { content: string; reasoning_content?: string } }> };
+
+    const delta = sanitized.choices[0].delta;
+    assert.equal(delta.content, "<think>reasoning here</think>final answer");
+    assert.equal(delta.reasoning_content, undefined);
+  });
+});
+
+describe("responseSanitizer/reasoning — MiniMax M3 fix regression guards", () => {
+  it("direct minimax tier (claude format) stays unaffected", () => {
+    assert.equal(isTextualReasoningTagNativeRoute("minimax", "minimax-m3"), false);
+    assert.equal(shouldParseTextualReasoningTags("minimax", "MiniMax-M3"), false);
+  });
+
+  it("direct minimax-cn tier (claude format) stays unaffected", () => {
+    assert.equal(isTextualReasoningTagNativeRoute("minimax-cn", "minimax-m3"), false);
+    assert.equal(shouldParseTextualReasoningTags("minimax-cn", "MiniMax-M3"), false);
+  });
+
+  it("MiniMax M2.x (non-M3) models on OpenAI-format tiers stay unaffected", () => {
+    assert.equal(isTextualReasoningTagNativeRoute("trae", "minimax-m2.7"), false);
+  });
+
+  it("existing deepseek-r1 / qwq textual-reasoning routes are unaffected", () => {
+    assert.equal(shouldParseTextualReasoningTags("together", "deepseek-ai/DeepSeek-R1"), true);
+    assert.equal(shouldParseTextualReasoningTags("cloudflare-ai", "@cf/qwen/qwq-32b"), true);
+    assert.equal(shouldParseTextualReasoningTags("openrouter", "deepseek/deepseek-v4-pro"), false);
   });
 });
 

--- a/tests/unit/usage-analytics.test.ts
+++ b/tests/unit/usage-analytics.test.ts
@@ -123,10 +123,10 @@ test("usage history persists entries and supports filtering and usageDb compatib
 test("getModelLatencyStats aggregates success rate and latency percentiles", async () => {
   const now = Date.now();
   const entries = [
-    { latencyMs: 100, success: true },
-    { latencyMs: 200, success: true },
-    { latencyMs: 400, success: true },
-    { latencyMs: 900, success: false },
+    { latencyMs: 100, timeToFirstTokenMs: 40, outputTokens: 6, success: true },
+    { latencyMs: 200, timeToFirstTokenMs: 80, outputTokens: 12, success: true },
+    { latencyMs: 400, timeToFirstTokenMs: 100, outputTokens: 30, success: true },
+    { latencyMs: 900, timeToFirstTokenMs: 200, outputTokens: 70, success: false },
   ];
 
   for (const [index, entry] of entries.entries()) {
@@ -135,6 +135,8 @@ test("getModelLatencyStats aggregates success rate and latency percentiles", asy
       model: "latency-model",
       success: entry.success,
       latencyMs: entry.latencyMs,
+      timeToFirstTokenMs: entry.timeToFirstTokenMs,
+      tokens: { output: entry.outputTokens },
       timestamp: new Date(now - index * 60 * 1000).toISOString(),
     });
   }
@@ -151,6 +153,9 @@ test("getModelLatencyStats aggregates success rate and latency percentiles", asy
   assert.equal(entry.successfulRequests, 3);
   assert.equal(entry.successRate, 0.75);
   assert.equal(entry.avgLatencyMs, 233);
+  assert.equal(entry.avgTtftMs, 73);
+  assert.equal(entry.avgE2ELatencyMs, 233);
+  assert.equal(entry.avgTokensPerSecond, 100);
   assert.equal(entry.p50LatencyMs, 200);
   assert.equal(entry.p95LatencyMs, 400);
   assert.equal(entry.p99LatencyMs, 400);


### PR DESCRIPTION
Second-wave upstream port — small cohesive bundle. Both features verified missing from KooshaPari main.

## Ported

- **#6050 feat(minimax): extract M3 reasoning content** — surface MiniMax M3 `<think>` reasoning as `reasoning_content` on OpenAI-format provider tiers (trae, huggingchat, bazaarlink, ollama-cloud, opencode, cline, opencode-zen, codebuddy-cn). Direct `minimax`/`minimax-cn` tiers stay on Anthropic's Messages format and already surface reasoning natively, so they are excluded. Applied clean.
- **#6040 [codex] Feed provider-model performance snapshots into routing** — feed `avgTtftMs` / `avgE2ELatencyMs` / `avgTokensPerSecond` from usage history into `buildAutoCandidates`. Applied clean; additionally extended the fork-local `HistoricalLatencyStatsEntry` type in `open-sse/services/combo/types.ts` with the three optional fields (upstream reads them off `ModelLatencyStatsEntry` directly; the fork narrows via `HistoricalLatencyStatsEntry`, which needed the fields to typecheck).

## Not ported (no-op)

- **#5921 feat(startup): show elapsed time** — already present in the fork in a **fuller** form. Conflicts in `bin/cli/commands/serve.mjs` and `src/app/api/providers/[id]/models/route.ts` resolved `--ours` because upstream would regress: the fork's `://v1` authority guard (#5899 fix) and the tray / `buildNodeHeapArgs` startup logic (fork uses `performance.now()`; upstream uses `Date.now()`/`--max-old-space-size`). Net zero change from #5921.

## Verification

- `tests/unit/responsesanitizer-reasoning-split.test.ts` (#6050): **26/26 pass**.
- `tests/unit/usage-analytics.test.ts` (#6040): fails on a **pre-existing** migration-113 version collision (`113_cli_access_tokens.sql` + `113_mux_service_seed.sql` both on origin/main — untouched by this PR). Not introduced here; tracked separately.
- `npm run typecheck:core`: **clean (0 errors)** after the `HistoricalLatencyStatsEntry` type extension.

CHANGELOG: keep-both; #6050 entry credits the upstream author (@zmf963).