### PR TITLE
ci: enforce v4 Bun version parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  bun-version-parity:
+    name: Bun version parity
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: bun scripts/check/check-v4-bun-version.mjs
+
   lint:
     name: Lint (oxlint)
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.14
       - name: Build v4 monorepo
         run: |
           cd OmniRoute

--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "bun@1.3.14",
+  "engines": {
+    "bun": "1.3.14"
+  },
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "start": "bun run src/index.ts",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "bun@1.3.14",
+  "engines": {
+    "bun": "1.3.14"
+  },
   "description": "argismonitor native desktop shell (Tauri 2.x)",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "bun@1.3.14",
+  "engines": {
+    "bun": "1.3.14"
+  },
   "scripts": {
     "dev": "vite dev --port 4321",
     "build": "vite build",

--- a/packages/api-contracts/package.json
+++ b/packages/api-contracts/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "bun@1.3.14",
+  "engines": {
+    "bun": "1.3.14"
+  },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "bun@1.3.14",
+  "engines": { "bun": "1.3.14" },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": { ".": "./src/index.ts", "./tailwind": "./src/tailwind.ts" },

--- a/scripts/check/check-v4-bun-version.mjs
+++ b/scripts/check/check-v4-bun-version.mjs
@@ -1,0 +1,72 @@
+import { readFile } from "node:fs/promises";
+
+const v4Packages = [
+  "packages/api-contracts",
+  "packages/design-tokens",
+  "apps/bff",
+  "apps/web",
+  "apps/desktop",
+];
+const bunWorkflows = [
+  ".github/workflows/ci.yml",
+  ".github/workflows/argismonitor-ci.yml",
+  ".github/workflows/release.yml",
+];
+
+const failures = [];
+const versions = new Set();
+
+for (const directory of v4Packages) {
+  const manifest = JSON.parse(await readFile(`${directory}/package.json`, "utf8"));
+  const packageManager = manifest.packageManager;
+  const packageManagerMatch = /^bun@(\d+\.\d+\.\d+)$/.exec(packageManager ?? "");
+  const engineVersion = manifest.engines?.bun;
+
+  if (!packageManagerMatch) {
+    failures.push(`${directory}/package.json must pin packageManager to bun@<exact version>`);
+    continue;
+  }
+
+  const version = packageManagerMatch[1];
+  versions.add(version);
+  if (engineVersion !== version) {
+    failures.push(`${directory}/package.json engines.bun must equal ${version}`);
+  }
+
+  const lockfile = await readFile(`${directory}/bun.lock`, "utf8");
+  if (!/"lockfileVersion"\s*:\s*1\b/.test(lockfile)) {
+    failures.push(`${directory}/bun.lock must use the expected text lockfile format`);
+  }
+}
+
+if (versions.size !== 1) {
+  failures.push(`v4 packageManager pins disagree: ${[...versions].sort().join(", ")}`);
+}
+
+const [expectedVersion] = versions;
+for (const workflow of bunWorkflows) {
+  const source = await readFile(workflow, "utf8");
+  const workflowVersions = [...source.matchAll(/bun-version:\s*([0-9]+\.[0-9]+\.[0-9]+)/g)].map(
+    (match) => match[1],
+  );
+
+  if (workflowVersions.length === 0) {
+    failures.push(`${workflow} must contain an exact bun-version pin`);
+  }
+  for (const version of workflowVersions) {
+    if (version !== expectedVersion) {
+      failures.push(`${workflow} pins Bun ${version}; expected ${expectedVersion}`);
+    }
+  }
+}
+
+if (process.versions.bun && process.versions.bun !== expectedVersion) {
+  failures.push(`running Bun ${process.versions.bun}; expected ${expectedVersion}`);
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) console.error(`Bun parity check failed: ${failure}`);
+  process.exit(1);
+}
+
+console.log(`Bun ${expectedVersion} is aligned across v4 manifests, locks, workflows, and runtime`);


### PR DESCRIPTION
Refs #319.

## What changed

- pins `packageManager` and `engines.bun` to Bun 1.3.14 in the five private v4 packages
- aligns the v4 release workflow from Bun 1.3.11 to 1.3.14, matching CI and ArgisMonitor CI
- adds a fast CI sentinel that verifies v4 manifest pins, text lockfile format, all Bun workflow pins, and the executing Bun runtime

The public root npm package and legacy npm/Electron publication paths are intentionally unchanged.

## Root cause

CI used Bun 1.3.14, but the release workflow still used 1.3.11 and none of the v4 manifests declared their expected package manager/runtime. That allowed developer and release tooling to drift independently from the lockfiles and blocking CI.

## Validation

- parity sentinel passes under Bun 1.3.14
- all five `bun install --frozen-lockfile --ignore-scripts` commands pass
- web Svelte check reports 0 errors and 0 warnings
- BFF TypeScript check passes
- API contracts tests pass 2/2
- BFF Vitest passes 1/1
- SvelteKit production build passes
- BFF Bun build passes
- `git diff --check` passes

No CI install deduplication, TypeScript 7, Oxfmt, dependency update, or application refactor is included.
