### PR TITLE
perf(db): batch/memoize combo-path DB lookups (N+1 elimination)

### DIFF
--- a/src/lib/db/apiKeyGroups.ts
+++ b/src/lib/db/apiKeyGroups.ts
@@ -276,6 +276,87 @@ export function checkKeyModelAccess(
   return { allowed: false, matchedRules: permissions, deniedBy: null };
 }
 
+/**
+ * Batch access check for multiple (keyId, model) pairs in a single pass.
+ * For each keyId, fetches its groups once and evaluates all models in-memory
+ * using the identical logic as checkKeyModelAccess — result[keyId][model]
+ * deep-equals checkKeyModelAccess(keyId, model, provider).
+ * Empty keyIds or empty models → nested empty maps, no throw.
+ */
+export function checkMultipleKeyModelAccess(
+  keyIds: string[],
+  models: string[],
+  provider?: string
+): Map<string, Map<string, ModelAccessCheck>> {
+  const outer = new Map<string, Map<string, ModelAccessCheck>>();
+  if (keyIds.length === 0 || models.length === 0) {
+    for (const keyId of keyIds) {
+      outer.set(keyId, new Map());
+    }
+    return outer;
+  }
+
+  const db = getDbInstance() as any;
+
+  for (const keyId of keyIds) {
+    const inner = new Map<string, ModelAccessCheck>();
+    outer.set(keyId, inner);
+
+    const groups = getKeyGroupsForApiKey(keyId);
+
+    if (groups.length === 0) {
+      // No groups → no restrictions; all models allowed
+      for (const model of models) {
+        inner.set(model, { allowed: true, matchedRules: [], deniedBy: null });
+      }
+      continue;
+    }
+
+    // Fetch all permissions for this key's groups in one query
+    const groupIds = groups.map((g) => g.id);
+    const placeholders = groupIds.map(() => "?").join(",");
+    const rules = db
+      .prepare(
+        `SELECT * FROM group_model_permissions WHERE group_id IN (${placeholders}) ORDER BY access_type ASC`
+      )
+      .all(...groupIds) as any[];
+    const permissions = rules.map(rowToPermission);
+
+    for (const model of models) {
+      // Deny rules first (take precedence)
+      const denyRules = permissions.filter(
+        (p) =>
+          p.accessType === "deny" &&
+          matchesModelPattern(p.modelPattern, model) &&
+          (!p.provider || p.provider === provider)
+      );
+
+      if (denyRules.length > 0) {
+        inner.set(model, { allowed: false, matchedRules: permissions, deniedBy: denyRules[0] });
+        continue;
+      }
+
+      // Allow rules
+      const allowRules = permissions.filter(
+        (p) =>
+          p.accessType === "allow" &&
+          matchesModelPattern(p.modelPattern, model) &&
+          (!p.provider || p.provider === provider)
+      );
+
+      if (allowRules.length > 0) {
+        inner.set(model, { allowed: true, matchedRules: permissions, deniedBy: null });
+        continue;
+      }
+
+      // No matching rules → restricted by group membership but no explicit allow
+      inner.set(model, { allowed: false, matchedRules: permissions, deniedBy: null });
+    }
+  }
+
+  return outer;
+}
+
 function matchesModelPattern(pattern: string, model: string): boolean {
   if (pattern === "*") return true;
   if (pattern.includes("*")) {

--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -7,7 +7,12 @@ import { v4 as uuidv4 } from "uuid";
 import { getDbInstance, rowToCamel } from "./core";
 import { backupDbFile } from "./backup";
 import { registerDbStateResetter } from "./stateReset";
-import { getKeyGroupsForApiKey, checkKeyModelAccess } from "./apiKeyGroups";
+import {
+  getKeyGroupsForApiKey,
+  checkKeyModelAccess,
+  checkMultipleKeyModelAccess,
+} from "./apiKeyGroups";
+export { checkMultipleKeyModelAccess } from "./apiKeyGroups";
 import { API_KEY_COLUMN_FALLBACKS } from "./apiKeyColumnFallbacks";
 import {
   appendUsageLimitUpdates,

--- a/src/lib/db/domainState.ts
+++ b/src/lib/db/domainState.ts
@@ -628,3 +628,77 @@ export function deleteAllCircuitBreakerStates() {
   const db = getDbInstance();
   db.prepare("DELETE FROM domain_circuit_breakers").run();
 }
+
+// ──────────────── Async-flush batch circuit-breaker writer ────────────────
+//
+// Callers that write CB state on every combo tick (5-20 writes per request)
+// can use queueCircuitBreakerState / flushCircuitBreakerStates to coalesce
+// those writes into a single transaction ~100ms later.
+//
+// saveCircuitBreakerState remains unchanged for callers that need immediate
+// persistence. These two APIs are strictly additive.
+
+const _cbQueue = new Map<string, CircuitBreakerStateRecord>();
+let _cbFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Queue a circuit breaker state update for async batch writing.
+ * Last-write-wins per name (same semantics as INSERT OR REPLACE).
+ * Schedules a flush ~100ms out if not already scheduled.
+ * The timer is unref()'d so it never prevents the process from exiting.
+ */
+export function queueCircuitBreakerState(name: string, cbState: CircuitBreakerStateRecord): void {
+  _cbQueue.set(name, cbState);
+
+  if (_cbFlushTimer === null) {
+    const timer = setTimeout(() => {
+      _cbFlushTimer = null;
+      flushCircuitBreakerStates();
+    }, 100);
+    // Allow the process to exit even if the timer hasn't fired yet.
+    if (typeof timer === "object" && timer !== null && typeof (timer as NodeJS.Timeout).unref === "function") {
+      (timer as NodeJS.Timeout).unref();
+    }
+    _cbFlushTimer = timer;
+  }
+}
+
+/**
+ * Synchronously drain the queue and persist all pending circuit breaker states
+ * inside a single SQLite transaction (one INSERT OR REPLACE per queued entry).
+ * The resulting rows are identical to having called saveCircuitBreakerState for
+ * each queued (name → latest state).
+ * Exported so combo completion / tests can force-flush without waiting.
+ */
+export function flushCircuitBreakerStates(): void {
+  if (_cbQueue.size === 0) return;
+
+  // Cancel a pending auto-flush timer — we're flushing now.
+  if (_cbFlushTimer !== null) {
+    clearTimeout(_cbFlushTimer);
+    _cbFlushTimer = null;
+  }
+
+  // Snapshot and clear before the transaction in case a queued re-entrant
+  // queueCircuitBreakerState call arrives mid-flight.
+  const snapshot = new Map(_cbQueue);
+  _cbQueue.clear();
+
+  const db = getDbInstance();
+  const stmt = db.prepare(
+    `INSERT OR REPLACE INTO domain_circuit_breakers (name, state, failure_count, last_failure_time, options)
+     VALUES (?, ?, ?, ?, ?)`
+  );
+
+  db.transaction(() => {
+    for (const [name, cbState] of snapshot) {
+      stmt.run(
+        name,
+        cbState.state,
+        cbState.failureCount,
+        cbState.lastFailureTime,
+        cbState.options ? JSON.stringify(cbState.options) : null
+      );
+    }
+  })();
+}

--- a/src/lib/db/models.ts
+++ b/src/lib/db/models.ts
@@ -444,6 +444,51 @@ export async function getAllSyncedAvailableModels(): Promise<
 }
 
 /**
+ * One-query accessor that returns synced available models grouped first by
+ * providerId, then by connectionId.
+ *
+ * result[providerId][connectionId] deep-equals
+ * getSyncedAvailableModelsByConnection(providerId)[connectionId]
+ * for every (providerId, connectionId) pair present in the store.
+ *
+ * Runs a single SELECT over the entire namespace instead of one query per
+ * provider, eliminating the N+1 pattern in the combo request path.
+ * Malformed JSON rows are skipped (same try/catch as getSyncedAvailableModelsByConnection).
+ */
+export async function getSyncedAvailableModelsGroupedByProviderConnection(): Promise<
+  Record<string, Record<string, SyncedAvailableModel[]>>
+> {
+  const db = getDbInstance();
+  const rows = db
+    .prepare("SELECT key, value FROM key_value WHERE namespace = 'syncedAvailableModels'")
+    .all();
+
+  const result: Record<string, Record<string, SyncedAvailableModel[]>> = {};
+
+  for (const row of rows) {
+    const { key, value } = getKeyValue(row);
+    if (!key || value === null) continue;
+
+    // Key format: '<providerId>:<connectionId>'  (providerId never contains ':')
+    const colonIdx = key.indexOf(":");
+    if (colonIdx === -1) continue;
+    const providerId = key.slice(0, colonIdx);
+    const connectionId = key.slice(colonIdx + 1);
+    if (!providerId || !connectionId) continue;
+
+    try {
+      const models = normalizeSyncedAvailableModels(JSON.parse(value));
+      if (!result[providerId]) result[providerId] = {};
+      result[providerId][connectionId] = models;
+    } catch {
+      // Ignore malformed legacy entries (same as getSyncedAvailableModelsByConnection).
+    }
+  }
+
+  return result;
+}
+
+/**
  * Replace the model list for a specific connection.
  * Key format: '<providerId>:<connectionId>'
  */

--- a/src/lib/db/providers.ts
+++ b/src/lib/db/providers.ts
@@ -76,6 +76,63 @@ export async function getProviderConnections(filter: JsonRecord = {}) {
   });
 }
 
+/**
+ * Batch fetch provider connections for multiple provider IDs in a single query.
+ * Returns a Map keyed by provider id; each value is the ordered connection list
+ * (same ORDER BY priority ASC, updated_at DESC as getProviderConnections).
+ * Providers with zero connections get an empty array.
+ * If providerIds is empty, returns an empty Map without querying the DB.
+ */
+export async function getProviderConnectionsByProviders(
+  providerIds: string[],
+  isActive?: boolean
+): Promise<Map<string, Awaited<ReturnType<typeof getProviderConnections>>>> {
+  if (providerIds.length === 0) return new Map();
+
+  const db = getDbInstance() as unknown as DbLike;
+
+  // Build named params @p0, @p1, ... for the IN clause
+  const paramNames = providerIds.map((_, i) => `@p${i}`);
+  const params: Record<string, unknown> = {};
+  providerIds.forEach((id, i) => {
+    params[`p${i}`] = id;
+  });
+
+  let sql = `SELECT * FROM provider_connections WHERE provider IN (${paramNames.join(",")})`;
+  if (isActive !== undefined) {
+    sql += " AND is_active = @isActive";
+    params.isActive = isActive ? 1 : 0;
+  }
+  sql += " ORDER BY priority ASC, updated_at DESC";
+
+  const rows = db.prepare(sql).all(params);
+
+  // Initialize map with empty arrays for all requested provider ids
+  const result = new Map<string, Awaited<ReturnType<typeof getProviderConnections>>>();
+  for (const pid of providerIds) {
+    result.set(pid, []);
+  }
+
+  for (const r of rows) {
+    const camelRow = rowToCamel(r);
+    const conn = decryptConnectionFields(
+      withNullableRateLimitOverrides(
+        withNullableQuotaWindowThresholds(
+          withNullableMaxConcurrent(cleanNulls(camelRow), camelRow),
+          camelRow
+        ),
+        camelRow
+      )
+    );
+    const pid = typeof conn.provider === "string" ? conn.provider : String(conn.provider ?? "");
+    if (result.has(pid)) {
+      result.get(pid)!.push(conn);
+    }
+  }
+
+  return result;
+}
+
 export async function getProviderConnectionById(id: string) {
   const db = getDbInstance() as unknown as DbLike;
   const row = db.prepare("SELECT * FROM provider_connections WHERE id = ?").get(id);

--- a/tests/unit/db-apikeygroups-batch.test.ts
+++ b/tests/unit/db-apikeygroups-batch.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for checkMultipleKeyModelAccess (batch access check).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-db-apikeygroups-batch-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const groupsDb = await import("../../src/lib/db/apiKeyGroups.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch {
+      await new Promise((r) => setTimeout(r, 50 * (attempt + 1)));
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  core.getDbInstance();
+}
+
+test.before(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  core.resetDbInstance();
+  try {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+test("batch result deep-equals looping checkKeyModelAccess for (key, model) pairs", async () => {
+  await resetStorage();
+
+  // Create a group with allow for gpt-4 and deny for claude-3
+  const group = groupsDb.createKeyGroup("TestGroup");
+  groupsDb.addGroupPermission(group.id, "gpt-4", "allow");
+  groupsDb.addGroupPermission(group.id, "claude-3", "deny");
+
+  // Create a key and add it to the group
+  // We'll fabricate a key id since apiKeyGroups only needs the id string
+  const keyId = "test-key-001";
+  groupsDb.addKeyToGroup(keyId, group.id);
+
+  const models = ["gpt-4", "claude-3", "gpt-3.5"];
+
+  const batch = groupsDb.checkMultipleKeyModelAccess([keyId], models);
+  const innerMap = batch.get(keyId)!;
+
+  for (const model of models) {
+    const single = groupsDb.checkKeyModelAccess(keyId, model);
+    const batchResult = innerMap.get(model)!;
+
+    assert.strictEqual(
+      batchResult.allowed,
+      single.allowed,
+      `allowed mismatch for model=${model}`
+    );
+    assert.strictEqual(
+      batchResult.deniedBy?.id ?? null,
+      single.deniedBy?.id ?? null,
+      `deniedBy mismatch for model=${model}`
+    );
+    assert.strictEqual(
+      batchResult.matchedRules.length,
+      single.matchedRules.length,
+      `matchedRules length mismatch for model=${model}`
+    );
+  }
+});
+
+test("key with no groups → all models allowed (same as checkKeyModelAccess)", async () => {
+  await resetStorage();
+
+  const keyId = "no-group-key";
+  const models = ["any-model", "another-model"];
+
+  const batch = groupsDb.checkMultipleKeyModelAccess([keyId], models);
+  for (const model of models) {
+    const batchResult = batch.get(keyId)!.get(model)!;
+    const single = groupsDb.checkKeyModelAccess(keyId, model);
+    assert.deepEqual(batchResult, single);
+  }
+});
+
+test("empty keyIds → empty outer map, no throw", async () => {
+  await resetStorage();
+  const result = groupsDb.checkMultipleKeyModelAccess([], ["gpt-4"]);
+  assert.strictEqual(result.size, 0);
+});
+
+test("empty models → inner map is empty for each key, no throw", async () => {
+  await resetStorage();
+  const result = groupsDb.checkMultipleKeyModelAccess(["some-key"], []);
+  assert.strictEqual(result.size, 1);
+  assert.strictEqual(result.get("some-key")!.size, 0);
+});

--- a/tests/unit/db-domainstate-cbbatch.test.ts
+++ b/tests/unit/db-domainstate-cbbatch.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for queueCircuitBreakerState + flushCircuitBreakerStates.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-db-cbbatch-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const ds = await import("../../src/lib/db/domainState.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch {
+      await new Promise((r) => setTimeout(r, 50 * (attempt + 1)));
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  core.getDbInstance();
+}
+
+test.before(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  // Force-flush any pending timer so the test runner can exit cleanly.
+  ds.flushCircuitBreakerStates();
+  core.resetDbInstance();
+  try {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+test("queue 3 states (including duplicate name), force-flush, assert last-write-wins", async () => {
+  await resetStorage();
+
+  const state1 = { state: "CLOSED", failureCount: 0, lastFailureTime: null };
+  const state2first = { state: "OPEN", failureCount: 3, lastFailureTime: 1000 };
+  const state2last = { state: "HALF_OPEN", failureCount: 1, lastFailureTime: 2000 };
+
+  ds.queueCircuitBreakerState("cb-a", state1);
+  ds.queueCircuitBreakerState("cb-b", state2first); // will be overwritten
+  ds.queueCircuitBreakerState("cb-b", state2last); // last write wins
+
+  // Nothing persisted yet (async)
+  assert.strictEqual(
+    ds.loadCircuitBreakerState("cb-a"),
+    null,
+    "should not be persisted before flush"
+  );
+
+  ds.flushCircuitBreakerStates();
+
+  const loadedA = ds.loadCircuitBreakerState("cb-a");
+  assert.ok(loadedA !== null, "cb-a should be persisted after flush");
+  assert.strictEqual(loadedA!.state, "CLOSED");
+  assert.strictEqual(loadedA!.failureCount, 0);
+
+  const loadedB = ds.loadCircuitBreakerState("cb-b");
+  assert.ok(loadedB !== null, "cb-b should be persisted after flush");
+  // last-write-wins: state2last
+  assert.strictEqual(loadedB!.state, "HALF_OPEN", "last-write-wins for duplicate name");
+  assert.strictEqual(loadedB!.failureCount, 1);
+  assert.strictEqual(loadedB!.lastFailureTime, 2000);
+
+  // Result must equal what saveCircuitBreakerState would have written
+  await resetStorage();
+  ds.saveCircuitBreakerState("cb-a", state1);
+  ds.saveCircuitBreakerState("cb-b", state2last);
+  const refA = ds.loadCircuitBreakerState("cb-a")!;
+  const refB = ds.loadCircuitBreakerState("cb-b")!;
+
+  // Re-flush the same states and compare
+  await resetStorage();
+  ds.queueCircuitBreakerState("cb-a", state1);
+  ds.queueCircuitBreakerState("cb-b", state2first);
+  ds.queueCircuitBreakerState("cb-b", state2last);
+  ds.flushCircuitBreakerStates();
+
+  assert.deepEqual(ds.loadCircuitBreakerState("cb-a"), refA);
+  assert.deepEqual(ds.loadCircuitBreakerState("cb-b"), refB);
+});
+
+test("auto-flush timer (~100ms) persists queued states", async () => {
+  await resetStorage();
+
+  const stateX = { state: "OPEN", failureCount: 5, lastFailureTime: 9999 };
+  ds.queueCircuitBreakerState("cb-auto", stateX);
+
+  // Should NOT be visible immediately
+  assert.strictEqual(ds.loadCircuitBreakerState("cb-auto"), null);
+
+  // Wait for auto-flush (~100ms + margin)
+  await new Promise((r) => setTimeout(r, 200));
+
+  const loaded = ds.loadCircuitBreakerState("cb-auto");
+  assert.ok(loaded !== null, "should be persisted after auto-flush timer fires");
+  assert.strictEqual(loaded!.state, "OPEN");
+  assert.strictEqual(loaded!.failureCount, 5);
+});
+
+test("flushCircuitBreakerStates is idempotent when queue is empty", async () => {
+  await resetStorage();
+  // Should not throw
+  ds.flushCircuitBreakerStates();
+  ds.flushCircuitBreakerStates();
+});

--- a/tests/unit/db-models-synced-grouped.test.ts
+++ b/tests/unit/db-models-synced-grouped.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for getSyncedAvailableModelsGroupedByProviderConnection.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-db-models-grouped-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch {
+      await new Promise((r) => setTimeout(r, 50 * (attempt + 1)));
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  core.getDbInstance();
+}
+
+test.before(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  core.resetDbInstance();
+  try {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+const MODEL_A = { id: "gpt-4", name: "GPT-4" };
+const MODEL_B = { id: "gpt-3.5", name: "GPT-3.5" };
+const MODEL_C = { id: "claude-3-opus", name: "Claude 3 Opus" };
+const MODEL_D = { id: "claude-3-haiku", name: "Claude 3 Haiku" };
+
+test("grouped result matches getSyncedAvailableModelsByConnection per provider", async () => {
+  await resetStorage();
+
+  // Seed 2 providers × 2 connections
+  await modelsDb.replaceSyncedAvailableModelsForConnection("openai", "conn-1", [MODEL_A]);
+  await modelsDb.replaceSyncedAvailableModelsForConnection("openai", "conn-2", [MODEL_B]);
+  await modelsDb.replaceSyncedAvailableModelsForConnection("anthropic", "conn-3", [MODEL_C]);
+  await modelsDb.replaceSyncedAvailableModelsForConnection("anthropic", "conn-4", [MODEL_D]);
+
+  const grouped = await modelsDb.getSyncedAvailableModelsGroupedByProviderConnection();
+
+  // Compare per-provider against getSyncedAvailableModelsByConnection
+  for (const providerId of ["openai", "anthropic"]) {
+    const singleResult = await modelsDb.getSyncedAvailableModelsByConnection(providerId);
+    const groupedForProvider = grouped[providerId] ?? {};
+
+    // Each connectionId bucket must match
+    for (const [connId, models] of Object.entries(singleResult)) {
+      assert.deepEqual(
+        groupedForProvider[connId],
+        models,
+        `provider=${providerId} connId=${connId} mismatch`
+      );
+    }
+
+    // No extra connectionIds in the grouped result
+    for (const connId of Object.keys(groupedForProvider)) {
+      assert.ok(
+        connId in singleResult,
+        `extra connId=${connId} in grouped that is not in singleResult for ${providerId}`
+      );
+    }
+  }
+});
+
+test("empty store → returns empty object", async () => {
+  await resetStorage();
+  const grouped = await modelsDb.getSyncedAvailableModelsGroupedByProviderConnection();
+  assert.deepEqual(grouped, {});
+});

--- a/tests/unit/db-providers-batch.test.ts
+++ b/tests/unit/db-providers-batch.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for getProviderConnectionsByProviders (batch N+1 eliminator).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-db-providers-batch-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (fs.existsSync(TEST_DATA_DIR)) {
+        fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+      }
+      break;
+    } catch {
+      await new Promise((r) => setTimeout(r, 50 * (attempt + 1)));
+    }
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  core.getDbInstance();
+}
+
+test.before(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  core.resetDbInstance();
+  try {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+test("batch result per provider equals looped single calls", async () => {
+  await resetStorage();
+
+  // Seed 2 providers × 2 connections each
+  await providersDb.createProviderConnection({
+    provider: "p1",
+    authType: "apikey",
+    name: "p1-conn-a",
+    apiKey: "k-p1a",
+    priority: 2,
+  });
+  await providersDb.createProviderConnection({
+    provider: "p1",
+    authType: "apikey",
+    name: "p1-conn-b",
+    apiKey: "k-p1b",
+    priority: 1,
+  });
+  await providersDb.createProviderConnection({
+    provider: "p2",
+    authType: "apikey",
+    name: "p2-conn-a",
+    apiKey: "k-p2a",
+    priority: 1,
+  });
+  await providersDb.createProviderConnection({
+    provider: "p2",
+    authType: "apikey",
+    name: "p2-conn-b",
+    apiKey: "k-p2b",
+    priority: 2,
+    isActive: false,
+  });
+
+  const batch = await providersDb.getProviderConnectionsByProviders(["p1", "p2"]);
+
+  const p1Single = await providersDb.getProviderConnections({ provider: "p1" });
+  const p2Single = await providersDb.getProviderConnections({ provider: "p2" });
+
+  // Batch result for p1 must equal single call result for p1
+  const batchP1 = batch.get("p1")!;
+  assert.deepEqual(batchP1, p1Single, "p1 batch should equal single-call result");
+
+  // Same for p2
+  const batchP2 = batch.get("p2")!;
+  assert.deepEqual(batchP2, p2Single, "p2 batch should equal single-call result");
+});
+
+test("isActive filter works the same in batch and single calls", async () => {
+  await resetStorage();
+
+  await providersDb.createProviderConnection({
+    provider: "pf1",
+    authType: "apikey",
+    name: "active-conn",
+    apiKey: "k-active",
+    isActive: true,
+  });
+  await providersDb.createProviderConnection({
+    provider: "pf1",
+    authType: "apikey",
+    name: "inactive-conn",
+    apiKey: "k-inactive",
+    isActive: false,
+  });
+
+  const batchActive = await providersDb.getProviderConnectionsByProviders(["pf1"], true);
+  const singleActive = await providersDb.getProviderConnections({ provider: "pf1", isActive: 1 });
+
+  assert.deepEqual(batchActive.get("pf1"), singleActive, "active filter should match");
+
+  const batchInactive = await providersDb.getProviderConnectionsByProviders(["pf1"], false);
+  const singleInactive = await providersDb.getProviderConnections({
+    provider: "pf1",
+    isActive: 0,
+  });
+  assert.deepEqual(batchInactive.get("pf1"), singleInactive, "inactive filter should match");
+});
+
+test("empty providerIds returns empty Map without error", async () => {
+  await resetStorage();
+  const result = await providersDb.getProviderConnectionsByProviders([]);
+  assert.ok(result instanceof Map, "should be a Map");
+  assert.strictEqual(result.size, 0, "empty input → empty Map");
+});
+
+test("requested provider with no connections returns empty array", async () => {
+  await resetStorage();
+  // seed one unrelated provider so DB is not empty
+  await providersDb.createProviderConnection({
+    provider: "existing",
+    authType: "apikey",
+    name: "conn",
+    apiKey: "k-existing",
+  });
+
+  const result = await providersDb.getProviderConnectionsByProviders(["nonexistent"]);
+  assert.ok(result.has("nonexistent"), "key should be present");
+  assert.deepEqual(result.get("nonexistent"), [], "zero connections → empty array");
+});


### PR DESCRIPTION
## What

Latency-only, behavior-preserving DB-layer batch/memoize primitives that eliminate N+1 lookups in the combo request path. Adds **new** db-module functions + tests only — existing functions and all callers are unchanged. `combo.ts` rewiring is intentionally deferred to the #51 owner (registry-pattern rewrite); this PR ships the primitives they call at the interface.

## Changes (all in `src/lib/db/`)

- **providers.ts** — `getProviderConnectionsByProviders(providerIds[], isActive?)`: single `WHERE provider IN (...)` query returning `Map<provider, connections[]>`, replacing one query per unique provider. Identical row-mapping pipeline + `ORDER BY priority ASC, updated_at DESC`.
- **apiKeyGroups.ts** — `checkMultipleKeyModelAccess(keyIds[], models[], provider?)`: fetches each key's group permissions once, evaluates all models in-memory with the identical deny-first/allow/default logic. Result deep-equals looping `checkKeyModelAccess`. Re-exported through `apiKeys.ts` alongside the existing `checkKeyModelAccess`.
- **models.ts** — `getSyncedAvailableModelsGroupedByProviderConnection()`: one `key_value` query grouped `provider → connection → models[]`, replacing per-provider `getSyncedAvailableModelsByConnection`.
- **domainState.ts** — `queueCircuitBreakerState()` / `flushCircuitBreakerStates()`: opt-in async-flush batch writer (last-write-wins per name, ~100ms unref'd timer, single `db.transaction()` drain). `saveCircuitBreakerState` unchanged for immediate-write callers.

## Behavior

All four are behavior-preserving — new batch results are byte-for-byte equivalent to the loop of single-call functions they replace. No existing function's behavior changes; no caller loop is rewired in this PR.

**Note:** the originally-scoped compression request-scoped cache was dropped — `getCompressionSettings()` already has a WeakRef + 5s-TTL module cache, so a second layer would be dead complexity.

## Tests

- `db-providers-batch.test.ts` — 4/4
- `db-apikeygroups-batch.test.ts` — 4/4
- `db-models-synced-grouped.test.ts` — 2/2
- `db-domainstate-cbbatch.test.ts` — 3/3

`typecheck:core` clean · `check:cycles` OK (no cycles, 343 files).