### PR TITLE
fix(ci): make dast-smoke teardown robust to missing server.pid

### DIFF
--- a/.github/workflows/dast-smoke.yml
+++ b/.github/workflows/dast-smoke.yml
@@ -53,7 +53,15 @@ jobs:
         run: npx --yes promptfoo@latest eval -c promptfooconfig.yaml --no-cache
       - name: Stop server
         if: always()
-        run: kill "$(cat server.pid)" || true
+        # Wrap in `set +e` + `|| true` defensively because if `cat server.pid` ever fails
+        # (e.g. the Start step errored before writing it, or the runner image lacks the
+        # file), bash's strict-mode `kill ''` is a non-zero exit. We don't want CI to
+        # fail purely because the teardown step couldn't read a PID file.
+        run: |
+          set +e
+          PID="$(cat server.pid 2>/dev/null || true)"
+          if [ -n "$PID" ]; then kill "$PID" || true; fi
+          exit 0
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:


### PR DESCRIPTION
## Summary

PR286 was merged with the `dast-smoke` check failing on the teardown step. Cause:
`kill "$(cat server.pid)" || true` under bash strict mode treats `cat server.pid`
failure (no such file) as a non-zero exit that `|| true` does **not** soften
because of `set -e` semantics — so `kill ''` (empty arg) propagates exit 1.

This PR replaces it with a guarded teardown: `cat ... 2>/dev/null || true`,
skip `kill` if the PID is empty, and `exit 0` explicitly so teardown never
blocks CI.

## Diff

```diff
       - name: Stop server
         if: always()
-        run: kill "$(cat server.pid)" || true
+        # Wrap in `set +e` + `|| true` defensively because if `cat server.pid` ever fails
+        # (e.g. the Start step errored before writing it, or the runner image lacks the
+        # file), bash's strict-mode `kill ''` is a non-zero exit. We don't want CI to
+        # fail purely because the teardown step couldn't read a PID file.
+        run: |
+          set +e
+          PID="$(cat server.pid 2>/dev/null || true)"
+          if [ -n "$PID" ]; then kill "$PID" || true; fi
+          exit 0
```

## Risk profile

**Low.** CI workflow only. No runtime code change, no provider behavior change,
no DB schema change.

## Refs

- PR286 (the PR that this would have kept green)
- Run https://github.com/KooshaPari/OmniRoute/actions/runs/28764849373/job/85286976261