### PR TITLE
feat(bifrost): wire runWithShadowSampler inverse into chatCore dispatch (WP-B4)

### DIFF
--- a/open-sse/executors/bifrost.ts
+++ b/open-sse/executors/bifrost.ts
@@ -61,7 +61,7 @@ const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 8080;
 const DEFAULT_BASE_URL = `http://${DEFAULT_HOST}:${DEFAULT_PORT}`;
 const HEALTH_CHECK_TIMEOUT_MS = 5000;
-const BIFROST_TAG = "BIFROST";
+export const BIFROST_TAG = "BIFROST";
 
 /**
  * Resolve the Bifrost base URL. Reads from env, falls back to the

--- a/open-sse/executors/bifrostShadowWrap.ts
+++ b/open-sse/executors/bifrostShadowWrap.ts
@@ -1,0 +1,134 @@
+/**
+ * bifrostShadowWrap — WP-B4 helper.
+ *
+ * Wraps a Bifrost-routed executor so every Bifrost-routed request
+ * also fires a `legacyExecute` call in parallel and the result is
+ * compared via `computeAgreementScore`. The LIVE response returned
+ * to the caller is the BIFROST result. The legacy result is only
+ * used for divergence measurement.
+ *
+ * This is the INVERSE of the existing `runWithShadowSampler` in
+ * `bifrostShadow.ts`, which treats the chatCore executor (named
+ * `legacyExecute` for historical reasons) as the live path and
+ * Bifrost as the shadow. The B6 phase used that shape. The B7
+ * phase (5% → 100%) flips the live path to Bifrost.
+ *
+ * @module open-sse/executors/bifrostShadowWrap
+ */
+
+import { computeAgreementScore } from "./bifrostShadow.ts";
+import { BIFROST_TAG } from "./bifrost.ts";
+
+type ShadowWrapLogger = {
+  info?: (tag: string, msg: string) => void;
+  warn?: (tag: string, msg: string) => void;
+  error?: (tag: string, msg: string) => void;
+};
+
+export interface WrapBifrostExecutorWithShadowOptions {
+  provider: string;
+  log?: ShadowWrapLogger;
+  /**
+   * Legacy executor used as the shadow. Fires in parallel with the
+   * live Bifrost call. Required.
+   */
+  legacyExecute: (input: unknown) => Promise<unknown>;
+  /**
+   * Optional divergence event recorder. Defaults to no-op.
+   */
+  recordEvent?: (input: {
+    provider: string;
+    agreementScore: number;
+    tsUnixMs: number;
+  }) => void;
+  /**
+   * Optional disable flag. When true the wrapper forwards to the
+   * Bifrost executor without firing a shadow. Defaults to false.
+   */
+  disableShadow?: boolean;
+}
+
+export interface BifrostShadowWrapped<T> {
+  wrapped: T;
+  /**
+   * Stop firing shadow calls. Subsequent `.execute(input)` calls
+   * only invoke the Bifrost executor.
+   */
+  disable(): void;
+}
+
+/**
+ * Wrap a Bifrost executor with legacy-shadow sampling. The returned
+ * `wrapped` object exposes the same `.execute(input)` shape as the
+ * underlying Bifrost executor. The BifrostShadowWrapped envelope
+ * also exposes `disable()` for the kill switch.
+ */
+export function wrapBifrostExecutorWithShadow<
+  T extends { execute: (input: unknown) => Promise<unknown> }
+>(bifrost: T, opts: WrapBifrostExecutorWithShadowOptions): BifrostShadowWrapped<T> {
+  let shadowEnabled = !opts.disableShadow;
+  const wrapped: T = Object.create(bifrost);
+  wrapped.execute = async (input: unknown): Promise<unknown> => {
+    if (!shadowEnabled) {
+      opts.log?.info?.(BIFROST_TAG, `${opts.provider} → bifrost (shadow disabled)`);
+      return bifrost.execute(input);
+    }
+    opts.log?.info?.(
+      BIFROST_TAG,
+      `${opts.provider} → bifrost (live) + legacy (shadow), agree=pending`,
+    );
+    // Fire both in parallel. Bifrost is the live path; the legacy
+    // result is captured for divergence measurement only.
+    const livePromise = bifrost.execute(input);
+    const shadowPromise = opts.legacyExecute(input);
+    void Promise.allSettled([livePromise, shadowPromise]).then(([live, shadow]) => {
+      if (live.status !== "fulfilled" || shadow.status !== "fulfilled") return;
+      const liveText = extractText(live.value);
+      const shadowText = extractText(shadow.value);
+      if (liveText === null || shadowText === null) return;
+      const score = computeAgreementScore(liveText, shadowText);
+      opts.recordEvent?.({
+        provider: opts.provider,
+        agreementScore: score,
+        tsUnixMs: Date.now(),
+      });
+      if (score < 0.8) {
+        opts.log?.warn?.(
+          BIFROST_TAG,
+          `${opts.provider} bifrost/legacy divergence score=${score.toFixed(3)}`,
+        );
+      }
+    });
+    return livePromise;
+  };
+  return {
+    wrapped,
+    disable(): void {
+      shadowEnabled = false;
+    },
+  };
+}
+
+/** Best-effort text extraction from an executor output. */
+function extractText(out: unknown): string | null {
+  if (!out || typeof out !== "object") return null;
+  const o = out as { response?: { body?: unknown } };
+  const body = o.response?.body;
+  if (typeof body === "string") return body;
+  if (body && typeof body === "object") {
+    const b = body as { text?: unknown; content?: unknown };
+    if (typeof b.text === "string") return b.text;
+    if (Array.isArray(b.content)) {
+      return b.content
+        .map((c: unknown) => {
+          if (c && typeof c === "object" && "text" in c) {
+            const t = (c as { text?: unknown }).text;
+            return typeof t === "string" ? t : "";
+          }
+          return "";
+        })
+        .join("");
+    }
+  }
+  return null;
+}

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -2064,7 +2064,8 @@ export async function handleChatCore({
   // mode="cliproxyapi": returns the CLIProxyAPI executor instead.
   // mode="fallback": returns a wrapper that tries native first, falls back to CLIProxyAPI on 5xx/network errors.
 
-  const resolveExecutorWithProxy = (prov: string) => resolveExecutorWithProxyFor(prov, log);
+  const resolveExecutorWithProxy = (prov: string) =>
+    resolveExecutorWithProxyFor(prov, log, { providerSpecificData: credentials?.providerSpecificData });
 
   // === Quota Share enforcement PRE-hook (B/F7) ===
   // Runs after provider/model/credentials/apiKeyInfo are fully resolved,

--- a/open-sse/handlers/chatCore/executorProxy.ts
+++ b/open-sse/handlers/chatCore/executorProxy.ts
@@ -10,6 +10,11 @@
  */
 
 import { getExecutor } from "../../executors/index.ts";
+import {
+  shouldRouteViaBifrost,
+  createBifrostBackedExecutor,
+} from "../../executors/bifrost.ts";
+import { wrapBifrostExecutorWithShadow } from "../../executors/bifrostShadowWrap.ts";
 import { getCachedSettings } from "@/lib/db/readCache";
 import { getUpstreamProxyConfigCached } from "./comboContextCache.ts";
 
@@ -77,7 +82,24 @@ async function executeCliproxyapiMapped(
   return proxyExec.execute(await mapCliproxyapiInput(providerId, input, providerMapping));
 }
 
-export async function resolveExecutorWithProxy(prov: string, log?: LoggerLike) {
+export async function resolveExecutorWithProxy(
+  prov: string,
+  log?: LoggerLike,
+  opts?: { providerSpecificData?: { bifrostMode?: boolean | null } | null },
+) {
+  // WP-B4: Bifrost-as-primary with legacy shadow.
+  // Check before the proxy-config path so a provider that wants
+  // Bifrost routing gets it regardless of the proxy mode.
+  if (shouldRouteViaBifrost(prov, { providerSpecificData: opts?.providerSpecificData })) {
+    log?.info?.("BIFROST", `${prov} → BifrostBackendExecutor (Tier-1, shadow-wrapped)`);
+    const bifrost = createBifrostBackedExecutor(prov, log);
+    const wrapped = wrapBifrostExecutorWithShadow(bifrost, {
+      provider: prov,
+      log: log as unknown as { info?: (tag: string, msg: string) => void },
+      legacyExecute: (input) => getExecutor(prov).execute(input as never),
+    });
+    return wrapped.wrapped as unknown as Awaited<ReturnType<typeof getExecutor>>;
+  }
   const cfg = await getUpstreamProxyConfigCached(prov);
   if (!cfg.enabled || cfg.mode === "native") return getExecutor(prov);
 

--- a/tests/unit/bifrost-shadow-wiring.test.ts
+++ b/tests/unit/bifrost-shadow-wiring.test.ts
@@ -1,0 +1,97 @@
+/**
+ * bifrost-shadow-wiring.test — WP-B4.
+ *
+ * Verifies `wrapBifrostExecutorWithShadow` in `bifrostShadowWrap.ts`:
+ *  - happy path: bifrost+legacy agree → live = bifrost, no event
+ *  - divergence: bifrost+legacy disagree → live = bifrost, event with low score
+ *  - kill switch: disable() stops firing shadow calls
+ *  - extractText robustness: missing fields handled
+ *
+ * Uses node:test (per house style: `npm exec --yes tsx -- --test ...`).
+ */
+
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  wrapBifrostExecutorWithShadow,
+  type BifrostShadowWrapped,
+} from "../../open-sse/executors/bifrostShadowWrap.ts";
+
+interface ExecResult {
+  response: { body: { text: string } };
+}
+
+function makeExecutor(result: ExecResult) {
+  return {
+    execute: async () => result,
+  };
+}
+
+function tick(): Promise<void> {
+  return new Promise((r) => setImmediate(r));
+}
+
+test("returns the bifrost live result when bifrost+legacy agree", async () => {
+  const events: Array<{ provider: string; agreementScore: number }> = [];
+  const bifrost = makeExecutor({ response: { body: { text: "hello" } } });
+  const legacy = async () => ({ response: { body: { text: "hello" } } });
+  const w: BifrostShadowWrapped<typeof bifrost> = wrapBifrostExecutorWithShadow(
+    bifrost,
+    {
+      provider: "openai",
+      legacyExecute: legacy,
+      recordEvent: (e) => events.push({ provider: e.provider, agreementScore: e.agreementScore }),
+    },
+  );
+  const result = (await w.wrapped.execute({})) as ExecResult;
+  assert.equal(result.response.body.text, "hello");
+  await tick();
+  assert.equal(events.length, 1);
+  assert.ok(events[0].agreementScore > 0.9, `expected >0.9 got ${events[0].agreementScore}`);
+});
+
+test("returns bifrost live result even when legacy disagrees", async () => {
+  const events: Array<{ provider: string; agreementScore: number }> = [];
+  const bifrost = makeExecutor({ response: { body: { text: "BIFROST" } } });
+  const legacy = async () => ({ response: { body: { text: "LEGACY" } } });
+  const w = wrapBifrostExecutorWithShadow(bifrost, {
+    provider: "openai",
+    legacyExecute: legacy,
+    recordEvent: (e) => events.push({ provider: e.provider, agreementScore: e.agreementScore }),
+  });
+  const result = (await w.wrapped.execute({})) as ExecResult;
+  assert.equal(result.response.body.text, "BIFROST");
+  await tick();
+  assert.equal(events.length, 1);
+  assert.ok(events[0].agreementScore < 0.5, `expected <0.5 got ${events[0].agreementScore}`);
+});
+
+test("disable() stops firing shadow calls", async () => {
+  const events: Array<{ provider: string; agreementScore: number }> = [];
+  const bifrost = makeExecutor({ response: { body: { text: "x" } } });
+  const legacy = async () => ({ response: { body: { text: "x" } } });
+  const w = wrapBifrostExecutorWithShadow(bifrost, {
+    provider: "openai",
+    legacyExecute: legacy,
+    recordEvent: (e) => events.push({ provider: e.provider, agreementScore: e.agreementScore }),
+  });
+  w.disable();
+  await w.wrapped.execute({});
+  await tick();
+  assert.equal(events.length, 0);
+});
+
+test("handles missing response fields without throwing", async () => {
+  const events: Array<{ provider: string; agreementScore: number }> = [];
+  const bifrost = { execute: async () => ({ response: {} }) };
+  const legacy = async () => null;
+  const w = wrapBifrostExecutorWithShadow(bifrost, {
+    provider: "openai",
+    legacyExecute: legacy,
+    recordEvent: (e) => events.push({ provider: e.provider, agreementScore: e.agreementScore }),
+  });
+  const result = (await w.wrapped.execute({})) as { response: Record<string, unknown> };
+  assert.deepEqual(result.response, {});
+  await tick();
+  assert.equal(events.length, 0);
+});


### PR DESCRIPTION
## Summary

WP-B4: the actual Bifrost dispatch + shadow wiring in chatCore. This is the inverse of the B6 shape (Bifrost-as-shadow, legacy-as-live) — Bifrost becomes the production path; the legacy chatCore executor becomes the divergence check.

## What's added

- `open-sse/executors/bifrostShadowWrap.ts` (134 LOC): `wrapBifrostExecutorWithShadow(executor, opts)` that:
  - Fires the Bifrost executor (live) and the legacy executor (shadow) in parallel
  - Returns the Bifrost result to the caller
  - Scores the divergence via `computeAgreementScore` and emits an event
  - Exposes a `disable()` kill switch on the wrapped envelope
- `tests/unit/bifrost-shadow-wiring.test.ts` (4 tests, all pass):
  - happy-path: bifrost + legacy agree → live = bifrost, score > 0.9
  - divergence: bifrost = "BIFROST" / legacy = "LEGACY" → live = bifrost, score < 0.5
  - kill switch: `disable()` → no shadow call, no event
  - robustness: missing response fields → no event, no throw

## What's wired

- `open-sse/handlers/chatCore/executorProxy.ts`:
  - exported `resolveExecutorWithProxy` now accepts an optional `{ providerSpecificData }` arg
  - at the very top, before the proxy-config path: `if (shouldRouteViaBifrost(prov, opts)) { return wrapBifrostExecutorWithShadow(createBifrostBackedExecutor(prov, log), { provider: prov, log, legacyExecute: ... }).wrapped }`
- `open-sse/handlers/chatCore.ts`:
  - the `resolveExecutorWithProxy` call site now passes `credentials?.providerSpecificData` so the per-connection `bifrostMode` flag flows down
- `open-sse/executors/bifrost.ts`:
  - `BIFROST_TAG` is now exported (was a private const)

## Validation

- `npm run typecheck:core` — clean
- `oxlint` — 0 errors on touched files (20 pre-existing warnings in chatCore.ts unrelated to this change)
- `npm exec --yes tsx -- --test tests/unit/bifrost-shadow-wiring.test.ts` — **4 passed, 0 failed**

## Why now

- The Tier-1 Bifrost executor (`bifrost.ts`) and shadow sampler (`bifrostShadow.ts`) were already on main from prior work (PRs #98, #102, #192, #4781711c4) but the wiring into chatCore's executor-resolution path was missing.
- This PR is the actual production cut-over prep: when `BIFROST_ENABLED=1` is set (or per-connection `bifrostMode: true`), every chatCore request now routes through Bifrost with legacy as a divergence shadow.

🤖 Generated with [Codex]