### PR TITLE
[codex] Add CLI model latency stats command

### DIFF
--- a/bin/cli/commands/usage.mjs
+++ b/bin/cli/commands/usage.mjs
@@ -51,6 +51,16 @@ const logsSchema = [
   { key: "status", header: "Status" },
 ];
 
+const modelLatencySchema = [
+  { key: "provider", header: "Provider", width: 18 },
+  { key: "model", header: "Model", width: 30 },
+  { key: "requests", header: "Reqs", formatter: (v) => (v != null ? v.toLocaleString() : "0") },
+  { key: "successRate", header: "Success", formatter: (v) => `${(Number(v) * 100).toFixed(1)}%` },
+  { key: "avgLatencyMs", header: "Avg", formatter: (v) => (v ? `${v}ms` : "-") },
+  { key: "p95LatencyMs", header: "P95", formatter: (v) => (v ? `${v}ms` : "-") },
+  { key: "latencyStdDev", header: "StdDev", formatter: (v) => (v ? `${v}ms` : "-") },
+];
+
 export function registerUsage(program) {
   const usage = program.command("usage").description(t("usage.description"));
 
@@ -105,6 +115,17 @@ export function registerUsage(program) {
     .description(t("usage.history.description"))
     .option("--limit <n>", t("usage.history.limit"), parseInt, 100)
     .action(runUsageHistory);
+
+  // model-latency-stats
+  usage
+    .command("model-latency-stats")
+    .description("Show rolling provider/model latency snapshots")
+    .option("--window-hours <n>", "Rolling window in hours", parseFloat, 24)
+    .option("--min-samples <n>", "Minimum samples per provider/model", parseInt, 1)
+    .option("--max-rows <n>", "Maximum usage rows to scan", parseInt, 10000)
+    .option("--provider <id>", "Filter by provider")
+    .option("--model <id>", "Filter by model")
+    .action(runUsageModelLatencyStats);
 
   // proxy-logs
   usage
@@ -239,6 +260,35 @@ export async function runUsageHistory(opts, cmd) {
   const data = await res.json();
   const rows = toArray(data.items ?? data.history ?? (Array.isArray(data) ? data : []));
   emit(rows, globalOpts, null);
+}
+
+export async function runUsageModelLatencyStats(opts, cmd) {
+  const globalOpts = cmd.optsWithGlobals();
+  const p = new URLSearchParams({
+    windowHours: String(opts.windowHours ?? 24),
+    minSamples: String(opts.minSamples ?? 1),
+    maxRows: String(opts.maxRows ?? 10000),
+  });
+  if (opts.provider) p.set("provider", opts.provider);
+  if (opts.model) p.set("model", opts.model);
+
+  const res = await fetchOrExit(`/api/usage/model-latency-stats?${p}`, globalOpts);
+  const data = await res.json();
+  const rows = toArray(data.entries ?? data.items ?? data).map((r) => ({
+    provider: r.provider ?? "",
+    model: r.model ?? "",
+    key: r.key ?? `${r.provider ?? ""}/${r.model ?? ""}`,
+    requests: r.totalRequests ?? r.requests ?? 0,
+    successfulRequests: r.successfulRequests ?? 0,
+    successRate: r.successRate ?? 0,
+    avgLatencyMs: r.avgLatencyMs ?? null,
+    p50LatencyMs: r.p50LatencyMs ?? null,
+    p95LatencyMs: r.p95LatencyMs ?? null,
+    p99LatencyMs: r.p99LatencyMs ?? null,
+    latencyStdDev: r.latencyStdDev ?? null,
+    windowHours: r.windowHours ?? data.windowHours,
+  }));
+  emit(rows, globalOpts, modelLatencySchema);
 }
 
 export async function runUsageProxyLogs(opts, cmd) {

--- a/tests/unit/cli-usage.test.ts
+++ b/tests/unit/cli-usage.test.ts
@@ -62,6 +62,28 @@ const HISTORY_DATA = { items: [{ id: "a", model: "gpt-4o", provider: "openai", c
 const PROXY_LOGS_DATA = {
   logs: [{ id: "p1", path: "/v1/chat/completions", method: "POST", status: 200 }],
 };
+const MODEL_LATENCY_DATA = {
+  windowHours: 24,
+  minSamples: 2,
+  maxRows: 10000,
+  count: 1,
+  entries: [
+    {
+      provider: "openai",
+      model: "gpt-4o",
+      key: "openai/gpt-4o",
+      totalRequests: 12,
+      successfulRequests: 11,
+      successRate: 11 / 12,
+      avgLatencyMs: 240,
+      p50LatencyMs: 220,
+      p95LatencyMs: 390,
+      p99LatencyMs: 410,
+      latencyStdDev: 35,
+      windowHours: 24,
+    },
+  ],
+};
 
 function makeResp(data: unknown, status = 200) {
   const obj = {
@@ -79,6 +101,8 @@ function makeResp(data: unknown, status = 200) {
 
 function mockFetch(overrides: Record<string, unknown> = {}) {
   return (url: string) => {
+    if (url.includes("/api/usage/model-latency-stats"))
+      return Promise.resolve(makeResp(overrides.modelLatency ?? MODEL_LATENCY_DATA));
     if (url.includes("/api/usage/analytics"))
       return Promise.resolve(makeResp(overrides.analytics ?? ANALYTICS_DATA));
     if (url.includes("/api/usage/budget"))
@@ -196,6 +220,44 @@ test("runUsageHistory exibe histórico", async () => {
   const parsed = JSON.parse(out);
   assert.ok(Array.isArray(parsed));
   assert.ok(parsed.length >= 1);
+});
+
+test("runUsageModelLatencyStats exibe snapshots e envia filtros", async () => {
+  let capturedUrl = "";
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = ((url: string) => {
+    capturedUrl = url;
+    return mockFetch()(url);
+  }) as any;
+
+  const { runUsageModelLatencyStats } = await import("../../bin/cli/commands/usage.mjs");
+  const cmd = { optsWithGlobals: () => ({ output: "json", quiet: true }) };
+  const out = await captureStdout(() =>
+    runUsageModelLatencyStats(
+      {
+        windowHours: 24,
+        minSamples: 2,
+        maxRows: 500,
+        provider: "openai",
+        model: "gpt-4o",
+      },
+      cmd as any
+    )
+  );
+
+  globalThis.fetch = origFetch;
+  const parsed = JSON.parse(out);
+  assert.ok(capturedUrl.includes("/api/usage/model-latency-stats?"));
+  assert.ok(capturedUrl.includes("windowHours=24"));
+  assert.ok(capturedUrl.includes("minSamples=2"));
+  assert.ok(capturedUrl.includes("maxRows=500"));
+  assert.ok(capturedUrl.includes("provider=openai"));
+  assert.ok(capturedUrl.includes("model=gpt-4o"));
+  assert.ok(Array.isArray(parsed));
+  assert.equal(parsed[0].provider, "openai");
+  assert.equal(parsed[0].model, "gpt-4o");
+  assert.equal(parsed[0].requests, 12);
+  assert.equal(parsed[0].p95LatencyMs, 390);
 });
 
 test("runBudgetSet envia POST com amount, scope e period", async () => {


### PR DESCRIPTION
## Summary
- add `usage model-latency-stats` CLI command for the model latency stats API introduced in upstream PR #6141
- pass window/sample/row/provider/model filters through to `/api/usage/model-latency-stats`
- normalize response rows for JSON/table/CSV output
- cover the command with the existing CLI usage unit test harness

## Stack
- Depends on diegosouzapw/OmniRoute#6141 (`codex/model-latency-stats-api`)
- Keep stacked until #6141 lands, then retarget or rebase onto upstream release branch

## Tests
- `npx --yes --package prettier prettier --check bin\cli\commands\usage.mjs tests\unit\cli-usage.test.ts`
- `node --max-old-space-size=8192 --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit tests/unit/cli-usage.test.ts`