### PR TITLE
release: add evidence-backed v4 readiness validator

### DIFF
--- a/.github/workflows/v4-release-readiness.yml
+++ b/.github/workflows/v4-release-readiness.yml
@@ -1,0 +1,43 @@
+name: v4 release readiness
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/v4-release-readiness.yml"
+      - ".github/workflows/release.yml"
+      - "config/release/v4-readiness.json"
+      - "scripts/release/validate-v4-release-readiness.mjs"
+      - "apps/web/package.json"
+      - "apps/bff/package.json"
+      - "apps/desktop/package.json"
+      - "apps/desktop/src-tauri/tauri.conf.json"
+      - "apps/desktop/src-tauri/Cargo.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v4-release-readiness-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Generate evidence-backed readiness report
+        run: node scripts/release/validate-v4-release-readiness.mjs
+      - name: Validate report shape
+        run: |
+          node -e "const r=require('./release-readiness/v4-release-readiness.json'); if(r.schemaVersion!==1||!Array.isArray(r.findings)||r.findings.length<1) process.exit(1)"
+      - name: Upload readiness report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v4-release-readiness-${{ github.sha }}
+          path: release-readiness/v4-release-readiness.json
+          if-no-files-found: error
+          retention-days: 14
+          include-hidden-files: false

--- a/config/release/v4-readiness.json
+++ b/config/release/v4-readiness.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": 1,
+  "releaseWorkflow": ".github/workflows/release.yml",
+  "versionGroups": [
+    {
+      "name": "v4-application",
+      "members": [
+        { "path": "apps/web/package.json", "format": "json", "field": "version" },
+        { "path": "apps/bff/package.json", "format": "json", "field": "version" },
+        { "path": "apps/desktop/package.json", "format": "json", "field": "version" },
+        { "path": "apps/desktop/src-tauri/tauri.conf.json", "format": "json", "field": "version" },
+        { "path": "apps/desktop/src-tauri/Cargo.toml", "format": "toml-package-version" }
+      ]
+    }
+  ],
+  "independentSurfaces": [
+    {
+      "path": "package.json",
+      "reason": "Legacy npm/CLI surface has an independent existing version line; this validator does not change or align it."
+    }
+  ],
+  "requiredControls": [
+    "pinned-actions",
+    "frozen-installs",
+    "checksums",
+    "sbom",
+    "provenance",
+    "no-secret-repository-clone",
+    "tag-version-validation"
+  ]
+}

--- a/docs/ops/V4_RELEASE_READINESS.md
+++ b/docs/ops/V4_RELEASE_READINESS.md
@@ -1,0 +1,25 @@
+# v4 release readiness validator
+
+This validator reports whether the existing v4 release path has the minimum reproducibility controls required for a release candidate. It does not publish, sign, attest, upload, or merge anything.
+
+Run:
+
+```sh
+node scripts/release/validate-v4-release-readiness.mjs
+```
+
+Use `--strict` only when the release workflow is expected to satisfy every control.
+
+The v4 app manifests form one version group. The legacy root npm/CLI package is explicitly treated as an independent existing release surface so this work does not silently align versions or break npm compatibility. Native platform support is neither expanded nor reduced.
+
+The generated report records:
+
+- agreement among existing v4 web, BFF, desktop, Tauri, and Cargo versions;
+- action SHA pinning;
+- frozen installs;
+- checksum, SBOM, and provenance controls;
+- absence of secret-backed repository cloning;
+- tag/version validation;
+- a digest of independent release-surface manifests.
+
+Related readiness epic: #322.

--- a/scripts/release/validate-v4-release-readiness.mjs
+++ b/scripts/release/validate-v4-release-readiness.mjs
@@ -1,0 +1,70 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+const configPath = path.join(root, "config/release/v4-readiness.json");
+const config = JSON.parse(await readFile(configPath, "utf8"));
+const findings = [];
+
+const add = (control, passed, evidence) => findings.push({ control, passed, evidence });
+const getField = (object, field) => field.split(".").reduce((value, key) => value?.[key], object);
+
+for (const group of config.versionGroups) {
+  const values = [];
+  for (const member of group.members) {
+    const source = await readFile(path.join(root, member.path), "utf8");
+    let value;
+    if (member.format === "json") {
+      value = getField(JSON.parse(source), member.field);
+    } else if (member.format === "toml-package-version") {
+      const packageBlock = source.match(/\[package\]([\s\S]*?)(?:\n\[|$)/)?.[1] ?? "";
+      value = packageBlock.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+    }
+    values.push({ path: member.path, value: value ?? null });
+  }
+  const distinct = [...new Set(values.map(({ value }) => value))];
+  add(`version-group:${group.name}`, distinct.length === 1 && distinct[0] !== null, values);
+}
+
+const workflow = await readFile(path.join(root, config.releaseWorkflow), "utf8");
+const actionUses = [...workflow.matchAll(/^\s*-?\s*uses:\s*([^\s#]+)/gm)].map((match) => match[1]);
+const unpinned = actionUses.filter((use) => {
+  const ref = use.split("@")[1] ?? "";
+  return !/^[0-9a-f]{40}$/.test(ref);
+});
+add("pinned-actions", actionUses.length > 0 && unpinned.length === 0, { actionUses, unpinned });
+add("frozen-installs", /bun install[^\n]*--frozen-lockfile/.test(workflow), "release workflow must use frozen lockfiles");
+add("checksums", /sha256sum|SHA256SUMS/i.test(workflow), "release workflow must emit checksums for artifacts");
+add("sbom", /\bsbom\b|cyclonedx|syft/i.test(workflow), "release workflow must produce an SBOM");
+add("provenance", /attest-build-provenance|slsa|provenance/i.test(workflow), "release workflow must produce verifiable provenance");
+add("no-secret-repository-clone", !/actions\/checkout@[^\n]+[\s\S]{0,240}token:\s*\$\{\{\s*secrets\./.test(workflow), "release must use the triggering checkout without a secret-backed second clone");
+add("tag-version-validation", /github\.ref_name[\s\S]{0,500}(package\.json|tauri\.conf|Cargo\.toml)|verify[^\n]*version/i.test(workflow), "tag/version agreement must be checked before artifacts are built");
+
+const independentSurfaces = [];
+for (const surface of config.independentSurfaces) {
+  const source = await readFile(path.join(root, surface.path), "utf8");
+  independentSurfaces.push({
+    path: surface.path,
+    reason: surface.reason,
+    sha256: createHash("sha256").update(source).digest("hex"),
+  });
+}
+
+const report = {
+  schemaVersion: 1,
+  repository: "KooshaPari/OmniRoute",
+  commit: process.env.GITHUB_SHA || null,
+  ready: findings.every(({ passed }) => passed),
+  findings,
+  independentSurfaces,
+};
+const outDir = path.join(root, "release-readiness");
+await mkdir(outDir, { recursive: true });
+await writeFile(path.join(outDir, "v4-release-readiness.json"), JSON.stringify(report, null, 2) + "\n");
+for (const finding of findings) {
+  console.log(`${finding.passed ? "PASS" : "BLOCK"} ${finding.control}`);
+}
+console.log(`V4 release ready: ${report.ready}`);
+if (process.argv.includes("--strict") && !report.ready) process.exit(1);


### PR DESCRIPTION
## Summary

Closes the highest verified pre-release visibility gap from #322 without publishing artifacts:

- defines the existing v4 application version group
- preserves the legacy npm/CLI package as an explicitly independent surface
- generates a machine-readable readiness report
- verifies version agreement, pinned actions, frozen installs, checksums, SBOM, provenance, tag/version validation, and absence of secret-backed second checkout
- uploads the report through a pinned, `contents: read` workflow

## Current expected result

The report is evidence, not a fabricated green gate. It should show v4 manifest version agreement while identifying missing reproducibility controls in the existing release workflow. The workflow runs non-strictly until those controls are implemented; `--strict` is available for the eventual release gate.

## Scope

- no release publication, tag, signing, attestation, or deployment
- no version changes or support-matrix claims
- no npm/native workflow mutation
- no docs-app or journey paths from #324/#325/#327/#329
