### PR TITLE
[codex] Sort model latency stats for routing diagnostics

### DIFF
--- a/src/app/api/usage/model-latency-stats/route.ts
+++ b/src/app/api/usage/model-latency-stats/route.ts
@@ -5,6 +5,11 @@ import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { getModelLatencyStats } from "@/lib/usage/usageHistory";
 import { buildErrorBody } from "@omniroute/open-sse/utils/error.ts";
 
+const sortBySchema = z.enum(["balanced", "latency", "reliability", "throughput"]);
+type SortBy = z.infer<typeof sortBySchema>;
+
+type ModelLatencyEntry = Awaited<ReturnType<typeof getModelLatencyStats>>[string];
+
 const querySchema = z.object({
   windowHours: z.coerce
     .number()
@@ -15,7 +20,69 @@ const querySchema = z.object({
   maxRows: z.coerce.number().int().positive().max(100_000).default(10_000),
   provider: z.string().trim().min(1).max(100).optional(),
   model: z.string().trim().min(1).max(200).optional(),
+  sortBy: sortBySchema.default("balanced"),
 });
+
+function finiteNumber(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function descending(a: number, b: number): number {
+  return b - a;
+}
+
+function ascending(a: number, b: number): number {
+  return a - b;
+}
+
+function stableEntryCompare(a: ModelLatencyEntry, b: ModelLatencyEntry): number {
+  const providerCompare = a.provider.localeCompare(b.provider);
+  if (providerCompare !== 0) return providerCompare;
+  return a.model.localeCompare(b.model);
+}
+
+function balancedScore(entry: ModelLatencyEntry): number {
+  const successRate = finiteNumber(entry.successRate, 0);
+  const p95LatencyMs = finiteNumber(entry.p95LatencyMs, Number.POSITIVE_INFINITY);
+  const latencyStdDev = finiteNumber(entry.latencyStdDev, Number.POSITIVE_INFINITY);
+  const throughput = finiteNumber(entry.avgTokensPerSecond, 0);
+  const latencyScore = Number.isFinite(p95LatencyMs) && p95LatencyMs > 0 ? 1 / p95LatencyMs : 0;
+  const stabilityScore = Number.isFinite(latencyStdDev) && latencyStdDev > 0 ? 1 / latencyStdDev : 0;
+
+  return successRate * 0.5 + latencyScore * 250 * 0.3 + stabilityScore * 100 * 0.1 + throughput * 0.001;
+}
+
+function sortEntries(entries: ModelLatencyEntry[], sortBy: SortBy): ModelLatencyEntry[] {
+  const sorted = [...entries];
+  sorted.sort((a, b) => {
+    let comparison = 0;
+    if (sortBy === "latency") {
+      comparison = ascending(
+        finiteNumber(a.p95LatencyMs, Number.POSITIVE_INFINITY),
+        finiteNumber(b.p95LatencyMs, Number.POSITIVE_INFINITY)
+      );
+    } else if (sortBy === "reliability") {
+      comparison = descending(finiteNumber(a.successRate, 0), finiteNumber(b.successRate, 0));
+      if (comparison === 0) {
+        comparison = ascending(
+          finiteNumber(a.latencyStdDev, Number.POSITIVE_INFINITY),
+          finiteNumber(b.latencyStdDev, Number.POSITIVE_INFINITY)
+        );
+      }
+    } else if (sortBy === "throughput") {
+      comparison = descending(
+        finiteNumber(a.avgTokensPerSecond, 0),
+        finiteNumber(b.avgTokensPerSecond, 0)
+      );
+    } else {
+      comparison = descending(balancedScore(a), balancedScore(b));
+    }
+
+    return comparison || stableEntryCompare(a, b);
+  });
+  return sorted;
+}
 
 export async function GET(request: Request) {
   const authError = await requireManagementAuth(request);
@@ -29,6 +96,7 @@ export async function GET(request: Request) {
       maxRows: searchParams.get("maxRows") || undefined,
       provider: searchParams.get("provider") || undefined,
       model: searchParams.get("model") || undefined,
+      sortBy: searchParams.get("sortBy") || undefined,
     });
 
     if (!parsed.success) {
@@ -38,18 +106,22 @@ export async function GET(request: Request) {
       );
     }
 
-    const { provider, model, ...options } = parsed.data;
+    const { provider, model, sortBy, ...options } = parsed.data;
     const stats = await getModelLatencyStats(options);
-    const entries = Object.values(stats).filter((entry) => {
-      if (provider && entry.provider !== provider) return false;
-      if (model && entry.model !== model) return false;
-      return true;
-    });
+    const entries = sortEntries(
+      Object.values(stats).filter((entry) => {
+        if (provider && entry.provider !== provider) return false;
+        if (model && entry.model !== model) return false;
+        return true;
+      }),
+      sortBy
+    );
 
     return NextResponse.json({
       windowHours: options.windowHours,
       minSamples: options.minSamples,
       maxRows: options.maxRows,
+      sortBy,
       count: entries.length,
       entries,
     });

--- a/src/app/api/usage/model-latency-stats/route.ts
+++ b/src/app/api/usage/model-latency-stats/route.ts
@@ -5,7 +5,7 @@ import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { getModelLatencyStats } from "@/lib/usage/usageHistory";
 import { buildErrorBody } from "@omniroute/open-sse/utils/error.ts";
 
-const sortBySchema = z.enum(["balanced", "latency", "reliability", "throughput"]);
+const sortBySchema = z.enum(["balanced", "latency", "reliability"]);
 type SortBy = z.infer<typeof sortBySchema>;
 
 type ModelLatencyEntry = Awaited<ReturnType<typeof getModelLatencyStats>>[string];
@@ -46,11 +46,11 @@ function balancedScore(entry: ModelLatencyEntry): number {
   const successRate = finiteNumber(entry.successRate, 0);
   const p95LatencyMs = finiteNumber(entry.p95LatencyMs, Number.POSITIVE_INFINITY);
   const latencyStdDev = finiteNumber(entry.latencyStdDev, Number.POSITIVE_INFINITY);
-  const throughput = finiteNumber(entry.avgTokensPerSecond, 0);
   const latencyScore = Number.isFinite(p95LatencyMs) && p95LatencyMs > 0 ? 1 / p95LatencyMs : 0;
-  const stabilityScore = Number.isFinite(latencyStdDev) && latencyStdDev > 0 ? 1 / latencyStdDev : 0;
+  const stabilityScore =
+    Number.isFinite(latencyStdDev) && latencyStdDev > 0 ? 1 / latencyStdDev : 0;
 
-  return successRate * 0.5 + latencyScore * 250 * 0.3 + stabilityScore * 100 * 0.1 + throughput * 0.001;
+  return successRate * 0.5 + latencyScore * 250 * 0.3 + stabilityScore * 100 * 0.2;
 }
 
 function sortEntries(entries: ModelLatencyEntry[], sortBy: SortBy): ModelLatencyEntry[] {
@@ -70,11 +70,6 @@ function sortEntries(entries: ModelLatencyEntry[], sortBy: SortBy): ModelLatency
           finiteNumber(b.latencyStdDev, Number.POSITIVE_INFINITY)
         );
       }
-    } else if (sortBy === "throughput") {
-      comparison = descending(
-        finiteNumber(a.avgTokensPerSecond, 0),
-        finiteNumber(b.avgTokensPerSecond, 0)
-      );
     } else {
       comparison = descending(balancedScore(a), balancedScore(b));
     }

--- a/tests/unit/model-latency-stats-route.test.ts
+++ b/tests/unit/model-latency-stats-route.test.ts
@@ -102,5 +102,70 @@ test("GET /api/usage/model-latency-stats rejects invalid query params", async ()
   const body = (await response.json()) as any;
 
   assert.equal(response.status, 400);
-  assert.equal(body.error.type, "invalid_request");
+  assert.equal(body.error.type, "invalid_request_error");
+});
+
+test("GET /api/usage/model-latency-stats sorts by latency with lowest p95 first", async () => {
+  const now = Date.now();
+  const rows = [
+    { provider: "anthropic", model: "claude-opus", latencyMs: 900, success: true },
+    { provider: "openai", model: "gpt-4o", latencyMs: 200, success: true },
+    { provider: "google", model: "gemini-flash", latencyMs: 120, success: true },
+  ];
+  for (const [index, row] of rows.entries()) {
+    await usageHistory.saveRequestUsage({
+      ...row,
+      timestamp: new Date(now - index * 60_000).toISOString(),
+    });
+  }
+
+  const response = await route.GET(
+    makeRequest(
+      "http://localhost/api/usage/model-latency-stats?windowHours=1&minSamples=1&sortBy=latency"
+    )
+  );
+  const body = (await response.json()) as any;
+
+  assert.equal(response.status, 200);
+  assert.equal(body.sortBy, "latency");
+  assert.deepEqual(
+    body.entries.map((entry: { model: string }) => entry.model),
+    ["gemini-flash", "gpt-4o", "claude-opus"]
+  );
+});
+
+test("GET /api/usage/model-latency-stats sorts by reliability with highest success rate first", async () => {
+  const now = Date.now();
+  const rows = [
+    { provider: "anthropic", model: "claude-opus", latencyMs: 200, success: false },
+    { provider: "openai", model: "gpt-4o", latencyMs: 200, success: true },
+    { provider: "google", model: "gemini-flash", latencyMs: 200, success: true },
+  ];
+  for (const [index, row] of rows.entries()) {
+    await usageHistory.saveRequestUsage({
+      ...row,
+      timestamp: new Date(now - index * 60_000).toISOString(),
+    });
+  }
+
+  const response = await route.GET(
+    makeRequest(
+      "http://localhost/api/usage/model-latency-stats?windowHours=1&minSamples=1&sortBy=reliability"
+    )
+  );
+  const body = (await response.json()) as any;
+
+  assert.equal(response.status, 200);
+  assert.equal(body.sortBy, "reliability");
+  assert.equal(body.entries.at(-1).model, "claude-opus");
+});
+
+test("GET /api/usage/model-latency-stats rejects unknown sortBy", async () => {
+  const response = await route.GET(
+    makeRequest("http://localhost/api/usage/model-latency-stats?sortBy=throughput")
+  );
+  const body = (await response.json()) as any;
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error.type, "invalid_request_error");
 });


### PR DESCRIPTION
## Summary
- add deterministic `sortBy` ordering to model latency stats: `balanced`, `latency`, and `reliability`
- keep sort inputs constrained to telemetry the endpoint actually returns
- cover sort ordering and invalid query handling

## Stack
- Depends on diegosouzapw/OmniRoute#6141 (`codex/model-latency-stats-api`)

## Validation
- `node --import tsx/esm --test tests/unit/model-latency-stats-route.test.ts`
- `npx --yes --package prettier prettier --check src/app/api/usage/model-latency-stats/route.ts tests/unit/model-latency-stats-route.test.ts`
- commit hooks: explicit-any budget and tracked-artifact checks