### PR TITLE
feat(bifrost, cost, cascade): B7 traffic swap + S4 batched ledger + S7 cascade (WPs B7/S4/S7)

### DIFF
--- a/open-sse/executors/bifrostShadowWrap.ts
+++ b/open-sse/executors/bifrostShadowWrap.ts
@@ -13,11 +13,52 @@
  * Bifrost as the shadow. The B6 phase used that shape. The B7
  * phase (5% → 100%) flips the live path to Bifrost.
  *
+ * B7 traffic swap (WP-B7): the `BIFROST_TRAFFIC_PCT` env var (0-100)
+ * controls what percentage of Bifrost-routed requests actually use
+ * Bifrost as the live path. The remainder fall through to the
+ * legacy executor (Bifrost is the shadow). Decision is made on a
+ * deterministic hash of the request id so it is stable across
+ * retries; default is 100 (full Bifrost).
+ *
  * @module open-sse/executors/bifrostShadowWrap
  */
 
 import { computeAgreementScore } from "./bifrostShadow.ts";
 import { BIFROST_TAG } from "./bifrost.ts";
+
+/**
+ * Read the B7 traffic swap percentage from the environment.
+ * Defaults to 100 (full Bifrost). Returns a number in [0, 100].
+ *
+ * `BIFROST_TRAFFIC_PCT=0`   → 0% Bifrost (legacy always, Bifrost shadow only)
+ * `BIFROST_TRAFFIC_PCT=5`   → 5% canary
+ * `BIFROST_TRAFFIC_PCT=50`  → 50/50 split
+ * `BIFROST_TRAFFIC_PCT=100` → 100% Bifrost (default)
+ */
+function readBifrostTrafficPct(): number {
+  const raw = process.env.BIFROST_TRAFFIC_PCT;
+  if (raw === undefined || raw === "") return 100;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n)) return 100;
+  if (n < 0) return 0;
+  if (n > 100) return 100;
+  return n;
+}
+
+/**
+ * Deterministic 0-99 bucket for a request id. Stable across retries
+ * so a retried request keeps the same routing decision.
+ */
+function bucketForRequest(requestId: string | null | undefined): number {
+  const id = (requestId ?? "").trim() || "default";
+  // FNV-1a 32-bit hash, modulo 100.
+  let h = 0x811c9dc5;
+  for (let i = 0; i < id.length; i++) {
+    h ^= id.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return Math.abs(h) % 100;
+}
 
 type ShadowWrapLogger = {
   info?: (tag: string, msg: string) => void;
@@ -66,6 +107,7 @@ export interface BifrostShadowWrapped<T> {
 export function wrapBifrostExecutorWithShadow<
   T extends { execute: (input: unknown) => Promise<unknown> }
 >(bifrost: T, opts: WrapBifrostExecutorWithShadowOptions): BifrostShadowWrapped<T> {
+  const trafficPct = readBifrostTrafficPct();
   let shadowEnabled = !opts.disableShadow;
   const wrapped: T = Object.create(bifrost);
   wrapped.execute = async (input: unknown): Promise<unknown> => {
@@ -73,9 +115,35 @@ export function wrapBifrostExecutorWithShadow<
       opts.log?.info?.(BIFROST_TAG, `${opts.provider} → bifrost (shadow disabled)`);
       return bifrost.execute(input);
     }
+    // B7 traffic swap: roll the dice on the request id to decide
+    // whether Bifrost is the LIVE path or the SHADOW for this call.
+    const reqId = readRequestId(input);
+    const bucket = bucketForRequest(reqId);
+    const inBifrostLive = bucket < trafficPct;
+    if (!inBifrostLive) {
+      opts.log?.info?.(
+        BIFROST_TAG,
+        `${opts.provider} → legacy (live, B7 pct=${trafficPct}%) + bifrost (shadow)`,
+      );
+      const liveP = opts.legacyExecute(input);
+      const shadowP = bifrost.execute(input);
+      void Promise.allSettled([liveP, shadowP]).then(([live, shadow]) => {
+        if (live.status !== "fulfilled" || shadow.status !== "fulfilled") return;
+        const liveText = extractText(live.value);
+        const shadowText = extractText(shadow.value);
+        if (liveText === null || shadowText === null) return;
+        const score = computeAgreementScore(liveText, shadowText);
+        opts.recordEvent?.({
+          provider: opts.provider,
+          agreementScore: score,
+          tsUnixMs: Date.now(),
+        });
+      });
+      return liveP;
+    }
     opts.log?.info?.(
       BIFROST_TAG,
-      `${opts.provider} → bifrost (live) + legacy (shadow), agree=pending`,
+      `${opts.provider} → bifrost (live, B7 pct=${trafficPct}%) + legacy (shadow), agree=pending`,
     );
     // Fire both in parallel. Bifrost is the live path; the legacy
     // result is captured for divergence measurement only.
@@ -129,6 +197,17 @@ function extractText(out: unknown): string | null {
         })
         .join("");
     }
+  }
+  return null;
+}
+
+/** Best-effort extraction of a request id from a chatCore input shape. */
+function readRequestId(input: unknown): string | null {
+  if (!input || typeof input !== "object") return null;
+  const o = input as { requestId?: unknown; body?: { requestId?: unknown } };
+  if (typeof o.requestId === "string") return o.requestId;
+  if (o.body && typeof o.body === "object" && typeof (o.body as { requestId?: unknown }).requestId === "string") {
+    return (o.body as { requestId: string }).requestId;
   }
   return null;
 }

--- a/src/lib/db/costLedger.ts
+++ b/src/lib/db/costLedger.ts
@@ -1,0 +1,93 @@
+/**
+ * db/costLedger.ts — Batched cost-event ledger (WP-S4).
+ *
+ * Wraps the existing recordCostEvent in db/costTracking.ts with a
+ * configurable in-memory queue that flushes either when the row
+ * threshold is reached or the time threshold elapses, whichever
+ * comes first. Default: 100 rows or 1000 ms.
+ *
+ * Env knobs (per SOTA G4):
+ *   - OMNIROUTE_LEDGER_FLUSH_ROWS  (default 100, integer >= 1)
+ *   - OMNIROUTE_LEDGER_FLUSH_MS    (default 1000, integer >= 1)
+ *
+ * Failure mode: if the synchronous DB write throws inside the flush,
+ * the rows are dropped (the existing per-event write path still
+ * works for callers that need sync). The queue length is exposed
+ * via ledgerQueueDepth() for ops dashboards and tests.
+ */
+
+import { recordCostEvent, type RecordCostEventInput } from "./costTracking.ts";
+
+interface QueueEntry {
+  input: RecordCostEventInput;
+  enqueuedAtUnixMs: number;
+}
+
+let queue: QueueEntry[] = [];
+let timer: ReturnType<typeof setTimeout> | null = null;
+let flushing = false;
+
+function readFlushRows(): number {
+  const raw = process.env.OMNIROUTE_LEDGER_FLUSH_ROWS;
+  if (raw === undefined || raw === "") return 100;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return 100;
+  return n;
+}
+
+function readFlushMs(): number {
+  const raw = process.env.OMNIROUTE_LEDGER_FLUSH_MS;
+  if (raw === undefined || raw === "") return 1000;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return 1000;
+  return n;
+}
+
+export function enqueueCostEvent(input: RecordCostEventInput): void {
+  queue.push({ input, enqueuedAtUnixMs: Date.now() });
+  if (queue.length >= readFlushRows()) {
+    void flushCostLedger();
+  } else if (timer === null) {
+    const ms = readFlushMs();
+    timer = setTimeout(() => {
+      timer = null;
+      void flushCostLedger();
+    }, ms);
+  }
+}
+
+export async function flushCostLedger(): Promise<number> {
+  if (flushing) return 0;
+  if (queue.length === 0) return 0;
+  flushing = true;
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  const batch = queue;
+  queue = [];
+  let ok = 0;
+  for (const entry of batch) {
+    try {
+      recordCostEvent(entry.input);
+      ok += 1;
+    } catch {
+      // Drop on error; the next event will retry its own write.
+    }
+  }
+  flushing = false;
+  return ok;
+}
+
+export function ledgerQueueDepth(): number {
+  return queue.length;
+}
+
+export function _resetLedgerForTests(): void {
+  queue = [];
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  flushing = false;
+}

--- a/src/lib/routing/cascade.ts
+++ b/src/lib/routing/cascade.ts
@@ -1,0 +1,95 @@
+/**
+ * routing/cascade.ts — WP-S7: per-combo cascade routing.
+ *
+ * Given an ordered list of candidate (provider, model) pairs, tries
+ * each one in order, stopping at the first success. Two pre-check
+ * filters short-circuit candidates that would violate a per-request
+ * cost ceiling or the tenant's monthly USD cap.
+ *
+ * The cascade is the simplest viable "try the next provider on
+ * failure" pattern; richer strategies (weighted, cost-aware) live
+ * elsewhere (intelligentRouting.ts).
+ *
+ * @module open-sse/routing/cascade
+ */
+
+export interface CascadeCandidate {
+  provider: string;
+  model: string;
+  estCostUsd: number;
+}
+
+export interface CascadeContext {
+  requestId: string;
+  monthlyUsdSpent: number;
+  monthlyUsdCap: number | null;
+  perRequestUsdCap: number | null;
+}
+
+export type CascadeOutcome = "success" | "quota_exceeded" | "all_failed" | "cost_ceiling_exceeded";
+
+export interface CascadeAttempt {
+  provider: string;
+  model: string;
+  estCostUsd: number;
+  status: "skipped_quota" | "skipped_cost_ceiling" | "tried" | "succeeded" | "failed";
+  error?: string;
+}
+
+export interface CascadeResult {
+  outcome: CascadeOutcome;
+  selected?: CascadeCandidate;
+  attempts: CascadeAttempt[];
+  totalEstCostUsd: number;
+}
+
+export interface ExecuteFn {
+  (candidate: CascadeCandidate): Promise<{ ok: boolean; error?: string }>;
+}
+
+/**
+ * Run the cascade. The execute function is called per candidate in
+ * order. Pre-checks happen synchronously before execute is called.
+ */
+export async function cascadeRoute(
+  candidates: CascadeCandidate[],
+  ctx: CascadeContext,
+  execute: ExecuteFn,
+): Promise<CascadeResult> {
+  const attempts: CascadeAttempt[] = [];
+  let totalEstCostUsd = 0;
+  for (const c of candidates) {
+    if (ctx.monthlyUsdCap !== null && ctx.monthlyUsdSpent + c.estCostUsd > ctx.monthlyUsdCap) {
+      attempts.push({ provider: c.provider, model: c.model, estCostUsd: c.estCostUsd, status: "skipped_quota" });
+      continue;
+    }
+    if (ctx.perRequestUsdCap !== null && c.estCostUsd > ctx.perRequestUsdCap) {
+      attempts.push({ provider: c.provider, model: c.model, estCostUsd: c.estCostUsd, status: "skipped_cost_ceiling" });
+      continue;
+    }
+    let result;
+    try {
+      result = await execute(c);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      attempts.push({ provider: c.provider, model: c.model, estCostUsd: c.estCostUsd, status: "failed", error: msg });
+      continue;
+    }
+    if (result.ok) {
+      attempts.push({ provider: c.provider, model: c.model, estCostUsd: c.estCostUsd, status: "succeeded" });
+      totalEstCostUsd += c.estCostUsd;
+      return { outcome: "success", selected: c, attempts, totalEstCostUsd };
+    }
+    attempts.push({ provider: c.provider, model: c.model, estCostUsd: c.estCostUsd, status: "failed", error: result.error });
+  }
+  // An empty candidate list (nothing tried) is all_failed, not quota_exceeded.
+  if (attempts.length === 0) {
+    return { outcome: "all_failed", attempts, totalEstCostUsd };
+  }
+  const allSkipped = attempts.every((a) => a.status === "skipped_quota");
+  return {
+    outcome: allSkipped ? "quota_exceeded" : "all_failed",
+    attempts,
+    totalEstCostUsd,
+  };
+}

--- a/src/lib/routing/index.ts
+++ b/src/lib/routing/index.ts
@@ -1,0 +1,1 @@
+export * from "./cascade";

--- a/tests/unit/bifrost-traffic-swap.test.ts
+++ b/tests/unit/bifrost-traffic-swap.test.ts
@@ -1,0 +1,128 @@
+/**
+ * bifrost-traffic-swap.test — WP-B7.
+ *
+ * Verifies the `BIFROST_TRAFFIC_PCT` env var controls what percentage
+ * of Bifrost-routed requests use Bifrost as the live path:
+ *  - 0%   → 0 requests use Bifrost as live; all go to legacy
+ *  - 100% → 0 requests fall through; all use Bifrost as live
+ *  - 50%  → roughly half-and-half (deterministic by request id)
+ *  - decision is stable across calls with the same request id
+ */
+
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { wrapBifrostExecutorWithShadow } from "../../open-sse/executors/bifrostShadowWrap.ts";
+
+interface ExecResult { response: { body: { text: string } } }
+function makeExecutor(tag: string) {
+  return { execute: async () => ({ response: { body: { text: tag } } }) };
+}
+
+function tick(): Promise<void> { return new Promise((r) => setImmediate(r)); }
+
+test("BIFROST_TRAFFIC_PCT=0 routes 0% to Bifrost (legacy always live)", async () => {
+  const prev = process.env.BIFROST_TRAFFIC_PCT;
+  process.env.BIFROST_TRAFFIC_PCT = "0";
+  try {
+    const bifrost = makeExecutor("B");
+    const legacy = makeExecutor("L");
+    const w = wrapBifrostExecutorWithShadow(bifrost, {
+      provider: "openai",
+      legacyExecute: legacy.execute as never,
+    });
+    for (let i = 0; i < 20; i++) {
+      const r = (await w.wrapped.execute({ requestId: `r${i}` })) as ExecResult;
+      assert.equal(r.response.body.text, "L", `requestId=r${i} should route to legacy`);
+    }
+  } finally {
+    if (prev === undefined) delete process.env.BIFROST_TRAFFIC_PCT;
+    else process.env.BIFROST_TRAFFIC_PCT = prev;
+  }
+});
+
+test("BIFROST_TRAFFIC_PCT=100 routes 100% to Bifrost (Bifrost always live)", async () => {
+  const prev = process.env.BIFROST_TRAFFIC_PCT;
+  process.env.BIFROST_TRAFFIC_PCT = "100";
+  try {
+    const bifrost = makeExecutor("B");
+    const legacy = makeExecutor("L");
+    const w = wrapBifrostExecutorWithShadow(bifrost, {
+      provider: "openai",
+      legacyExecute: legacy.execute as never,
+    });
+    for (let i = 0; i < 20; i++) {
+      const r = (await w.wrapped.execute({ requestId: `r${i}` })) as ExecResult;
+      assert.equal(r.response.body.text, "B", `requestId=r${i} should route to Bifrost`);
+    }
+  } finally {
+    if (prev === undefined) delete process.env.BIFROST_TRAFFIC_PCT;
+    else process.env.BIFROST_TRAFFIC_PCT = prev;
+  }
+});
+
+test("BIFROST_TRAFFIC_PCT=50 splits roughly half", async () => {
+  const prev = process.env.BIFROST_TRAFFIC_PCT;
+  process.env.BIFROST_TRAFFIC_PCT = "50";
+  try {
+    const bifrost = makeExecutor("B");
+    const legacy = makeExecutor("L");
+    const w = wrapBifrostExecutorWithShadow(bifrost, {
+      provider: "openai",
+      legacyExecute: legacy.execute as never,
+    });
+    let bf = 0;
+    let lg = 0;
+    for (let i = 0; i < 200; i++) {
+      const r = (await w.wrapped.execute({ requestId: `req${i}` })) as ExecResult;
+      if (r.response.body.text === "B") bf++;
+      else lg++;
+    }
+    // Allow ±20% deviation around 50/50 — the FNV hash is uniform
+    // but the sample is small.
+    assert.ok(bf > 70 && bf < 130, `expected 70-130 bifrost, got ${bf}`);
+    assert.ok(lg > 70 && lg < 130, `expected 70-130 legacy, got ${lg}`);
+    assert.equal(bf + lg, 200);
+  } finally {
+    if (prev === undefined) delete process.env.BIFROST_TRAFFIC_PCT;
+    else process.env.BIFROST_TRAFFIC_PCT = prev;
+  }
+});
+
+test("decision is deterministic for the same request id", async () => {
+  const prev = process.env.BIFROST_TRAFFIC_PCT;
+  process.env.BIFROST_TRAFFIC_PCT = "50";
+  try {
+    const bifrost = makeExecutor("B");
+    const legacy = makeExecutor("L");
+    const w = wrapBifrostExecutorWithShadow(bifrost, {
+      provider: "openai",
+      legacyExecute: legacy.execute as never,
+    });
+    const first = (await w.wrapped.execute({ requestId: "stable-id-42" })) as ExecResult;
+    for (let i = 0; i < 5; i++) {
+      const r = (await w.wrapped.execute({ requestId: "stable-id-42" })) as ExecResult;
+      assert.equal(r.response.body.text, first.response.body.text, "decision must be stable");
+    }
+  } finally {
+    if (prev === undefined) delete process.env.BIFROST_TRAFFIC_PCT;
+    else process.env.BIFROST_TRAFFIC_PCT = prev;
+  }
+});
+
+test("default (no env var) is 100% Bifrost", async () => {
+  const prev = process.env.BIFROST_TRAFFIC_PCT;
+  delete process.env.BIFROST_TRAFFIC_PCT;
+  try {
+    const bifrost = makeExecutor("B");
+    const legacy = makeExecutor("L");
+    const w = wrapBifrostExecutorWithShadow(bifrost, {
+      provider: "openai",
+      legacyExecute: legacy.execute as never,
+    });
+    const r = (await w.wrapped.execute({ requestId: "default-test" })) as ExecResult;
+    assert.equal(r.response.body.text, "B");
+  } finally {
+    if (prev === undefined) delete process.env.BIFROST_TRAFFIC_PCT;
+    else process.env.BIFROST_TRAFFIC_PCT = prev;
+  }
+});

--- a/tests/unit/cascade-routing.test.ts
+++ b/tests/unit/cascade-routing.test.ts
@@ -1,0 +1,128 @@
+/**
+ * cascade-routing.test — WP-S7.
+ *
+ * Verifies the per-combo cascade:
+ *  - happy path: first candidate succeeds → returns success + that candidate
+ *  - fallback: first fails, second succeeds → returns second
+ *  - all fail: returns all_failed with no selection
+ *  - monthly quota: skips candidates that would exceed cap
+ *  - per-request cap: skips candidates that exceed per-request limit
+ *  - quota exceeded (all skipped): returns quota_exceeded outcome
+ *  - error from execute is caught and counted as failed
+ */
+
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  cascadeRoute,
+  type CascadeCandidate,
+  type CascadeContext,
+  type ExecuteFn,
+} from "../../src/lib/routing/cascade.ts";
+
+function mkCandidate(provider: string, model: string, estCostUsd: number): CascadeCandidate {
+  return { provider, model, estCostUsd };
+}
+
+const noCaps: CascadeContext = {
+  requestId: "r1",
+  monthlyUsdSpent: 0,
+  monthlyUsdCap: null,
+  perRequestUsdCap: null,
+};
+
+test("happy path: first candidate succeeds", async () => {
+  const candidates = [mkCandidate("openai", "gpt-4o", 0.01), mkCandidate("anthropic", "claude-3-5", 0.02)];
+  const execute: ExecuteFn = async (c) => c.provider === "openai" ? { ok: true } : { ok: false };
+  const r = await cascadeRoute(candidates, noCaps, execute);
+  assert.equal(r.outcome, "success");
+  assert.equal(r.selected?.provider, "openai");
+  assert.equal(r.attempts.length, 1);
+  assert.equal(r.attempts[0].status, "succeeded");
+  assert.equal(r.totalEstCostUsd, 0.01);
+});
+
+test("fallback: first fails, second succeeds", async () => {
+  const candidates = [mkCandidate("openai", "gpt-4o", 0.01), mkCandidate("anthropic", "claude-3-5", 0.02)];
+  const execute: ExecuteFn = async (c) => c.provider === "anthropic" ? { ok: true } : { ok: false, error: "rate limited" };
+  const r = await cascadeRoute(candidates, noCaps, execute);
+  assert.equal(r.outcome, "success");
+  assert.equal(r.selected?.provider, "anthropic");
+  assert.equal(r.attempts.length, 2);
+  assert.equal(r.attempts[0].status, "failed");
+  assert.equal(r.attempts[1].status, "succeeded");
+});
+
+test("all fail: returns all_failed", async () => {
+  const candidates = [mkCandidate("a", "m1", 0.01), mkCandidate("b", "m2", 0.02)];
+  const execute: ExecuteFn = async () => ({ ok: false, error: "down" });
+  const r = await cascadeRoute(candidates, noCaps, execute);
+  assert.equal(r.outcome, "all_failed");
+  assert.equal(r.selected, undefined);
+  assert.equal(r.attempts.length, 2);
+  for (const a of r.attempts) assert.equal(a.status, "failed");
+});
+
+test("monthly quota: skip candidates that exceed cap", async () => {
+  const candidates = [mkCandidate("a", "m1", 0.05), mkCandidate("b", "m2", 0.10)];
+  const ctx: CascadeContext = {
+    requestId: "r1",
+    monthlyUsdSpent: 0.95,
+    monthlyUsdCap: 1.00, // a: 0.95+0.05=1.00 ok; b: 0.95+0.10=1.05 over
+    perRequestUsdCap: null,
+  };
+  const execute: ExecuteFn = async () => ({ ok: true });
+  const r = await cascadeRoute(candidates, ctx, execute);
+  assert.equal(r.outcome, "success");
+  assert.equal(r.selected?.provider, "a");
+  assert.equal(r.attempts[0].status, "succeeded");
+});
+
+test("quota exceeded (all skipped): returns quota_exceeded", async () => {
+  const candidates = [mkCandidate("a", "m1", 0.20), mkCandidate("b", "m2", 0.30)];
+  const ctx: CascadeContext = {
+    requestId: "r1",
+    monthlyUsdSpent: 0.90,
+    monthlyUsdCap: 1.00,
+    perRequestUsdCap: null,
+  };
+  const execute: ExecuteFn = async () => ({ ok: true });
+  const r = await cascadeRoute(candidates, ctx, execute);
+  assert.equal(r.outcome, "quota_exceeded");
+  for (const a of r.attempts) assert.equal(a.status, "skipped_quota");
+});
+
+test("per-request cost ceiling: skip candidates over the limit", async () => {
+  const candidates = [mkCandidate("a", "m1", 0.10), mkCandidate("b", "m2", 0.05)];
+  const ctx: CascadeContext = {
+    requestId: "r1",
+    monthlyUsdSpent: 0,
+    monthlyUsdCap: null,
+    perRequestUsdCap: 0.07, // a: 0.10 over; b: 0.05 ok
+  };
+  const execute: ExecuteFn = async (c) => c.provider === "b" ? { ok: true } : { ok: false };
+  const r = await cascadeRoute(candidates, ctx, execute);
+  assert.equal(r.outcome, "success");
+  assert.equal(r.selected?.provider, "b");
+  assert.equal(r.attempts[0].status, "skipped_cost_ceiling");
+  assert.equal(r.attempts[1].status, "succeeded");
+});
+
+test("execute throwing is caught and counted as failed", async () => {
+  const candidates = [mkCandidate("a", "m1", 0.01), mkCandidate("b", "m2", 0.01)];
+  const execute: ExecuteFn = async (c) => {
+    if (c.provider === "a") throw new Error("boom");
+    return { ok: true };
+  };
+  const r = await cascadeRoute(candidates, noCaps, execute);
+  assert.equal(r.outcome, "success");
+  assert.equal(r.selected?.provider, "b");
+  assert.equal(r.attempts[0].status, "failed");
+  assert.equal(r.attempts[0].error, "boom");
+});
+
+test("empty candidate list returns all_failed with no attempts", async () => {
+  const r = await cascadeRoute([], noCaps, async () => ({ ok: true }));
+  assert.equal(r.outcome, "all_failed");
+  assert.equal(r.attempts.length, 0);
+});

--- a/tests/unit/cost-ledger.test.ts
+++ b/tests/unit/cost-ledger.test.ts
@@ -1,0 +1,74 @@
+/**
+ * cost-ledger.test — WP-S4.
+ */
+
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  enqueueCostEvent,
+  flushCostLedger,
+  ledgerQueueDepth,
+  _resetLedgerForTests,
+} from "../../src/lib/db/costLedger.ts";
+import { summarizeCostForTenant } from "../../src/lib/db/costTracking.ts";
+
+function makeInput(overrides: Partial<{ tenantId: string; costUsd: number; provider: string; model: string }> = {}) {
+  return {
+    virtualKeyId: "vk-test",
+    tenantId: overrides.tenantId ?? "t1",
+    provider: overrides.provider ?? "openai",
+    model: overrides.model ?? "gpt-4o",
+    promptTokens: 100,
+    completionTokens: 50,
+    costUsd: overrides.costUsd ?? 0.001,
+  };
+}
+
+test("flush is a no-op when queue is empty", async () => {
+  _resetLedgerForTests();
+  const n = await flushCostLedger();
+  assert.equal(n, 0);
+  assert.equal(ledgerQueueDepth(), 0);
+});
+
+test("enqueue increments the queue depth", () => {
+  _resetLedgerForTests();
+  assert.equal(ledgerQueueDepth(), 0);
+  enqueueCostEvent(makeInput({ costUsd: 0.01 }));
+  assert.equal(ledgerQueueDepth(), 1);
+  enqueueCostEvent(makeInput({ costUsd: 0.02 }));
+  assert.equal(ledgerQueueDepth(), 2);
+});
+
+test("size-based flush triggers at OMNIROUTE_LEDGER_FLUSH_ROWS", async () => {
+  _resetLedgerForTests();
+  const prev = process.env.OMNIROUTE_LEDGER_FLUSH_ROWS;
+  process.env.OMNIROUTE_LEDGER_FLUSH_ROWS = "3";
+  delete process.env.OMNIROUTE_LEDGER_FLUSH_MS;
+  try {
+    enqueueCostEvent(makeInput({ costUsd: 0.01 }));
+    enqueueCostEvent(makeInput({ costUsd: 0.02 }));
+    assert.equal(ledgerQueueDepth(), 2);
+    enqueueCostEvent(makeInput({ costUsd: 0.03 }));
+    await new Promise((r) => setImmediate(r));
+    assert.equal(ledgerQueueDepth(), 0);
+  } finally {
+    if (prev === undefined) delete process.env.OMNIROUTE_LEDGER_FLUSH_ROWS;
+    else process.env.OMNIROUTE_LEDGER_FLUSH_ROWS = prev;
+  }
+});
+test("flush writes through recordCostEvent without errors", async () => {
+  _resetLedgerForTests();
+  const prevRows = process.env.OMNIROUTE_LEDGER_FLUSH_ROWS;
+  process.env.OMNIROUTE_LEDGER_FLUSH_ROWS = "5";
+  try {
+    for (let i = 0; i < 5; i++) {
+      enqueueCostEvent(makeInput({ costUsd: 0.001 * (i + 1) }));
+    }
+    await new Promise((r) => setImmediate(r));
+    assert.equal(ledgerQueueDepth(), 0);
+  } finally {
+    if (prevRows === undefined) delete process.env.OMNIROUTE_LEDGER_FLUSH_ROWS;
+    else process.env.OMNIROUTE_LEDGER_FLUSH_ROWS = prevRows;
+  }
+});

--- a/tests/unit/cost-ledger.test.ts
+++ b/tests/unit/cost-ledger.test.ts
@@ -10,7 +10,6 @@ import {
   ledgerQueueDepth,
   _resetLedgerForTests,
 } from "../../src/lib/db/costLedger.ts";
-import { summarizeCostForTenant } from "../../src/lib/db/costTracking.ts";
 
 function makeInput(overrides: Partial<{ tenantId: string; costUsd: number; provider: string; model: string }> = {}) {
   return {


### PR DESCRIPTION
## Summary

Three WPs in one PR, all on the feat/b7-bifrost-traffic-swap branch:

1. **B7 — traffic swap (`BIFROST_TRAFFIC_PCT`)** — single env var controls the 5% → 100% cutover. Deterministic per request id (FNV-1a). 5 tests pass.
2. **S4 — batched cost ledger (`OMNIROUTE_LEDGER_FLUSH_ROWS` / `OMNIROUTE_LEDGER_FLUSH_MS`)** — wraps the existing `recordCostEvent` with an in-memory queue so the per-request cost event doesn't become a 5k-RPS write storm. 4 tests pass.
3. **S7 — per-combo cascade routing (`cascadeRoute`)** — the last SOTA gap. Tries each candidate in order, stops at first success; pre-checks for monthly USD cap and per-request USD ceiling. 8 tests pass.

## All 7 SOTA gaps now closed

| Gap | Status | File |
|---|---|---|
| S1 learned router | ✅ | `src/lib/combos/intelligentRouting.ts` (192 LOC) |
| S2 semantic cache | ✅ | `src/lib/semanticCache.ts` (377 LOC) |
| S3 virtual keys | ✅ | `src/lib/db/virtualKeys.ts` (436 LOC) |
| S4 cost ledger | ✅ this PR | `src/lib/db/costLedger.ts` (93 LOC) |
| S5 router-eval harness | ✅ | `src/lib/routerEval/` + `scripts/router-eval/` |
| S6 guardrails | ✅ | `src/lib/guardrails/` (1851 LOC across 8 files) |
| S7 cascade routing | ✅ this PR | `src/lib/routing/cascade.ts` (94 LOC) |

## Commits in this PR

| SHA | What |
|---|---|
| `3a73f0643` | B7 traffic swap + 5 tests |
| `231faea1b` | S4 batched cost ledger + 4 tests |
| `f7af1f638` | S7 cascade routing + 8 tests |

## Validation

- `npm run typecheck:core` — clean on touched files (pre-existing `resolveOmniRouteBaseUrl.ts` error unchanged)
- `oxlint` — clean on touched files
- `npm exec --yes tsx -- --test tests/unit/{bifrost-traffic-swap,cost-ledger,cascade-routing,bifrost-shadow-wiring}.test.ts` — **21 passed, 0 failed** total (4+5+4+8)

## B7 30-day soak gates (per ADR-031)

- 0 SEV-1 incidents
- p99 latency regression ≤ 20% vs the chatCore-only baseline
- shadow agreement score ≥ 0.92 over the soak window

🤖 Generated with [Codex]