### PR TITLE
ci: pin v4 Oxlint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
     "release:uncovered": "node scripts/release/list-uncovered-commits.mjs",
     "build:tokn-ffi": "cd packages/tokn && node scripts/build.mjs",
     "test:tokn": "tsx --test src/lib/tokn/__tests__/*.test.ts",
-    "ci:v4:lint": "bunx oxlint apps packages",
+    "ci:v4:lint": "bunx oxlint@1.74.0 apps packages",
     "ci:v4:typecheck": "bun run --cwd apps/web typecheck && bun run --cwd apps/bff typecheck",
     "ci:v4:test": "bun --filter \"./apps/*\" test"
   },


### PR DESCRIPTION
## What changed

Pins the v4 CI lint command to `oxlint@1.74.0` instead of resolving an unspecified latest release through `bunx` on every run.

## Why

The v4 package installs are frozen, and CI pins Bun 1.3.14, but lint was the remaining floating executable in the blocking v4 path. The same commit could therefore pass or fail against different Oxlint rule sets without any repository change.

This intentionally does not add TypeScript 7, Oxfmt, type-aware linting, dependency upgrades, or application refactors.

## Evidence

- before: `bunx oxlint apps packages` resolved from the registry at runtime
- after: `bunx oxlint@1.74.0 apps packages`
- `bun run ci:v4:lint` passes with the pinned version
- `git diff --check` passes
- prior clean-main audit also passed all five frozen Bun installs, web/BFF typechecks, focused contracts/BFF tests, and web/BFF builds

The four existing BFF unused-symbol warnings remain visible and are not masked.
