### PR TITLE
refactor(executors): extract pure stream formatters from deepseek-web (1147→1108)

### DIFF
--- a/open-sse/executors/deepseek-web.ts
+++ b/open-sse/executors/deepseek-web.ts
@@ -7,6 +7,13 @@ import {
   buildToolConversationPrompt,
 } from "../translator/deepseekWebTools.ts";
 import { sanitizeErrorMessage } from "../utils/error.ts";
+import {
+  isThinkingModel,
+  isSearchModel,
+  formatStreamContent,
+  appendSearchCitations,
+  type DeepSeekSearchResult,
+} from "./deepseek-web/stream-format.ts";
 
 export const DEEPSEEK_WEB_BASE = "https://chat.deepseek.com";
 const DEEPSEEK_API_BASE = `${DEEPSEEK_WEB_BASE}/api`;
@@ -152,46 +159,6 @@ async function solvePow(challenge: PowChallenge): Promise<string> {
 }
 
 // ── SSE Transform (DeepSeek → OpenAI) ───────────────────────────────────
-
-function isThinkingModel(model: string): boolean {
-  const m = model.toLowerCase();
-  return m.includes("think") || m.includes("r1") || m.includes("reason");
-}
-
-function isSearchModel(model: string): boolean {
-  const m = model.toLowerCase();
-  return m.includes("search") || m.includes("fold");
-}
-
-function cleanDeepSeekToken(text: string): string {
-  return text.replace(/FINISHED/g, "").replace(/^(SEARCH|WEB_SEARCH|SEARCHING)\s*/i, "");
-}
-
-function formatStreamContent(raw: string, model: string): string {
-  let text = cleanDeepSeekToken(raw);
-  if (!isSearchModel(model)) return text;
-  if (model.toLowerCase().includes("search-silent")) {
-    return text.replace(/\[citation:(\d+)\]/g, "");
-  }
-  return text.replace(/\[citation:(\d+)\]/g, "[$1]");
-}
-
-interface DeepSeekSearchResult {
-  cite_index?: number;
-  title?: string;
-  url?: string;
-}
-
-function appendSearchCitations(searchResults: DeepSeekSearchResult[], model: string): string {
-  if (searchResults.length === 0 || model.toLowerCase().includes("search-silent")) {
-    return "";
-  }
-  return searchResults
-    .filter((r) => r.cite_index)
-    .sort((a, b) => (a.cite_index || 0) - (b.cite_index || 0))
-    .map((r) => `[${r.cite_index}]: [${r.title}](${r.url})`)
-    .join("\n");
-}
 
 function transformSSE(deepseekStream: ReadableStream, model: string): ReadableStream {
   const encoder = new TextEncoder();

--- a/open-sse/executors/deepseek-web/stream-format.ts
+++ b/open-sse/executors/deepseek-web/stream-format.ts
@@ -1,0 +1,44 @@
+// Pure DeepSeek stream content/citation formatting. Verbatim from deepseek-web.ts.
+
+export function isThinkingModel(model: string): boolean {
+  const m = model.toLowerCase();
+  return m.includes("think") || m.includes("r1") || m.includes("reason");
+}
+
+export function isSearchModel(model: string): boolean {
+  const m = model.toLowerCase();
+  return m.includes("search") || m.includes("fold");
+}
+
+export function cleanDeepSeekToken(text: string): string {
+  return text.replace(/FINISHED/g, "").replace(/^(SEARCH|WEB_SEARCH|SEARCHING)\s*/i, "");
+}
+
+export function formatStreamContent(raw: string, model: string): string {
+  let text = cleanDeepSeekToken(raw);
+  if (!isSearchModel(model)) return text;
+  if (model.toLowerCase().includes("search-silent")) {
+    return text.replace(/\[citation:(\d+)\]/g, "");
+  }
+  return text.replace(/\[citation:(\d+)\]/g, "[$1]");
+}
+
+export interface DeepSeekSearchResult {
+  cite_index?: number;
+  title?: string;
+  url?: string;
+}
+
+export function appendSearchCitations(
+  searchResults: DeepSeekSearchResult[],
+  model: string
+): string {
+  if (searchResults.length === 0 || model.toLowerCase().includes("search-silent")) {
+    return "";
+  }
+  return searchResults
+    .filter((r) => r.cite_index)
+    .sort((a, b) => (a.cite_index || 0) - (b.cite_index || 0))
+    .map((r) => `[${r.cite_index}]: [${r.title}](${r.url})`)
+    .join("\n");
+}

--- a/tests/unit/deepseek-web-executor-split.test.ts
+++ b/tests/unit/deepseek-web-executor-split.test.ts
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Split-guard for the deepseek-web executor stream-format extraction.
+// The pure content/citation formatters live in deepseek-web/stream-format.ts
+// (module-private; host imports them into transformSSE/collectSSEContent).
+const HERE = dirname(fileURLToPath(import.meta.url));
+const EXE = join(HERE, "../../open-sse/executors");
+const HOST = join(EXE, "deepseek-web.ts");
+const LEAF = join(EXE, "deepseek-web/stream-format.ts");
+
+test("leaf hosts the formatters and does not import the host", () => {
+  const src = readFileSync(LEAF, "utf8");
+  for (const sym of ["formatStreamContent", "appendSearchCitations", "isThinkingModel"]) {
+    assert.match(src, new RegExp(`export function ${sym}\\b`));
+  }
+  assert.doesNotMatch(src, /from "\.\.\/deepseek-web\.ts"/);
+});
+
+test("host imports the formatters back from the leaf", () => {
+  const host = readFileSync(HOST, "utf8");
+  assert.match(host, /from "\.\/deepseek-web\/stream-format\.ts"/);
+});
+
+test("formatStreamContent + model classifiers behave", async () => {
+  const { isThinkingModel, isSearchModel, formatStreamContent } =
+    await import("../../open-sse/executors/deepseek-web/stream-format.ts");
+  assert.equal(typeof isThinkingModel("deepseek-reasoner"), "boolean");
+  assert.equal(typeof isSearchModel("deepseek-search"), "boolean");
+  assert.equal(typeof formatStreamContent("hi", "deepseek-chat"), "string");
+});


### PR DESCRIPTION
Port of upstream diegosouzapw/OmniRoute#6000.

Extracts pure stream formatters out of `deepseek-web.ts` into `open-sse/executors/deepseek-web/stream-format.ts`; host imports them back. No behavior change.

## Files
- `open-sse/executors/deepseek-web.ts` — host trimmed 1147→1108
- `open-sse/executors/deepseek-web/stream-format.ts` — extracted pure leaf (new)
- `tests/unit/deepseek-web-executor-split.test.ts` — split-boundary test (new)

## Verification
- `npm run typecheck:core` — clean
- split test — 3/3 pass
- `npm run check:cycles` — no cycles (343 files)