### PR TITLE
feat(sidecar): add provider manifest client (port #6042)

### DIFF
--- a/docs/reference/PROVIDER_PLUGIN_MANIFEST.md
+++ b/docs/reference/PROVIDER_PLUGIN_MANIFEST.md
@@ -21,6 +21,11 @@ OmniRoute advertises that URL to Bifrost and CLIProxyAPI via the
 `OMNIROUTE_PROVIDER_MANIFEST_URL` when the sidecar needs a public or container
 network URL instead of the local request origin.
 
+Code that needs to consume the manifest over HTTP should use
+`open-sse/config/providerPluginManifestClient.ts` instead of hard-coding the
+route. The client resolves `OMNIROUTE_PROVIDER_MANIFEST_URL`, then an explicit
+base URL, then the local OmniRoute API default.
+
 ## Goal
 
 Move provider metadata toward a plugin contract so the hot request path can

--- a/open-sse/config/providerPluginManifestClient.ts
+++ b/open-sse/config/providerPluginManifestClient.ts
@@ -1,0 +1,87 @@
+import type {
+  ProviderPluginManifest,
+  ProviderPluginManifestEntry,
+} from "./providerPluginManifest.ts";
+
+export const PROVIDER_PLUGIN_MANIFEST_PATH = "/api/v1/provider-plugin-manifest";
+export const PROVIDER_PLUGIN_MANIFEST_ENV = "OMNIROUTE_PROVIDER_MANIFEST_URL";
+
+export interface ProviderPluginManifestClientOptions {
+  baseUrl?: string | null;
+  manifestUrl?: string | null;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal | null;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+export function resolveProviderPluginManifestUrl(
+  options: Pick<ProviderPluginManifestClientOptions, "baseUrl" | "manifestUrl"> = {},
+): string {
+  const explicitUrl = options.manifestUrl?.trim();
+  if (explicitUrl) return explicitUrl;
+
+  const envUrl = process.env[PROVIDER_PLUGIN_MANIFEST_ENV]?.trim();
+  if (envUrl) return envUrl;
+
+  const baseUrl = options.baseUrl?.trim();
+  if (baseUrl) {
+    return `${trimTrailingSlash(baseUrl)}${PROVIDER_PLUGIN_MANIFEST_PATH}`;
+  }
+
+  const host = process.env.HOST || "127.0.0.1";
+  const port = process.env.PORT || process.env.DASHBOARD_PORT || process.env.API_PORT || "20128";
+  const protocol = process.env.OMNIROUTE_PUBLIC_PROTOCOL || "http";
+  return `${protocol}://${host}:${port}${PROVIDER_PLUGIN_MANIFEST_PATH}`;
+}
+
+export async function fetchProviderPluginManifest(
+  options: ProviderPluginManifestClientOptions = {},
+): Promise<ProviderPluginManifest> {
+  const fetcher = options.fetchImpl ?? fetch;
+  const url = resolveProviderPluginManifestUrl(options);
+  const response = await fetcher(url, {
+    headers: { Accept: "application/json" },
+    signal: options.signal ?? undefined,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Provider plugin manifest request failed: HTTP ${response.status}`);
+  }
+
+  const manifest = (await response.json()) as ProviderPluginManifest;
+  if (manifest.schemaVersion !== 1 || !Array.isArray(manifest.providers)) {
+    throw new Error("Provider plugin manifest response is not schemaVersion 1");
+  }
+
+  return manifest;
+}
+
+export function getProviderPluginManifestEntryForModelFromManifest(
+  manifest: ProviderPluginManifest,
+  model: string | undefined,
+): ProviderPluginManifestEntry | null {
+  if (!model) return null;
+
+  const providerPrefix = model.includes("/") ? model.split("/", 1)[0] : "";
+  if (providerPrefix) {
+    const prefixed = manifest.providers.find(
+      (provider) => provider.id === providerPrefix || provider.alias === providerPrefix,
+    );
+    if (prefixed) return prefixed;
+  }
+
+  return manifest.providers.find((provider) =>
+    provider.models.some((candidate) => candidate.id === model),
+  ) ?? null;
+}
+
+export async function fetchProviderPluginManifestEntryForModel(
+  model: string | undefined,
+  options: ProviderPluginManifestClientOptions = {},
+): Promise<ProviderPluginManifestEntry | null> {
+  const manifest = await fetchProviderPluginManifest(options);
+  return getProviderPluginManifestEntryForModelFromManifest(manifest, model);
+}

--- a/tests/unit/provider-plugin-manifest-client.test.ts
+++ b/tests/unit/provider-plugin-manifest-client.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  fetchProviderPluginManifest,
+  fetchProviderPluginManifestEntryForModel,
+  getProviderPluginManifestEntryForModelFromManifest,
+  PROVIDER_PLUGIN_MANIFEST_ENV,
+  PROVIDER_PLUGIN_MANIFEST_PATH,
+  resolveProviderPluginManifestUrl,
+} from "../../open-sse/config/providerPluginManifestClient.ts";
+import type { ProviderPluginManifest } from "../../open-sse/config/providerPluginManifest.ts";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function restoreEnv() {
+  process.env = { ...ORIGINAL_ENV };
+}
+
+test.afterEach(() => {
+  restoreEnv();
+});
+
+test("provider plugin manifest client resolves explicit and env URLs first", () => {
+  process.env[PROVIDER_PLUGIN_MANIFEST_ENV] = "http://env.example/manifest";
+
+  assert.equal(
+    resolveProviderPluginManifestUrl({ manifestUrl: "http://explicit.example/manifest" }),
+    "http://explicit.example/manifest",
+  );
+  assert.equal(
+    resolveProviderPluginManifestUrl({ baseUrl: "http://local.example:20128/" }),
+    "http://env.example/manifest",
+  );
+});
+
+test("provider plugin manifest client resolves base and default local URLs", () => {
+  delete process.env[PROVIDER_PLUGIN_MANIFEST_ENV];
+  process.env.HOST = "0.0.0.0";
+  process.env.PORT = "20129";
+
+  assert.equal(
+    resolveProviderPluginManifestUrl({ baseUrl: "http://127.0.0.1:20128/" }),
+    `http://127.0.0.1:20128${PROVIDER_PLUGIN_MANIFEST_PATH}`,
+  );
+  assert.equal(
+    resolveProviderPluginManifestUrl(),
+    `http://0.0.0.0:20129${PROVIDER_PLUGIN_MANIFEST_PATH}`,
+  );
+});
+
+test("provider plugin manifest client fetches and validates schemaVersion 1", async () => {
+  const manifest: ProviderPluginManifest = {
+    schemaVersion: 1,
+    generatedFrom: "open-sse/config/providers",
+    providers: [],
+  };
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl: typeof fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response(JSON.stringify(manifest), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  const result = await fetchProviderPluginManifest({
+    manifestUrl: "http://sidecar.local/manifest",
+    fetchImpl,
+  });
+
+  assert.deepEqual(result, manifest);
+  assert.equal(calls[0]?.url, "http://sidecar.local/manifest");
+  assert.equal((calls[0]?.init?.headers as Record<string, string>).Accept, "application/json");
+});
+
+test("provider plugin manifest client rejects failed HTTP and malformed responses", async () => {
+  await assert.rejects(
+    fetchProviderPluginManifest({
+      manifestUrl: "http://sidecar.local/manifest",
+      fetchImpl: async () => new Response("nope", { status: 503 }),
+    }),
+    /HTTP 503/,
+  );
+
+  await assert.rejects(
+    fetchProviderPluginManifest({
+      manifestUrl: "http://sidecar.local/manifest",
+      fetchImpl: async () => new Response(JSON.stringify({ providers: [] }), { status: 200 }),
+    }),
+    /schemaVersion 1/,
+  );
+});
+
+test("provider plugin manifest client resolves model entries from fetched manifests", async () => {
+  const manifest: ProviderPluginManifest = {
+    schemaVersion: 1,
+    generatedFrom: "open-sse/config/providers",
+    providers: [
+      {
+        id: "anthropic",
+        alias: "claude",
+        format: "anthropic",
+        executor: "default",
+        auth: { type: "apikey", header: "x-api-key" },
+        endpoints: { baseUrl: "https://api.anthropic.com" },
+        capabilities: ["apikey", "sidecar-candidate"],
+        passthroughModels: false,
+        models: [{ id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6" }],
+        sidecar: { eligible: true, reasons: [] },
+      },
+      {
+        id: "openai",
+        format: "openai",
+        executor: "default",
+        auth: { type: "apikey", header: "Authorization", prefix: "Bearer" },
+        endpoints: { baseUrl: "https://api.openai.com/v1" },
+        capabilities: ["apikey", "sidecar-candidate"],
+        passthroughModels: false,
+        models: [{ id: "gpt-4.1", name: "GPT-4.1" }],
+        sidecar: { eligible: true, reasons: [] },
+      },
+    ],
+  };
+  const fetchImpl: typeof fetch = async () =>
+    new Response(JSON.stringify(manifest), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  assert.equal(
+    getProviderPluginManifestEntryForModelFromManifest(manifest, "openai/gpt-4.1")?.id,
+    "openai",
+  );
+  assert.equal(
+    getProviderPluginManifestEntryForModelFromManifest(manifest, "claude/claude-sonnet-4.6")?.id,
+    "anthropic",
+  );
+  assert.equal(
+    getProviderPluginManifestEntryForModelFromManifest(manifest, "gpt-4.1")?.id,
+    "openai",
+  );
+  assert.equal(
+    await fetchProviderPluginManifestEntryForModel("missing-model", {
+      manifestUrl: "http://sidecar.local/manifest",
+      fetchImpl,
+    }),
+    null,
+  );
+});


### PR DESCRIPTION
Ports upstream diegosouzapw/OmniRoute#6042 `feat(sidecar): add provider manifest client` as a self-contained follow-up.

## What
Adds `open-sse/config/providerPluginManifestClient.ts` — an HTTP client for the read-only provider plugin manifest (`GET /api/v1/provider-plugin-manifest`, introduced by the manifest system in #253) so sidecars/relays discover providers over the network instead of hard-coding the route.

- `resolveProviderPluginManifestUrl` — resolution order: explicit `manifestUrl` → `OMNIROUTE_PROVIDER_MANIFEST_URL` env → `baseUrl` → local OmniRoute API default (`HOST`/`PORT`).
- `fetchProviderPluginManifest` — fetch + `schemaVersion === 1` / `providers` array validation; throws on non-OK HTTP or malformed body.
- `getProviderPluginManifestEntryForModelFromManifest` / `fetchProviderPluginManifestEntryForModel` — model→provider lookup by `provider/` prefix, alias, then model id.

## Files (3)
- `open-sse/config/providerPluginManifestClient.ts` (new, 87 lines)
- `tests/unit/provider-plugin-manifest-client.test.ts` (new, 5 tests)
- `docs/reference/PROVIDER_PLUGIN_MANIFEST.md` (keep-both merge: retains the existing `X-OmniRoute-Provider-Manifest-Url` header-advertising paragraph AND adds the new client-usage guidance)

## Excluded (branch-drift noise)
The upstream 3-dot diff carried two unrelated changes that do not belong to the sidecar client; both reverted to base:
- `tests/unit/translator-openai-responses-req.test.ts` → `-chat.test.ts` rename (446-line translator test churn).
- `scripts/ci/should-promote-latest.sh` (CI release-promotion regex hardening).

The upstream diff also touched `route.ts`, `API_REFERENCE.md`, `stryker.conf.json`, and the route test — those already match main (landed via the #253/#261 manifest system) so the patch was a no-op there.

## Verification
- `node --import tsx/esm --test tests/unit/provider-plugin-manifest-client.test.ts` → 5/5 pass.
- `npm run typecheck:core` → clean (0 errors). Manifest type fields (`id`/`alias`/`schemaVersion`/`models[].id`) verified present on main — no fork divergence.