### PR TITLE
release: add deterministic v4 artifact dry run

### DIFF
--- a/.github/workflows/v4-release-artifact-dry-run.yml
+++ b/.github/workflows/v4-release-artifact-dry-run.yml
@@ -1,0 +1,85 @@
+name: v4 release artifact dry run
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/v4-release-artifact-dry-run.yml"
+      - "scripts/release/prepare-v4-artifact-dry-run.mjs"
+      - "apps/web/**"
+      - "apps/bff/**"
+      - "apps/desktop/package.json"
+      - "apps/desktop/src-tauri/tauri.conf.json"
+      - "apps/desktop/src-tauri/Cargo.toml"
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v4-release-artifact-dry-run-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  artifacts:
+    name: Build dry-run artifacts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 12
+    env:
+      RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+      SOURCE_DATE_EPOCH: "0"
+      NO_COLOR: "1"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install locked v4 dependencies
+        run: |
+          bun install --frozen-lockfile --cwd packages/api-contracts --ignore-scripts
+          bun install --frozen-lockfile --cwd apps/bff --ignore-scripts
+          bun install --frozen-lockfile --cwd apps/web --ignore-scripts
+
+      - name: Tag and version preflight
+        run: node scripts/release/prepare-v4-artifact-dry-run.mjs
+
+      - name: Build existing v4 web and BFF artifacts
+        run: |
+          cd apps/web
+          bunx svelte-kit sync
+          bun run build
+          cd ../bff
+          bun run build
+
+      - name: Create deterministic archives and checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./apps/web/package.json').version")"
+          tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner -C apps/web -cf - build | gzip -n > "release-candidate/omniroute-web-${version}.tar.gz"
+          tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner -C apps/bff -cf - dist | gzip -n > "release-candidate/omniroute-bff-${version}.tar.gz"
+          (
+            cd release-candidate
+            sha256sum "omniroute-web-${version}.tar.gz" "omniroute-bff-${version}.tar.gz" v4-sbom.cdx.json v4-preflight.json > SHA256SUMS
+            sha256sum --check SHA256SUMS
+          )
+
+      - name: Assert dry-run boundaries
+        run: |
+          node -e "const p=require('./release-candidate/v4-preflight.json'); if(p.publication||p.signing||p.nativeCompatibilityChanged||p.npmCompatibilityChanged) process.exit(1)"
+          test -s release-candidate/SHA256SUMS
+          test -s release-candidate/v4-sbom.cdx.json
+
+      - name: Upload release candidate only
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v4-release-candidate-${{ github.sha }}
+          path: release-candidate/
+          if-no-files-found: error
+          retention-days: 14
+          include-hidden-files: false

--- a/docs/ops/V4_RELEASE_ARTIFACT_DRY_RUN.md
+++ b/docs/ops/V4_RELEASE_ARTIFACT_DRY_RUN.md
@@ -1,0 +1,14 @@
+# v4 release artifact dry run
+
+This workflow produces an ephemeral release-candidate artifact without creating a GitHub Release, publishing npm packages, signing files, deploying services, or changing native targets.
+
+It uses the existing v4 web and BFF build commands, then emits:
+
+- deterministic web and BFF `.tar.gz` archives;
+- `SHA256SUMS`, verified in the same job;
+- a CycloneDX 1.6 component SBOM for the existing v4 application surfaces;
+- `v4-preflight.json` recording version/tag agreement and explicit compatibility/publication boundaries.
+
+On a tag, the tag must exactly equal `v<existing v4 version>`. On pull requests and manual runs, the same version-group check runs without inventing a tag.
+
+The legacy root npm/CLI surface and native platform workflows remain untouched. This is a hardening slice for #330 and #322, not a release.

--- a/scripts/release/prepare-v4-artifact-dry-run.mjs
+++ b/scripts/release/prepare-v4-artifact-dry-run.mjs
@@ -1,0 +1,85 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+const output = path.join(root, "release-candidate");
+const manifests = [
+  ["web", "apps/web/package.json", "npm"],
+  ["bff", "apps/bff/package.json", "npm"],
+  ["desktop", "apps/desktop/package.json", "npm"],
+  ["desktop-tauri", "apps/desktop/src-tauri/tauri.conf.json", "application"],
+];
+const components = [];
+for (const [key, relative, type] of manifests) {
+  const bytes = await readFile(path.join(root, relative));
+  const manifest = JSON.parse(bytes);
+  if (!manifest.version) throw new Error(`${relative} has no version`);
+  components.push({
+    type,
+    name: manifest.name || manifest.productName || key,
+    version: manifest.version,
+    properties: [
+      { name: "omniroute:surface", value: key },
+      { name: "omniroute:manifest", value: relative },
+      { name: "omniroute:manifest:sha256", value: createHash("sha256").update(bytes).digest("hex") },
+    ],
+  });
+}
+const cargo = await readFile(path.join(root, "apps/desktop/src-tauri/Cargo.toml"), "utf8");
+const cargoVersion = cargo.match(/\[package\]([\s\S]*?)(?:\n\[|$)/)?.[1]?.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+if (!cargoVersion) throw new Error("Cargo package version not found");
+components.push({
+  type: "application",
+  name: "argismonitor-desktop",
+  version: cargoVersion,
+  properties: [{ name: "omniroute:manifest", value: "apps/desktop/src-tauri/Cargo.toml" }],
+});
+
+const versions = [...new Set(components.map(({ version }) => version))];
+if (versions.length !== 1) {
+  throw new Error(`v4 version mismatch: ${components.map(({ name, version }) => `${name}=${version}`).join(", ")}`);
+}
+const version = versions[0];
+const tag = process.env.RELEASE_TAG?.trim();
+if (tag && tag !== `v${version}`) {
+  throw new Error(`release tag ${tag} does not match v4 version v${version}`);
+}
+
+const commit = process.env.GITHUB_SHA || "local";
+const serial = Number.parseInt(createHash("sha256").update(commit).digest("hex").slice(0, 8), 16);
+const sbom = {
+  bomFormat: "CycloneDX",
+  specVersion: "1.6",
+  serialNumber: `urn:uuid:00000000-0000-4000-8000-${serial.toString(16).padStart(12, "0")}`,
+  version: 1,
+  metadata: {
+    component: {
+      type: "application",
+      name: "omniroute-v4-release-candidate",
+      version,
+      properties: [
+        { name: "omniroute:commit", value: commit },
+        { name: "omniroute:publication", value: "dry-run" },
+      ],
+    },
+  },
+  components,
+};
+const preflight = {
+  schemaVersion: 1,
+  version,
+  tag: tag || null,
+  commit,
+  publication: false,
+  signing: false,
+  nativeCompatibilityChanged: false,
+  npmCompatibilityChanged: false,
+  manifests: components.map(({ name, version, properties }) => ({ name, version, properties })),
+};
+
+await mkdir(output, { recursive: true });
+await writeFile(path.join(output, "v4-preflight.json"), JSON.stringify(preflight, null, 2) + "\n");
+await writeFile(path.join(output, "v4-sbom.cdx.json"), JSON.stringify(sbom, null, 2) + "\n");
+console.log(`Validated v4 release candidate ${version}${tag ? ` against ${tag}` : ""}; publication disabled.`);


### PR DESCRIPTION
## Summary

First concrete hardening slice following #330 and #322:

- validates agreement across existing v4 web/BFF/desktop/Tauri/Cargo versions
- validates an actual tag as `v<existing v4 version>` when tag-triggered
- builds existing v4 web and BFF outputs
- creates deterministic gzip archives
- generates and verifies SHA-256 checksums
- generates a CycloneDX 1.6 component SBOM and dry-run preflight record
- uploads artifacts only

## Non-publication boundary

This workflow has `contents: read` only. It does not create a release, publish npm/native assets, sign/attest, deploy, or mutate platform/version support. The existing release workflows remain unchanged.

On pull requests it is strictly an artifact dry run. Tag execution still uploads only the private workflow artifact and fails if the tag disagrees with the existing v4 version.
