### PR TITLE
ci: prove v4 journey evidence lifecycle

### DIFF
--- a/.github/workflows/v4-journey-evidence.yml
+++ b/.github/workflows/v4-journey-evidence.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install locked dependencies
         run: |
-          bun install --frozen-lockfile --ignore-scripts
+          npm ci --ignore-scripts --no-audit --no-fund
           bun install --frozen-lockfile --cwd packages/api-contracts --ignore-scripts
           bun install --frozen-lockfile --cwd apps/bff --ignore-scripts
           bun install --frozen-lockfile --cwd apps/web --ignore-scripts
@@ -58,7 +58,7 @@ jobs:
       - name: Start BFF and web preview
         run: |
           mkdir -p journey-evidence/service-logs
-          (cd apps/bff && bun run start) >journey-evidence/service-logs/bff.log 2>&1 &
+          (cd apps/bff && PORT=4322 bun run start) >journey-evidence/service-logs/bff.log 2>&1 &
           echo $! > journey-evidence/service-logs/bff.pid
           (cd apps/web && bun run preview --host 127.0.0.1 --port 4321) >journey-evidence/service-logs/web.log 2>&1 &
           echo $! > journey-evidence/service-logs/web.pid

--- a/.github/workflows/v4-journey-evidence.yml
+++ b/.github/workflows/v4-journey-evidence.yml
@@ -1,0 +1,104 @@
+name: v4 journey evidence proof
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/v4-journey-evidence.yml"
+      - "tests/e2e/journey-evidence-smoke.spec.ts"
+      - "apps/web/**"
+      - "apps/bff/**"
+      - "packages/api-contracts/**"
+      - "playwright.config.ts"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v4-journey-evidence-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  capture:
+    name: Capture anonymous home smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      CI: "true"
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:4321
+      NO_COLOR: "1"
+    steps:
+      - name: Check out source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install locked dependencies
+        run: |
+          bun install --frozen-lockfile --ignore-scripts
+          bun install --frozen-lockfile --cwd packages/api-contracts --ignore-scripts
+          bun install --frozen-lockfile --cwd apps/bff --ignore-scripts
+          bun install --frozen-lockfile --cwd apps/web --ignore-scripts
+
+      - name: Install Chromium
+        run: bunx playwright install --with-deps chromium
+
+      - name: Build v4 services
+        run: |
+          cd apps/web
+          bunx svelte-kit sync
+          bun run build
+          cd ../bff
+          bun run build
+
+      - name: Start BFF and web preview
+        run: |
+          mkdir -p journey-evidence/service-logs
+          (cd apps/bff && bun run start) >journey-evidence/service-logs/bff.log 2>&1 &
+          echo $! > journey-evidence/service-logs/bff.pid
+          (cd apps/web && bun run preview --host 127.0.0.1 --port 4321) >journey-evidence/service-logs/web.log 2>&1 &
+          echo $! > journey-evidence/service-logs/web.pid
+
+      - name: Wait for v4 web lifecycle
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error http://127.0.0.1:4321/ >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "v4 web preview did not become ready" >&2
+          exit 1
+
+      - name: Capture deterministic evidence
+        run: bunx playwright test tests/e2e/journey-evidence-smoke.spec.ts --project=chromium --workers=1 --retries=0
+
+      - name: Reject textual secret patterns
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -RIE --exclude='*.png' --exclude='*.zip' '(api[-_ ]?key|authorization|token|secret|cookie)[[:space:]]*[:=][[:space:]]*[^[:space:]]+|bearer[[:space:]]+[^[:space:]]+' journey-evidence; then
+            echo "Potential secret material found in journey evidence" >&2
+            exit 1
+          fi
+
+      - name: Upload journey evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: anonymous-home-smoke-${{ github.sha }}
+          path: |
+            journey-evidence/anonymous-home-smoke/
+            journey-evidence/service-logs/
+            playwright-report/
+            test-results/
+          if-no-files-found: warn
+          retention-days: 14
+          include-hidden-files: false

--- a/tests/e2e/journey-evidence-smoke.spec.ts
+++ b/tests/e2e/journey-evidence-smoke.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/test";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const evidenceRoot = path.resolve("journey-evidence/anonymous-home-smoke");
+const forbiddenText = /(api[-_ ]?key|authorization|token|secret|cookie)\s*[:=]\s*\S+|bearer\s+\S+/i;
+
+test.use({
+  viewport: { width: 1280, height: 800 },
+  deviceScaleFactor: 1,
+  reducedMotion: "reduce",
+  colorScheme: "light",
+});
+
+test("captures anonymous v4 home journey evidence", async ({ page, context }) => {
+  await mkdir(evidenceRoot, { recursive: true });
+
+  await context.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    if (["127.0.0.1", "localhost"].includes(url.hostname)) {
+      await route.continue();
+      return;
+    }
+    await route.abort("blockedbyclient");
+  });
+
+  await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+  await page.goto("/", { waitUntil: "networkidle" });
+
+  const heading = page.locator("h1").first();
+  await expect(heading).toContainText("Welcome to OmniRoute v4");
+  await expect(page.locator("body")).not.toContainText(forbiddenText);
+
+  await page.locator("input[type='password'], [data-sensitive='true']").evaluateAll((nodes) => {
+    for (const node of nodes) {
+      node.setAttribute("value", "[REDACTED]");
+      node.textContent = "[REDACTED]";
+    }
+  });
+
+  const accessibility = await page.evaluate(() => {
+    const headings = Array.from(document.querySelectorAll("h1,h2,h3,h4,h5,h6")).map((element) => ({
+      level: Number(element.tagName.slice(1)),
+      text: element.textContent?.trim() ?? "",
+    }));
+    const hasHeadingSkip = headings.some((heading, index) =>
+      index > 0 && heading.level > headings[index - 1].level + 1
+    );
+    return {
+      title: document.title,
+      language: document.documentElement.lang || null,
+      headingCount: headings.length,
+      hasHeadingSkip,
+      landmarks: {
+        main: document.querySelectorAll("main").length,
+        navigation: document.querySelectorAll("nav").length,
+      },
+      imagesMissingAlt: document.querySelectorAll("img:not([alt])").length,
+      unnamedButtons: Array.from(document.querySelectorAll("button")).filter(
+        (button) => !(button.getAttribute("aria-label") || button.textContent?.trim())
+      ).length,
+      horizontalOverflow: document.documentElement.scrollWidth > window.innerWidth + 1,
+      reducedMotion: window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+    };
+  });
+
+  expect(accessibility.title).not.toBe("");
+  expect(accessibility.headingCount).toBeGreaterThan(0);
+  expect(accessibility.hasHeadingSkip).toBe(false);
+  expect(accessibility.landmarks.main).toBeGreaterThan(0);
+  expect(accessibility.imagesMissingAlt).toBe(0);
+  expect(accessibility.unnamedButtons).toBe(0);
+  expect(accessibility.horizontalOverflow).toBe(false);
+  expect(accessibility.reducedMotion).toBe(true);
+
+  await writeFile(
+    path.join(evidenceRoot, "accessibility-smoke.json"),
+    JSON.stringify(accessibility, null, 2) + "\n",
+    { mode: 0o600 }
+  );
+  await page.screenshot({
+    path: path.join(evidenceRoot, "home.png"),
+    fullPage: false,
+    animations: "disabled",
+  });
+  await context.tracing.stop({ path: path.join(evidenceRoot, "trace.zip") });
+});


### PR DESCRIPTION
## Summary

Separate CI proof for #325 and #322:

- starts the existing v4 BFF and built web preview using repository scripts
- waits on the existing root route
- runs a deterministic Chromium smoke capture with local-only networking and reduced motion
- uploads ephemeral screenshot, Playwright trace, accessibility-smoke JSON, service logs, and failure diagnostics
- blocks obvious textual secret patterns before publication

## Security and scope

- `contents: read` only
- pinned action commit SHAs
- Bun pinned to 1.3.14
- 15-minute job timeout, one worker, no retries
- no repository secrets or provider credentials
- external browser requests are aborted
- artifacts retained for 14 days; no screenshot is committed
- no deployment, DNS, route, identity, schema, or production code changes

## Expected evidence

Artifact `anonymous-home-smoke-<commit>` contains, when the lifecycle succeeds:

- `home.png` at 1280×800, reduced motion
- `trace.zip` with Playwright screenshots/snapshots/sources
- `accessibility-smoke.json` with title, language, headings, landmarks, missing-alt/unnamed-button counts, overflow, reduced-motion, and viewport assertions
- BFF/web lifecycle logs
- Playwright report/test results on failure

## Validation requested

This draft exists to prove the service lifecycle in GitHub-hosted CI. It does not mark #325 evidence as captured until the workflow run succeeds and artifacts pass redaction review.
