### PR TITLE
docs: add Phenotype identity and documentation decision inputs

### DIFF
--- a/docs/PUBLIC_DOCS_BOUNDARY.md
+++ b/docs/PUBLIC_DOCS_BOUNDARY.md
@@ -1,0 +1,127 @@
+---
+title: Proposed Public Documentation Boundary
+status: proposed
+---
+
+# Proposed public documentation boundary
+
+This document defines a proposed input boundary for a fork-owned Phenodocs build. It changes no deployment or navigation by itself.
+
+## Public information architecture
+
+1. **Evaluate**
+   - product overview
+   - verified capabilities
+   - comparisons with dated sources
+   - security/trust overview
+2. **Quickstart**
+   - prerequisites
+   - local install
+   - container install
+   - first verified request
+   - uninstall
+3. **Journeys**
+   - connect a provider
+   - configure a client/IDE
+   - create and test fallback
+   - inspect usage and cost
+   - diagnose failure
+   - secure remote access
+   - upgrade and rollback
+4. **Concepts**
+   - architecture and request lifecycle
+   - providers, accounts, models
+   - routing and resilience
+   - authentication/authorization
+   - protocols and extensions
+5. **Reference**
+   - generated OpenAPI
+   - generated provider catalog
+   - generated CLI/environment/feature flags
+   - configuration schema
+6. **Operations**
+   - deployment
+   - monitoring and SLOs
+   - backup/recovery
+   - security hardening
+   - release and upgrade operations
+7. **Contribute**
+   - repository map
+   - development setup
+   - testing and quality gates
+   - architecture decisions
+   - contribution/security/support policies
+
+## Included source classes
+
+Public build inputs may include reviewed content from:
+
+- `docs/getting-started/`
+- `docs/guides/`
+- `docs/architecture/`
+- `docs/reference/`
+- `docs/routing/`
+- `docs/providers/`
+- reviewed user-facing pages in `docs/frameworks/`
+- reviewed operational pages in `docs/operations/` and `docs/ops/`
+- reviewed security guidance in `docs/security/`
+- `docs/openapi.yaml`
+- approved root policies such as `CONTRIBUTING.md`, `SECURITY.md`, and `SUPPORT.md`
+
+Inclusion requires an owner, audience, last-reviewed date, and passing link/content checks.
+
+## Excluded from public navigation by default
+
+Keep available in repository history or an explicitly internal/archive build, but do not feed primary public navigation:
+
+- `docs/audits/`
+- `docs/reports/`
+- `docs/research/`
+- session/worklog material
+- raw findings
+- active cutover plans
+- OKRs, technical-debt ledgers, and transient status reports
+- superseded ADRs without an archival banner
+- security material that exposes operational secrets or abuse-enabling detail
+
+Exclusion is not deletion.
+
+## Required front matter
+
+Every public page should declare:
+
+```yaml
+title: <human title>
+audience: evaluate|user|operator|developer
+owner: <team or role>
+status: draft|reviewed|deprecated
+lastReviewed: YYYY-MM-DD
+sourceOfTruth: <code path, schema, or decision record when applicable>
+journey: <manifest slug when applicable>
+```
+
+## Publication gates
+
+- no broken internal or external links
+- no unresolved rich-media placeholders
+- capability claims conform to `docs/reference/CAPABILITY_FACTS.md`
+- examples execute against supported release artifacts
+- generated references are current at the source commit
+- secrets and private/internal URLs are absent
+- accessibility checks cover headings, alt text, contrast, keyboard navigation, and reduced motion
+- deprecated/superseded content has redirects or banners
+- preview build succeeds before merge
+
+## Journey evidence boundary
+
+Journey media is published only when backed by a deterministic manifest containing persona, preconditions, fixtures, steps, assertions, viewport, redaction rules, and source commit. Generic feature screenshots may illustrate a page but must not be labeled journey evidence.
+
+## Open owner decisions
+
+- canonical product/org identity and URLs
+- whether GitHub Wiki is synchronized, deprecated, or an offline mirror
+- hosting and preview provider
+- public metrics/privacy policy
+- versioning and support window
+- content ownership roles and review cadence
+- which security/stealth material is appropriate for public navigation

--- a/docs/adr/ADR-002-phenotype-identity-decision-inputs.md
+++ b/docs/adr/ADR-002-phenotype-identity-decision-inputs.md
@@ -1,0 +1,117 @@
+# ADR-002: Phenotype identity decision inputs
+
+- Status: Proposed decision template
+- Decision owner: repository owner
+- Scope: naming, URLs, governance disclosure, and upstream attribution
+- Out of scope: choosing a brand, acquiring a domain, DNS, deployment, or changing upstream history
+
+## Context
+
+The fork currently mixes fork, Phenotype, and upstream OmniRoute signals. Public claims and links cannot be normalized safely until the owner selects an identity model and approves owned URLs.
+
+## Decision 1 — canonical product and organization naming
+
+### Option A: OmniRoute by Phenotype
+
+**Consequences:** preserves product recognition and package continuity; requires a clear “by Phenotype” lockup and a written rule distinguishing product from organization.
+
+### Option B: Phenotype OmniRoute
+
+**Consequences:** makes organization ownership prominent; likely requires coordinated package, UI, documentation, and release-copy updates while retaining upstream attribution.
+
+### Option C: new product name under Phenotype
+
+**Consequences:** strongest differentiation but highest migration cost; requires trademark/package/domain checks, redirects, compatibility aliases, and a deprecation period.
+
+### Owner must record
+
+- Canonical product display name:
+- Canonical organization display name:
+- CLI/package names retained or migrated:
+- Compatibility/deprecation period:
+- Legal/trademark review required:
+
+## Decision 2 — canonical URLs
+
+### Option A: subpath on an existing approved Phenotype domain
+
+Lower operational surface; URL structure and deployment base path become coupled.
+
+### Option B: dedicated documentation subdomain
+
+Clear docs identity and flexible hosting; requires approved domain, DNS, certificates, and ownership/renewal controls.
+
+### Option C: GitHub Pages as the initial canonical surface
+
+Fast and repository-coupled; weaker product identity and subject to Pages constraints. A later custom-domain move needs redirects.
+
+### Owner must record
+
+- Product homepage:
+- Documentation:
+- API/reference:
+- Status:
+- Support/issues:
+- Security reporting:
+- Redirect policy:
+- Domain owner and renewal contact:
+
+No URL is canonical until ownership and operational responsibility are verified.
+
+## Decision 3 — governance disclosure placement
+
+### Option A: concise README notice plus full governance document
+
+Transparent without dominating product onboarding. Requires a maintained governance page and link.
+
+### Option B: full disclosure near the top of README
+
+Maximum visibility but materially affects product positioning and first-use comprehension.
+
+### Option C: governance document linked from contributing/support surfaces
+
+Least intrusive, but may under-disclose repository operating assumptions.
+
+### Owner must record
+
+- Selected placement:
+- Required wording constraints:
+- Review cadence and owner:
+- Which claims require human verification:
+
+## Decision 4 — upstream attribution
+
+### Option A: visible README “Fork lineage” section plus docs notice
+
+Balances discoverability and product focus; should link to upstream repository and explain divergence.
+
+### Option B: concise README footer plus detailed `docs/FORK.md`
+
+Reduces front-page prominence while preserving durable attribution.
+
+### Option C: persistent site/release footer attribution
+
+Strong cross-surface consistency; requires template and release automation changes.
+
+### Mandatory regardless of option
+
+- Preserve license and copyright notices.
+- Do not imply upstream endorsement.
+- Document fork point, sync policy, local divergence, and vulnerability/reporting ownership.
+- Keep upstream links distinct from fork support and release links.
+
+## Decision record
+
+- Selected naming option:
+- Selected URL option:
+- Selected disclosure option:
+- Selected attribution option:
+- Rationale:
+- Approved by:
+- Approval date:
+- Follow-up issues:
+- Revisit trigger:
+
+## Implementation gate
+
+README, repository metadata, website, docs deployment, package renaming, or redirects must not encode a final identity until this record is approved. Capability claims must follow `docs/reference/CAPABILITY_FACTS.md`.

--- a/docs/reference/CAPABILITY_FACTS.md
+++ b/docs/reference/CAPABILITY_FACTS.md
@@ -1,0 +1,65 @@
+---
+title: Capability Facts Inventory
+status: decision-input
+sourceBranch: main
+---
+
+# Capability facts inventory
+
+This inventory defines how public capability claims must be verified. It deliberately records no owner-selected positioning and no copied numeric claims.
+
+## Rules
+
+1. A public claim is valid only when its value is derived from an authoritative source below at the same commit.
+2. Generated values must include the source commit SHA and generator command.
+3. README, documentation, website, and release copy must not maintain independent numeric values.
+4. A failed or ambiguous derivation blocks publication of the claim; it does not invite estimation.
+5. Runtime support and implemented source are distinct. A feature is “supported” only when its contract test passes against release artifacts.
+
+## Authoritative inventory
+
+| Fact family | Authoritative source | Reproduction / verification | Publication gate |
+|---|---|---|---|
+| Product version | `package.json` and release tag | `bun -p "require('./package.json').version"`; compare with release tag | Values agree |
+| Provider identifiers | `src/shared/constants/providers.ts` | Use the repository provider-reference generator: `bun scripts/docs/gen-provider-reference.ts`; review generated `docs/reference/PROVIDER_REFERENCE.md` diff | Generator succeeds and provider contract tests pass |
+| Routing strategies | `src/shared/constants/routingStrategies.ts` | Import/export the canonical collection in a small checked script; do not count README text | Collection is unique and strategy tests pass |
+| Public HTTP API | `docs/openapi.yaml` plus implemented route handlers | Validate OpenAPI, then run contract tests against the built artifact | Spec validation and contract suite pass |
+| Environment variables | Runtime schema/config source and `docs/reference/ENVIRONMENT.md` | Generate or compare the reference against schema keys | No undocumented or stale public keys |
+| CLI commands | CLI command registry / entry points and `docs/reference/CLI-TOOLS.md` | Enumerate registered commands from the built CLI; compare with reference | CLI smoke test passes |
+| MCP surface | MCP server tool registry | Enumerate registered tools/scopes from the server at build time | MCP contract tests pass |
+| A2A surface | A2A server skill/method registry | Enumerate registered public methods/skills from built server | A2A contract tests pass |
+| Supported locales | `config/i18n.json` | Parse canonical locale keys; validate each catalog | Catalog validation passes |
+| Supported installation targets | Packaging manifests and release workflow matrix | Derive from artifacts actually produced by the release workflow | Clean-install smoke passes for each advertised target |
+| Desktop clients | Desktop package manifests and release artifacts | Report only clients built and attached for the release | Artifact launch smoke passes |
+| License | Root license files and package metadata | Compare SPDX/package metadata with root license set | Metadata is consistent |
+
+## Provenance record
+
+Every generated public-facts artifact must carry:
+
+```json
+{
+  "schemaVersion": 1,
+  "repository": "KooshaPari/OmniRoute",
+  "commit": "<40-character commit SHA>",
+  "generatedAt": "<ISO-8601 UTC timestamp>",
+  "generators": {
+    "<fact-family>": {
+      "sourcePaths": ["<path>"],
+      "command": "<exact command>",
+      "value": "<generated value>",
+      "verification": "<test or check name>"
+    }
+  }
+}
+```
+
+`generatedAt` is informational. Re-running at the same commit must reproduce all values.
+
+## Adoption work
+
+- Add a checked generator that emits a JSON facts artifact from the authoritative registries.
+- Make docs generation consume that artifact.
+- Add drift checks for prose surfaces that still contain numeric capability claims.
+- Attach the facts artifact to releases with checksums/provenance.
+- Replace this decision-input inventory with generated values only after the generator and contract gates land.


### PR DESCRIPTION
## Summary

Adds decision inputs required by #322 without selecting a brand, domain, capability count, or deployment:

- a reproducible capability-facts inventory with source provenance and publication gates
- an identity ADR template covering concrete naming, URL, governance-disclosure, and upstream-attribution options
- a proposed public Phenodocs information architecture and source-input boundary

## Scope controls

- Documentation only
- Based on `main`
- No overlap with recovery PR #323 changed paths
- No deployment, DNS, secret, package rename, capability-count, or final identity changes
- No journey-manifest recovery

## Review decisions requested

1. Select or amend the identity options in ADR-002.
2. Confirm which source registries are authoritative for the future generated facts artifact.
3. Approve or revise the public-docs input boundary before deployment work begins.

Closes no issue; contributes decision inputs to #322.
