### PR TITLE
docs: add deterministic journey evidence harness

### DIFF
--- a/docs/journeys/README.md
+++ b/docs/journeys/README.md
@@ -1,0 +1,41 @@
+# Deterministic journey evidence
+
+This directory introduces a validated contract for product-journey evidence. It does not claim that screenshots exist when CI cannot reproduce them.
+
+## Layout
+
+- `schema/journey.schema.json` — portable JSON Schema for authoring/tooling.
+- `manifests/*.json` — one deterministic journey per file.
+- `scripts/docs/validate-journey-manifests.mjs` — dependency-free repository/provenance validation.
+
+## Validation
+
+```sh
+node scripts/docs/validate-journey-manifests.mjs
+```
+
+The validator checks required safety/accessibility fields and verifies that each manifest's route and test title exist in its cited Playwright test.
+
+## Evidence lifecycle
+
+- **blocked:** a precise technical blocker is recorded; artifact paths are planned only.
+- **captured:** CI produced the artifacts at the source commit and redaction review passed.
+- **published:** reviewed artifacts are linked from public documentation.
+
+Never commit a hand-made or local screenshot as journey evidence. A capture must use the declared viewport, reduced motion, isolated fixture/network policy, and exact source commit.
+
+## Redaction requirements
+
+Captures must contain no API keys, authorization headers, tokens, cookies, secrets, personal data, private hostnames, or machine-specific paths. Declared selectors are masked before capture, deny-pattern scanning runs on textual artifacts, and human review remains mandatory before publication.
+
+## Accessibility requirements
+
+Every journey declares its applicable checks. The capture runner must force reduced motion and record results for document title, heading order, landmarks, visible focus, accessible names, contrast, and horizontal overflow as declared.
+
+## First smoke journey
+
+`anonymous-home-smoke` is grounded in the existing `tests/e2e/smoke.spec.ts` root-route assertion. It is reproducible locally with the existing Playwright lifecycle, requires no credentials, and uses local-only networking.
+
+Screenshot/trace capture remains **blocked**, honestly, because `playwright.config.ts` disables its `webServer` in CI and the repository does not yet provide a dedicated journey job that proves the v4 BFF/web preview lifecycle. The next PR may add artifact capture only after a CI run demonstrates that lifecycle without secrets or external providers.
+
+Related: #322.

--- a/docs/journeys/manifests/anonymous-home-smoke.json
+++ b/docs/journeys/manifests/anonymous-home-smoke.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion": 1,
+  "slug": "anonymous-home-smoke",
+  "title": "Anonymous visitor opens the v4 home surface",
+  "persona": "A first-time visitor evaluating a local OmniRoute v4 checkout",
+  "purpose": "Prove that the public root route renders the stable v4 heading without credentials or external services.",
+  "preconditions": [
+    "Dependencies are installed from the repository lockfile.",
+    "The existing Playwright web server command can build apps/web and start apps/bff plus the web preview on localhost.",
+    "No provider credentials are configured."
+  ],
+  "fixture": {
+    "kind": "repository",
+    "network": "local-only",
+    "secrets": false
+  },
+  "viewport": {
+    "width": 1280,
+    "height": 800,
+    "deviceScaleFactor": 1
+  },
+  "steps": [
+    {
+      "id": "open-home",
+      "action": "goto",
+      "target": "/",
+      "assertions": [
+        "The first h1 contains the exact text 'Welcome to OmniRoute v4'.",
+        "The document has no horizontal overflow at the declared viewport."
+      ]
+    }
+  ],
+  "accessibility": {
+    "keyboardOnly": true,
+    "reducedMotion": true,
+    "checks": [
+      "document-title",
+      "heading-order",
+      "landmarks",
+      "focus-visible",
+      "accessible-names",
+      "contrast",
+      "no-horizontal-overflow"
+    ]
+  },
+  "redaction": {
+    "denyPatterns": [
+      "(?i)(api[-_ ]?key|authorization|token|secret|cookie)\\s*[:=]\\s*\\S+",
+      "(?i)bearer\\s+\\S+"
+    ],
+    "maskSelectors": [
+      "input[type='password']",
+      "[data-sensitive='true']"
+    ],
+    "reviewRequired": true
+  },
+  "evidence": {
+    "captureStatus": "blocked",
+    "artifacts": [
+      {
+        "kind": "screenshot",
+        "path": "journey-evidence/anonymous-home-smoke/home.png"
+      },
+      {
+        "kind": "trace",
+        "path": "journey-evidence/anonymous-home-smoke/trace.zip"
+      },
+      {
+        "kind": "accessibility-report",
+        "path": "journey-evidence/anonymous-home-smoke/accessibility.json"
+      }
+    ],
+    "retentionDays": 14,
+    "blocker": "Current Playwright configuration disables its webServer in CI, and no dedicated journey job currently starts the v4 BFF/web preview. Artifact capture must not be claimed until that service lifecycle is proven stable in CI."
+  },
+  "provenance": {
+    "baseBranch": "main",
+    "testFile": "tests/e2e/smoke.spec.ts",
+    "testTitle": "home page renders",
+    "command": "bunx playwright test tests/e2e/smoke.spec.ts --project=chromium --grep \"home page renders\""
+  }
+}

--- a/docs/journeys/schema/journey.schema.json
+++ b/docs/journeys/schema/journey.schema.json
@@ -1,0 +1,288 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KooshaPari/OmniRoute/blob/main/docs/journeys/schema/journey.schema.json",
+  "title": "OmniRoute deterministic journey evidence manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "slug",
+    "title",
+    "persona",
+    "purpose",
+    "preconditions",
+    "fixture",
+    "viewport",
+    "steps",
+    "accessibility",
+    "redaction",
+    "evidence",
+    "provenance"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": 1
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "persona": {
+      "type": "string",
+      "minLength": 1
+    },
+    "purpose": {
+      "type": "string",
+      "minLength": 1
+    },
+    "preconditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "network",
+        "secrets"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "none",
+            "repository"
+          ]
+        },
+        "network": {
+          "enum": [
+            "blocked",
+            "mocked",
+            "local-only"
+          ]
+        },
+        "secrets": {
+          "const": false
+        }
+      }
+    },
+    "viewport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "width",
+        "height",
+        "deviceScaleFactor"
+      ],
+      "properties": {
+        "width": {
+          "type": "integer",
+          "minimum": 320
+        },
+        "height": {
+          "type": "integer",
+          "minimum": 480
+        },
+        "deviceScaleFactor": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 3
+        }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "action",
+          "target",
+          "assertions"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "action": {
+            "enum": [
+              "goto",
+              "click",
+              "fill",
+              "press",
+              "observe"
+            ]
+          },
+          "target": {
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {
+            "type": "string"
+          },
+          "assertions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "accessibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keyboardOnly",
+        "reducedMotion",
+        "checks"
+      ],
+      "properties": {
+        "keyboardOnly": {
+          "type": "boolean"
+        },
+        "reducedMotion": {
+          "const": true
+        },
+        "checks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": [
+              "document-title",
+              "heading-order",
+              "landmarks",
+              "focus-visible",
+              "accessible-names",
+              "contrast",
+              "no-horizontal-overflow"
+            ]
+          }
+        }
+      }
+    },
+    "redaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "denyPatterns",
+        "maskSelectors",
+        "reviewRequired"
+      ],
+      "properties": {
+        "denyPatterns": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "maskSelectors": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "reviewRequired": {
+          "const": true
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "captureStatus",
+        "artifacts",
+        "retentionDays",
+        "blocker"
+      ],
+      "properties": {
+        "captureStatus": {
+          "enum": [
+            "blocked",
+            "captured",
+            "published"
+          ]
+        },
+        "artifacts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "kind",
+              "path"
+            ],
+            "properties": {
+              "kind": {
+                "enum": [
+                  "screenshot",
+                  "trace",
+                  "video",
+                  "accessibility-report"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "retentionDays": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "blocker": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "baseBranch",
+        "testFile",
+        "testTitle",
+        "command"
+      ],
+      "properties": {
+        "baseBranch": {
+          "const": "main"
+        },
+        "testFile": {
+          "type": "string",
+          "pattern": "^tests/"
+        },
+        "testTitle": {
+          "type": "string",
+          "minLength": 1
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/scripts/docs/validate-journey-manifests.mjs
+++ b/scripts/docs/validate-journey-manifests.mjs
@@ -1,0 +1,77 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+const manifestDir = path.join(root, "docs", "journeys", "manifests");
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const allowedActions = new Set(["goto", "click", "fill", "press", "observe"]);
+const allowedChecks = new Set([
+  "document-title", "heading-order", "landmarks", "focus-visible",
+  "accessible-names", "contrast", "no-horizontal-overflow",
+]);
+const errors = [];
+const assert = (condition, file, message) => {
+  if (!condition) errors.push(`${file}: ${message}`);
+};
+
+const files = (await readdir(manifestDir)).filter((name) => name.endsWith(".json")).sort();
+assert(files.length > 0, manifestDir, "at least one manifest is required");
+
+for (const file of files) {
+  const relative = path.posix.join("docs/journeys/manifests", file);
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(path.join(manifestDir, file), "utf8"));
+  } catch (error) {
+    errors.push(`${relative}: invalid JSON: ${error.message}`);
+    continue;
+  }
+
+  assert(manifest.schemaVersion === 1, relative, "schemaVersion must be 1");
+  assert(slugPattern.test(manifest.slug ?? ""), relative, "slug must be kebab-case");
+  assert(file === `${manifest.slug}.json`, relative, "filename must equal <slug>.json");
+  for (const key of ["title", "persona", "purpose"]) {
+    assert(typeof manifest[key] === "string" && manifest[key].trim(), relative, `${key} is required`);
+  }
+  assert(Array.isArray(manifest.preconditions) && manifest.preconditions.length > 0, relative, "preconditions are required");
+  assert(manifest.fixture?.secrets === false, relative, "fixture.secrets must be false");
+  assert(["blocked", "mocked", "local-only"].includes(manifest.fixture?.network), relative, "fixture.network must be isolated");
+  assert(Number.isInteger(manifest.viewport?.width) && manifest.viewport.width >= 320, relative, "viewport.width is invalid");
+  assert(Number.isInteger(manifest.viewport?.height) && manifest.viewport.height >= 480, relative, "viewport.height is invalid");
+  assert(Array.isArray(manifest.steps) && manifest.steps.length > 0, relative, "steps are required");
+  for (const step of manifest.steps ?? []) {
+    assert(slugPattern.test(step.id ?? ""), relative, "step id must be kebab-case");
+    assert(allowedActions.has(step.action), relative, `unsupported action ${step.action}`);
+    assert(typeof step.target === "string" && step.target.length > 0, relative, "step target is required");
+    assert(Array.isArray(step.assertions) && step.assertions.length > 0, relative, "each step needs assertions");
+  }
+  assert(manifest.accessibility?.reducedMotion === true, relative, "reducedMotion must be true");
+  for (const check of manifest.accessibility?.checks ?? []) {
+    assert(allowedChecks.has(check), relative, `unsupported accessibility check ${check}`);
+  }
+  assert(manifest.redaction?.reviewRequired === true, relative, "human redaction review is required");
+  assert(Array.isArray(manifest.redaction?.denyPatterns) && manifest.redaction.denyPatterns.length > 0, relative, "denyPatterns are required");
+  assert(["blocked", "captured", "published"].includes(manifest.evidence?.captureStatus), relative, "invalid evidence status");
+  if (manifest.evidence?.captureStatus === "blocked") {
+    assert(typeof manifest.evidence.blocker === "string" && manifest.evidence.blocker.length > 0, relative, "blocked evidence needs a blocker");
+  }
+  assert(manifest.provenance?.baseBranch === "main", relative, "provenance.baseBranch must be main");
+  assert(/^tests\//.test(manifest.provenance?.testFile ?? ""), relative, "provenance.testFile must reference tests/");
+  try {
+    const testSource = await readFile(path.join(root, manifest.provenance.testFile), "utf8");
+    assert(testSource.includes(manifest.provenance.testTitle), relative, "referenced test title was not found");
+    const gotoTargets = (manifest.steps ?? []).filter((step) => step.action === "goto").map((step) => step.target);
+    for (const target of gotoTargets) {
+      assert(testSource.includes(`goto('${target}')`) || testSource.includes(`goto("${target}")`), relative, `route ${target} is not present in the referenced test`);
+    }
+  } catch (error) {
+    errors.push(`${relative}: cannot verify test provenance: ${error.message}`);
+  }
+}
+
+if (errors.length) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}
+console.log(`Validated ${files.length} deterministic journey manifest(s).`);


### PR DESCRIPTION
## Summary

Begins concrete journey-evidence delivery for #322 without choosing unresolved branding:

- machine-readable JSON Schema for deterministic journey manifests
- mandatory redaction and accessibility evidence requirements
- dependency-free manifest/provenance validator
- one smoke manifest grounded in the existing `tests/e2e/smoke.spec.ts` root route and exact v4 heading assertion

## Honest artifact state

The smoke journey is locally reproducible using the existing Playwright lifecycle, but screenshot/trace capture is marked **blocked**. Current `playwright.config.ts` disables its web server in CI, and no dedicated journey job proves the v4 BFF/web preview lifecycle. This PR therefore defines validated artifact paths and requirements without fabricating screenshots.

## Scope

- based on current `main`
- does not touch PR #324 files
- no route, identity, DNS, deployment, secret, or provider changes
- no external-provider fixture

## Validation

`node scripts/docs/validate-journey-manifests.mjs`

Contributes to #322.
