### PR TITLE
feat(tokn): scaffold Rust routing substrate (WP-T1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["crates/*"]
+resolver = "2"

--- a/crates/tokn/Cargo.toml
+++ b/crates/tokn/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tokn"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Tokn: canonical Rust routing substrate for OmniRoute (ADR-001)"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"

--- a/crates/tokn/docs/FFI_CONTRACT.md
+++ b/crates/tokn/docs/FFI_CONTRACT.md
@@ -1,0 +1,71 @@
+# Tokn ↔ TS FFI Contract (WP-T1 → WP-T2)
+
+This document defines the boundary between the Rust substrate (`crates/tokn/`)
+and the TypeScript engine. The TS engine talks to Tokn via **napi-rs** (Rust →
+Node add-on) over a single synchronous entry point.
+
+## Single entry point
+
+```rust
+pub fn decide(&self, req: &RouteRequest) -> Result<RouteDecision, RoutingError>
+```
+
+`ParetoRouter::decide` is the only function called across the FFI. It:
+1. Asks the configured `RoutingPort` for a `RouteDecision`.
+2. Records the decision via the configured `LedgerPort`.
+3. Returns the decision (or a structured `RoutingError`).
+
+## Type mapping
+
+| Rust | TS (via napi-rs) | Notes |
+|---|---|---|
+| `RouteRequest` | `{ requestId, requestedModel, tenantId, policyTags }` | camelCase via serde rename |
+| `RouteDecision` | `{ requestId, provider, model, estCostMicrocents, estP99Ms }` | same |
+| `RoutingError` | discriminated union: `UnknownProvider \| PolicyDenied \| PricingStale \| Ledger` | `thiserror` → `napi::Error` |
+| `LedgerSnapshot` | `{ windowStart, windowEnd, totalMicrocents, byTenant: TenantSpend[] }` | read-only, returned on demand |
+
+All types are `Serialize + Deserialize` so the same struct crosses both the
+FFI boundary and the wire boundary (when the TS engine forwards decisions
+to a downstream billing service).
+
+## Latency budget
+
+- p99 of `decide` end-to-end (FFI call + return) **must be ≤ 5 ms** on a
+  2024-class M-series MacBook Pro. Measured in WP-T2 with the
+  `benches/decide_bench.rs` harness.
+- The default `ParetoRouter` is sync. Async work (DB flush, network
+  pricing refresh) is the responsibility of the port implementation,
+  not the router.
+
+## FFI-safe boundary rules
+
+- **No async fn in port traits.** All port methods are sync. Async
+  work is hidden inside the implementation.
+- **No panics across the boundary.** Port implementations must
+  convert errors to `RoutingError`. `Result::unwrap` / `expect` are
+  banned in the FFI surface.
+- **No raw pointers or lifetime parameters in public types.** All
+  public types are owned, `Clone`, and `'static`.
+- **No global mutable state.** `ParetoRouter` is constructed once
+  per process and shared via `Arc`.
+
+## Threading
+
+- The `ParetoRouter` is `Send + Sync` and intended to be cloned across
+  worker threads. Internal `Mutex` use in port implementations is
+  fine; do not block on cross-process locks.
+- napi-rs's `ThreadsafeFunction` is the preferred way to call back
+  into TS (e.g. for event recording). The default impl uses an
+  in-memory port; a production impl will bridge to the TS-side
+  event recorder via `ThreadsafeFunction::call`.
+
+## Migration path
+
+1. **WP-T1 (this WP)**: scaffold the crate + ports + default in-memory
+   adapters. Land as a separate Cargo workspace. `cargo test` green.
+2. **WP-T2 (next)**: add napi-rs binding exposing `ParetoRouter::decide`
+   to TS. Wire the TS engine's `combo.ts` cost-aware routing to call
+   it. Latency benchmark in `benches/decide_bench.rs`.
+3. **WP-T3**: production `RoutingPort` impl that consults the real
+   provider catalog and per-tenant policy. Replace the stub.
+

--- a/crates/tokn/src/cost/ledger.rs
+++ b/crates/tokn/src/cost/ledger.rs
@@ -1,0 +1,26 @@
+// A single ledger entry: one routed call's cost in micro-cents.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LedgerEntry {
+    pub request_id: String,
+    pub tenant_id: String,
+    pub provider: String,
+    pub model: String,
+    pub cost_microcents: u64,
+    pub ts_unix_ms: u64,
+}
+
+/// An aggregate snapshot: total spend per tenant over a window.
+/// Returned to the TS engine for budget enforcement.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LedgerSnapshot {
+    pub window_start_unix_ms: u64,
+    pub window_end_unix_ms: u64,
+    pub total_microcents: u64,
+    pub by_tenant: Vec<TenantSpend>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct TenantSpend {
+    pub tenant_id: String,
+    pub total_microcents: u64,
+}

--- a/crates/tokn/src/cost/mod.rs
+++ b/crates/tokn/src/cost/mod.rs
@@ -1,0 +1,7 @@
+// Cost ledger: per-call entries plus an aggregate snapshot for
+// budget / quota enforcement. The TS engine reads the snapshot
+// over FFI; the entries are flushed in batches by the ledger port.
+
+mod ledger;
+
+pub use ledger::{LedgerEntry, LedgerSnapshot, TenantSpend};

--- a/crates/tokn/src/lib.rs
+++ b/crates/tokn/src/lib.rs
@@ -1,0 +1,10 @@
+// Tokn: canonical Rust routing substrate for OmniRoute (ADR-001).
+//
+// Public API re-exports. Consumers (TS via napi-rs, or other Rust
+// binaries in the OmniRoute workspace) interact through these.
+
+pub mod pareto_router;
+pub mod cost;
+
+pub use pareto_router::{ParetoRouter, RoutingPort, CostPort, LedgerPort, RouteRequest, RouteDecision};
+pub use cost::{LedgerEntry, LedgerSnapshot};

--- a/crates/tokn/src/pareto_router/adapters.rs
+++ b/crates/tokn/src/pareto_router/adapters.rs
@@ -1,0 +1,37 @@
+// Default adapter wiring: a `ParetoRouter` composes a `RoutingPort`,
+// a `CostPort`, and a `LedgerPort`. The ParetoRouter is the only
+// type the TS engine interacts with directly.
+
+use std::sync::Arc;
+
+use super::ports::{
+    CostPort, LedgerPort, LedgerOutcome, RouteDecision, RouteRequest, RoutingError, RoutingPort,
+};
+
+/// The composed router. Held in an `Arc` for cheap cloning across
+/// the FFI boundary.
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct ParetoRouter {
+    routing: Arc<dyn RoutingPort>,
+    cost: Arc<dyn CostPort>,
+    ledger: Arc<dyn LedgerPort>,
+}
+
+impl ParetoRouter {
+    pub fn new(
+        routing: Arc<dyn RoutingPort>,
+        cost: Arc<dyn CostPort>,
+        ledger: Arc<dyn LedgerPort>,
+    ) -> Self {
+        Self { routing, cost, ledger }
+    }
+
+    /// Resolve a routing request and record the decision.
+    /// This is the single FFI-exposed entry point.
+    pub fn decide(&self, req: &RouteRequest) -> Result<RouteDecision, RoutingError> {
+        let decision = self.routing.route(req)?;
+        self.ledger.record(&decision, LedgerOutcome::Success);
+        Ok(decision)
+    }
+}

--- a/crates/tokn/src/pareto_router/mod.rs
+++ b/crates/tokn/src/pareto_router/mod.rs
@@ -1,0 +1,11 @@
+// ParetoRouter: port + adapter pattern for routing decisions.
+//
+// `ports.rs` defines the trait surfaces. `adapters.rs` provides a
+// default synchronous impl. The TS engine calls into `ParetoRouter`
+// via napi-rs (see docs/FFI_CONTRACT.md).
+
+pub mod ports;
+pub mod adapters;
+
+pub use ports::{RoutingPort, CostPort, LedgerPort, RouteRequest, RouteDecision};
+pub use adapters::ParetoRouter;

--- a/crates/tokn/src/pareto_router/ports.rs
+++ b/crates/tokn/src/pareto_router/ports.rs
@@ -1,0 +1,76 @@
+// Port traits for the routing substrate. All traits are synchronous;
+// FFI callers (napi-rs) must not invoke these from an async context
+// without wrapping them in spawn_blocking. See docs/FFI_CONTRACT.md.
+
+use crate::cost::LedgerSnapshot;
+
+/// A single routing decision request from the TS engine.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RouteRequest {
+    /// Stable request id (echoed from the caller for log correlation).
+    pub request_id: String,
+    /// Logical model name as the user requested it.
+    pub requested_model: String,
+    /// Tenant id (workspace + user) the request belongs to.
+    pub tenant_id: String,
+    /// Per-tenant policy flags (cost ceiling, latency ceiling, etc).
+    #[serde(default)]
+    pub policy_tags: Vec<String>,
+}
+
+/// The routing decision returned to the caller.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RouteDecision {
+    pub request_id: String,
+    /// Resolved upstream provider id (e.g. "openai", "anthropic").
+    pub provider: String,
+    /// Resolved upstream model id (after alias / override resolution).
+    pub model: String,
+    /// Estimated cost in micro-cents at decision time.
+    pub est_cost_microcents: u64,
+    /// Estimated p99 latency at decision time, in milliseconds.
+    pub est_p99_ms: u32,
+}
+
+/// Provider-routing port. Implementations consult the provider
+/// catalog, apply per-tenant policy, and return a `RouteDecision`.
+pub trait RoutingPort: Send + Sync {
+    fn route(&self, req: &RouteRequest) -> Result<RouteDecision, RoutingError>;
+}
+
+/// Cost port. Implementations translate provider/model into a
+/// micro-cents estimate given the current pricing snapshot.
+pub trait CostPort: Send + Sync {
+    fn estimate(&self, provider: &str, model: &str) -> Result<u64, RoutingError>;
+    fn snapshot(&self) -> LedgerSnapshot;
+}
+
+/// Ledger port. Implementations persist decisions for audit /
+/// billing reconciliation. The default in-memory adapter is
+/// sufficient for unit tests; the production adapter will write
+/// to the TS-side SQLite (via the existing migration runner).
+pub trait LedgerPort: Send + Sync {
+    fn record(&self, decision: &RouteDecision, outcome: LedgerOutcome);
+    fn flush(&self) -> Result<(), RoutingError>;
+}
+
+/// Outcome of a routed call, recorded alongside the decision for
+/// downstream cost reconciliation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum LedgerOutcome {
+    Success,
+    Fallback,
+    Error,
+}
+
+#[derive(Debug, thiserror::Error, serde::Serialize, serde::Deserialize)]
+pub enum RoutingError {
+    #[error("unknown provider: {0}")]
+    UnknownProvider(String),
+    #[error("tenant policy denied: {0}")]
+    PolicyDenied(String),
+    #[error("pricing snapshot stale (last update {0:?})")]
+    PricingStale(Option<u64>),
+    #[error("ledger write failed: {0}")]
+    Ledger(String),
+}

--- a/crates/tokn/tests/integration_test.rs
+++ b/crates/tokn/tests/integration_test.rs
@@ -1,0 +1,96 @@
+// End-to-end test: stub RoutingPort + CostPort + LedgerPort,
+// wire them into a ParetoRouter, and verify a routing decision
+// flows through all three ports.
+
+use std::sync::{Arc, Mutex};
+
+use tokn::pareto_router::{adapters::ParetoRouter, ports::*, RouteRequest};
+use tokn::pareto_router::ports::RoutingError;
+use tokn::cost::{LedgerEntry, LedgerSnapshot, TenantSpend};
+
+#[derive(Default)]
+struct StubRouting {
+    decisions: Mutex<Vec<RouteDecision>>,
+}
+
+impl RoutingPort for StubRouting {
+    fn route(&self, req: &RouteRequest) -> Result<RouteDecision, RoutingError> {
+        let d = RouteDecision {
+            request_id: req.request_id.clone(),
+            provider: "openai".to_string(),
+            model: "gpt-4o".to_string(),
+            est_cost_microcents: 100,
+            est_p99_ms: 250,
+        };
+        self.decisions.lock().unwrap().push(d.clone());
+        Ok(d)
+    }
+}
+
+#[derive(Default)]
+struct StubCost;
+
+impl CostPort for StubCost {
+    fn estimate(&self, _provider: &str, _model: &str) -> Result<u64, RoutingError> {
+        Ok(100)
+    }
+    fn snapshot(&self) -> LedgerSnapshot {
+        LedgerSnapshot {
+            window_start_unix_ms: 0,
+            window_end_unix_ms: 0,
+            total_microcents: 0,
+            by_tenant: vec![],
+        }
+    }
+}
+
+#[derive(Default)]
+struct StubLedger {
+    entries: Mutex<Vec<LedgerEntry>>,
+}
+
+impl LedgerPort for StubLedger {
+    fn record(&self, decision: &RouteDecision, _outcome: LedgerOutcome) {
+        self.entries.lock().unwrap().push(LedgerEntry {
+            request_id: decision.request_id.clone(),
+            tenant_id: "t1".to_string(),
+            provider: decision.provider.clone(),
+            model: decision.model.clone(),
+            cost_microcents: decision.est_cost_microcents,
+            ts_unix_ms: 0,
+        });
+    }
+    fn flush(&self) -> Result<(), RoutingError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn end_to_end_route_flow() {
+    let router = ParetoRouter::new(
+        Arc::new(StubRouting::default()),
+        Arc::new(StubCost),
+        Arc::new(StubLedger::default()),
+    );
+    let req = RouteRequest {
+        request_id: "r1".to_string(),
+        requested_model: "gpt-4o".to_string(),
+        tenant_id: "t1".to_string(),
+        policy_tags: vec![],
+    };
+    let d = router.decide(&req).expect("route ok");
+    assert_eq!(d.provider, "openai");
+    assert_eq!(d.model, "gpt-4o");
+    assert_eq!(d.request_id, "r1");
+}
+
+#[test]
+fn snapshot_default_is_zero() {
+    let s = LedgerSnapshot::default();
+    assert_eq!(s.total_microcents, 0);
+    assert!(s.by_tenant.is_empty());
+    let _ = TenantSpend {
+        tenant_id: "t1".to_string(),
+        total_microcents: 0,
+    };
+}

--- a/phenotype-routing/README.md
+++ b/phenotype-routing/README.md
@@ -1,0 +1,23 @@
+# phenotype-routing (alias)
+
+This directory is the **alias entry point** for the canonical Rust
+routing substrate described by:
+
+- **ADR-001** (OmniRoute as canonical routing project) — accepted
+  2026-05-30. The `Tokn` repo migrates into `OmniRoute/crates/tokn/`.
+- **ADR-009** (naming collision resolution) — the old
+  `phenoRouterMonitor/crates/bifrost-routing` stub is deprecated.
+  Its path is preserved as `@deprecated` until the upstream projects
+  catch up.
+
+The actual crate lives at `crates/tokn/`. This README is the pointer
+document for cross-repo discoverability.
+
+## Why two names?
+
+- `Tokn` is the upstream repo name (KooshaPari/Tokn) and the
+  historical brand for the cost-ledger substrate.
+- `phenotype-routing` is the Phenotype-org-wide name for the
+  routing cluster, which now lives inside the OmniRoute workspace.
+
+Both names are valid; new code should import from `crates/tokn/`.


### PR DESCRIPTION
## Summary

WP-T1 of the Bifrost/Tokn Tier-1 integration track: scaffold the canonical Rust routing substrate per ADR-001.

## What's added

- `Cargo.toml` workspace root with `crates/*` membership
- `crates/tokn/` package (edition 2021, MIT)
  - `src/lib.rs` — public re-exports
  - `src/pareto_router/{mod,ports,adapters}.rs` — `ParetoRouter` + `RoutingPort`, `CostPort`, `LedgerPort` traits (sync-only)
  - `src/cost/{mod,ledger}.rs` — `LedgerEntry`, `LedgerSnapshot`, `TenantSpend`
  - `tests/integration_test.rs` — 2 tests (both pass)
- `crates/tokn/docs/FFI_CONTRACT.md` — TS↔Rust type map, ≤5 ms p99 budget, sync-only boundary rules, migration path to WP-T2
- `phenotype-routing/README.md` — alias doc (ADR-001 + ADR-009)

## Deps

Just `serde`, `serde_json`, `thiserror`. No `async-trait`, no `tokio`. Keeps the dep tree tiny per the AGENTS.md hard rules.

## Validation

- `cargo build` — clean (one `#[allow(dead_code)]` for the held `cost` field, intentional)
- `cargo test` — 2 passed, 0 failed

## Next

WP-T2 will add the napi-rs binding exposing `ParetoRouter::decide` to TS and wire the TS engine's `combo.ts` cost-aware routing to call it.

🤖 Generated with [Codex]