### PR TITLE
docs: scaffold deterministic v4 documentation app

### DIFF
--- a/.github/workflows/v4-docs-build.yml
+++ b/.github/workflows/v4-docs-build.yml
@@ -1,0 +1,44 @@
+name: v4 docs scaffold build
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/v4-docs-build.yml"
+      - "apps/docs/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/v4-docs-build.yml"
+      - "apps/docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v4-docs-build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Validate public boundary
+        run: node apps/docs/scripts/build.mjs --check
+      - name: Build deterministic preview
+        run: |
+          node apps/docs/scripts/build.mjs
+          test -s apps/docs/dist/index.html
+          test -s apps/docs/dist/build-manifest.json
+          grep -q '"deployable": false' apps/docs/dist/build-manifest.json
+      - name: Upload non-deployable preview
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v4-docs-scaffold-${{ github.sha }}
+          path: apps/docs/dist/
+          if-no-files-found: error
+          retention-days: 7
+          include-hidden-files: false

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,0 +1,32 @@
+# v4 documentation application scaffold
+
+The rewritten v4 tree does not currently contain a routed docs application: `apps/web` has no `/docs` route and uses the SvelteKit Node adapter. Legacy root Fumadocs/Next configuration still exists, but its broad source glob includes unreviewed architecture, security, framework, and operations material and is not a safe public deployment input.
+
+This zero-dependency scaffold establishes a deterministic public-docs build without copying that material.
+
+## Build
+
+```sh
+node apps/docs/scripts/build.mjs
+node apps/docs/scripts/build.mjs --check
+```
+
+Outputs are written to `apps/docs/dist/`:
+
+- accessible static `index.html`
+- `styles.css`
+- machine-readable `search-index.json`
+- deterministic `build-manifest.json` with the source digest and deployment-readiness flag
+
+## Publication gate
+
+Every section in `content/public-boundary.json` starts with `publishable: false`. The build manifest remains `deployable: false` until reviewed, source-backed content exists. The validation workflow uploads only a preview artifact; it does not configure or deploy GitHub Pages.
+
+A later deployment PR may add Pages only after:
+
+1. the identity/URL decisions tracked in #322 are approved;
+2. at least one user-facing section has reviewed content and provenance;
+3. link, accessibility, secret, and capability-drift gates exist;
+4. repository Pages settings and base-path behavior are explicitly selected.
+
+This scaffold deliberately avoids the three decision-input files in #324 and the journey schema paths in #325.

--- a/apps/docs/content/public-boundary.json
+++ b/apps/docs/content/public-boundary.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": 1,
+  "site": {
+    "title": "OmniRoute documentation",
+    "description": "Task-oriented documentation scaffold for the v4 product surface.",
+    "status": "scaffold"
+  },
+  "sections": [
+    {
+      "slug": "evaluate",
+      "title": "Evaluate",
+      "description": "Product overview, verified capabilities, comparisons, and trust information.",
+      "publishable": false
+    },
+    {
+      "slug": "quickstart",
+      "title": "Quickstart",
+      "description": "Prerequisites, installation, first verified request, and uninstall.",
+      "publishable": false
+    },
+    {
+      "slug": "journeys",
+      "title": "Journeys",
+      "description": "Reproducible user workflows backed by deterministic evidence.",
+      "publishable": false
+    },
+    {
+      "slug": "concepts",
+      "title": "Concepts",
+      "description": "Architecture, providers, routing, resilience, authentication, and protocols.",
+      "publishable": false
+    },
+    {
+      "slug": "reference",
+      "title": "Reference",
+      "description": "Generated API, provider, CLI, environment, and configuration reference.",
+      "publishable": false
+    },
+    {
+      "slug": "operations",
+      "title": "Operations",
+      "description": "Deployment, monitoring, recovery, security hardening, and upgrades.",
+      "publishable": false
+    },
+    {
+      "slug": "contribute",
+      "title": "Contribute",
+      "description": "Development setup, testing, architecture decisions, and project policies.",
+      "publishable": false
+    }
+  ]
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@omniroute/docs",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "check": "node scripts/build.mjs --check"
+  }
+}

--- a/apps/docs/scripts/build.mjs
+++ b/apps/docs/scripts/build.mjs
@@ -1,0 +1,88 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import process from "node:process";
+
+const appRoot = path.resolve(import.meta.dirname, "..");
+const sourcePath = path.join(appRoot, "content", "public-boundary.json");
+const outputRoot = path.join(appRoot, "dist");
+const checkOnly = process.argv.includes("--check");
+const source = JSON.parse(await readFile(sourcePath, "utf8"));
+
+if (source.schemaVersion !== 1) throw new Error("Unsupported content schema");
+if (!source.site?.title || !source.site?.description) throw new Error("Site metadata is required");
+if (!Array.isArray(source.sections) || source.sections.length === 0) throw new Error("At least one section is required");
+
+const slugs = new Set();
+for (const section of source.sections) {
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(section.slug)) throw new Error(`Invalid slug: ${section.slug}`);
+  if (slugs.has(section.slug)) throw new Error(`Duplicate slug: ${section.slug}`);
+  slugs.add(section.slug);
+  if (!section.title || !section.description || typeof section.publishable !== "boolean") {
+    throw new Error(`Incomplete section: ${section.slug}`);
+  }
+}
+
+const escapeHtml = (value) => String(value)
+  .replaceAll("&", "&amp;")
+  .replaceAll("<", "&lt;")
+  .replaceAll(">", "&gt;")
+  .replaceAll('"', "&quot;")
+  .replaceAll("'", "&#39;");
+
+const cards = source.sections.map((section) => `
+  <article id="${escapeHtml(section.slug)}" aria-labelledby="${escapeHtml(section.slug)}-title">
+    <p class="status">${section.publishable ? "Reviewed" : "Content pending review"}</p>
+    <h2 id="${escapeHtml(section.slug)}-title">${escapeHtml(section.title)}</h2>
+    <p>${escapeHtml(section.description)}</p>
+  </article>`).join("");
+
+const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="${escapeHtml(source.site.description)}">
+  <title>${escapeHtml(source.site.title)}</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <a class="skip" href="#content">Skip to content</a>
+  <header>
+    <p class="eyebrow">Documentation scaffold</p>
+    <h1>${escapeHtml(source.site.title)}</h1>
+    <p>${escapeHtml(source.site.description)}</p>
+    <p class="notice">This preview defines the public information boundary. Sections remain unpublished until their content is reviewed and source-backed.</p>
+  </header>
+  <main id="content">${cards}
+  </main>
+  <footer><p>Build input: content/public-boundary.json</p></footer>
+</body>
+</html>
+`;
+
+const css = `:root{color-scheme:light dark;font:16px/1.55 system-ui,sans-serif}*{box-sizing:border-box}body{max-width:72rem;margin:auto;padding:2rem;color:CanvasText;background:Canvas}.skip{position:absolute;left:-9999px}.skip:focus{left:1rem;top:1rem;padding:.5rem;background:Canvas}.eyebrow,.status{font-size:.8rem;text-transform:uppercase;letter-spacing:.08em}.notice,article{border:1px solid GrayText;border-radius:.5rem;padding:1rem}main{display:grid;grid-template-columns:repeat(auto-fit,minmax(16rem,1fr));gap:1rem;margin-block:2rem}h1,h2{line-height:1.2}footer{border-top:1px solid GrayText;margin-top:2rem;padding-top:1rem}@media(prefers-reduced-motion:reduce){*{scroll-behavior:auto!important}}\n`;
+
+const searchIndex = source.sections.map(({ slug, title, description, publishable }) => ({
+  slug, title, description, publishable,
+}));
+const buildManifest = {
+  schemaVersion: 1,
+  source: "content/public-boundary.json",
+  sourceSha256: createHash("sha256").update(JSON.stringify(source)).digest("hex"),
+  outputs: ["index.html", "styles.css", "search-index.json"],
+  deployable: source.sections.some((section) => section.publishable),
+};
+
+if (checkOnly) {
+  console.log(`Validated ${source.sections.length} public documentation section(s); deployable=${buildManifest.deployable}.`);
+  process.exit(0);
+}
+
+await rm(outputRoot, { recursive: true, force: true });
+await mkdir(outputRoot, { recursive: true });
+await writeFile(path.join(outputRoot, "index.html"), html);
+await writeFile(path.join(outputRoot, "styles.css"), css);
+await writeFile(path.join(outputRoot, "search-index.json"), JSON.stringify(searchIndex, null, 2) + "\n");
+await writeFile(path.join(outputRoot, "build-manifest.json"), JSON.stringify(buildManifest, null, 2) + "\n");
+console.log(`Built deterministic docs scaffold with ${source.sections.length} section(s); deployable=${buildManifest.deployable}.`);


### PR DESCRIPTION
## Summary

The v4 rewrite has no real docs route/app in `apps/web`. The legacy root Fumadocs/Next configuration still exists, but its broad globs include unreviewed material and are not a safe public deployment boundary.

This PR adds the smallest real, zero-dependency static docs application:

- structured public-boundary content input
- deterministic Node build with HTML/CSS/search index/build manifest
- accessibility basics and explicit non-publishable section state
- pinned, least-privilege PR/main build-validation workflow
- ephemeral preview artifact only

## Deployment status

**Not deployed and intentionally not deployable.** Every section is `publishable: false`; CI asserts `deployable: false`. No Pages workflow, environment, custom domain, DNS, secret, or branding choice is added.

Pages delivery remains gated on reviewed source-backed content, #322 identity/URL decisions, link/accessibility/secret/capability-drift gates, and explicit base-path/Pages configuration.

## Scope

- separate from #324 decision-input files and #325 journey paths
- no stale/internal docs copied
- no production app route or runtime dependency changed
- build uses Node standard library only

Contributes to #322.
