### PR TITLE
fix(web): clear svelte-check errors blocking v4 typecheck

### DIFF
--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.0",
         "@tailwindcss/vite": "^4.0.0",
+        "@types/node": "^22.0.0",
         "svelte-check": "^4.0.0",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0",
@@ -236,6 +237,8 @@
     "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 
@@ -466,6 +469,8 @@
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
+    "@types/node": "^22.0.0",
     "svelte-check": "^4.0.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",

--- a/apps/web/src/lib/components/combos/FlowEditor.svelte
+++ b/apps/web/src/lib/components/combos/FlowEditor.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { SvelteFlow, Background, Controls, MiniMap, type Node, type Edge } from '@xyflow/svelte';
   import '@xyflow/svelte/dist/style.css';
-import RouterNode from './nodes/RouterNode.svelte';
-import ModelCardNode from './nodes/ModelCardNode.svelte';
-import ConditionNode from './nodes/ConditionNode.svelte';
-import FallbackNode from './nodes/FallbackNode.svelte';
-import QuotaBucketNode from './nodes/QuotaBucketNode.svelte';
-import RejectNode from './nodes/RejectNode.svelte';
+  import RouterNode from './nodes/RouterNode.svelte';
+  import ModelCardNode from './nodes/ModelCardNode.svelte';
+  import ConditionNode from './nodes/ConditionNode.svelte';
+  import FallbackNode from './nodes/FallbackNode.svelte';
+  import QuotaBucketNode from './nodes/QuotaBucketNode.svelte';
+  import RejectNode from './nodes/RejectNode.svelte';
 
   type ComboNodeData = {
     label: string;
@@ -19,10 +19,12 @@ import RejectNode from './nodes/RejectNode.svelte';
   let {
     primaryModel,
     fallbackModels = [],
+    costBudget = 0,
     onchange,
   }: {
     primaryModel: string;
     fallbackModels: string[];
+    costBudget?: number;
     onchange?: (nodes: ComboNode[], edges: Edge[]) => void;
   } = $props();
 
@@ -75,7 +77,9 @@ import RejectNode from './nodes/RejectNode.svelte';
     nodes = initialNodes;
     edges = initialEdges;
   });
-  $effect(() => { onchange?.(nodes, edges); });
+  $effect(() => {
+    onchange?.(nodes, edges);
+  });
 
   const nodeTypes = {
     router: RouterNode,
@@ -102,4 +106,7 @@ import RejectNode from './nodes/RejectNode.svelte';
 </div>
 <p class="text-xs text-gray-500 mt-2">
   Drag nodes to rearrange. Edit edges by clicking. Visual representation of the same ComboNode[] / Edge[] arrays stored in the combos editor form above.
+  {#if costBudget > 0}
+    <span class="ml-2">Cost budget: ${costBudget}</span>
+  {/if}
 </p>

--- a/apps/web/src/lib/components/ui/Button.svelte
+++ b/apps/web/src/lib/components/ui/Button.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-type Variant = 'primary' | 'secondary' | 'ghost' | 'danger';
+  type Variant = 'primary' | 'secondary' | 'ghost' | 'danger';
   type Size = 'sm' | 'md' | 'lg';
 
   let {
@@ -7,6 +7,7 @@ type Variant = 'primary' | 'secondary' | 'ghost' | 'danger';
     size = 'md' as Size,
     disabled = false,
     type = 'button' as 'button' | 'submit' | 'reset',
+    class: className = '',
     onclick,
     children,
   } = $props<{
@@ -14,11 +15,13 @@ type Variant = 'primary' | 'secondary' | 'ghost' | 'danger';
     size?: Size;
     disabled?: boolean;
     type?: 'button' | 'submit' | 'reset';
+    class?: string;
     onclick?: (e: MouseEvent) => void;
-    children?: any;
+    children?: import('svelte').Snippet;
   }>();
 
-  const base = 'inline-flex items-center justify-center font-semibold rounded transition disabled:opacity-50 disabled:cursor-not-allowed';
+  const base =
+    'inline-flex items-center justify-center font-semibold rounded transition disabled:opacity-50 disabled:cursor-not-allowed';
   const sizes: Record<Size, string> = {
     sm: 'px-3 py-1.5 text-sm',
     md: 'px-4 py-2 text-base',
@@ -31,6 +34,10 @@ type Variant = 'primary' | 'secondary' | 'ghost' | 'danger';
     danger: 'bg-red-500 text-white hover:bg-red-600',
   };
 
-const cls = $derived(`{base} {sizes[size]} {variants[variant]}`);
+  const cls = $derived(`${base} ${sizes[size]} ${variants[variant]} ${className}`.trim());
   const style = $derived(variant === 'primary' ? 'background: var(--grad-brand)' : '');
 </script>
+
+<button {type} {disabled} class={cls} style={style} {onclick}>
+  {@render children?.()}
+</button>

--- a/apps/web/src/routes/dashboard/notifications/+page.svelte
+++ b/apps/web/src/routes/dashboard/notifications/+page.svelte
@@ -48,7 +48,7 @@
       <div>
         <h3 class="text-sm font-semibold text-gray-700 mb-2">Channels</h3>
         <div class="space-y-2">
-          {#each Object.entries(prefs.channels) as [k, v]}
+          {#each (Object.keys(prefs.channels) as Array<keyof Prefs['channels']>) as k}
             <label class="flex items-center gap-2">
               <input type="checkbox" bind:checked={prefs.channels[k as keyof Prefs['channels']]} class="rounded" />
               <span class="text-sm capitalize">{k}</span>
@@ -60,10 +60,10 @@
       <div>
         <h3 class="text-sm font-semibold text-gray-700 mb-2">Events</h3>
         <div class="space-y-2">
-          {#each Object.entries(prefs.events) as [k, v]}
+          {#each (Object.keys(prefs.events) as Array<keyof Prefs['events']>) as k}
             <label class="flex items-center gap-2">
               <input type="checkbox" bind:checked={prefs.events[k as keyof Prefs['events']]} class="rounded" />
-              <span class="text-sm capitalize">{k.replace(/([A-Z])/g, ' $1').trim()}</span>
+              <span class="text-sm capitalize">{String(k).replace(/([A-Z])/g, ' $1').trim()}</span>
             </label>
           {/each}
         </div>

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,6 +4,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
## Summary
- Add `@types/node` + tsconfig `types: ["node"]` for process.env in hooks/logger
- Fix FlowEditor xyflow event props / accept `costBudget`
- Add `class` prop to Button (and repair class template)
- Type notification channel/event keys for bind:checked

## Test plan
- [ ] Typecheck job green on PR
- [ ] Build web still green