### PR TITLE
docs: add source-backed v4 local Quickstart

### DIFF
--- a/.github/workflows/v4-quickstart-provenance.yml
+++ b/.github/workflows/v4-quickstart-provenance.yml
@@ -1,0 +1,26 @@
+name: v4 Quickstart provenance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/v4-quickstart-provenance.yml"
+      - "docs/public/QUICKSTART_V4.md"
+      - "scripts/docs/validate-v4-quickstart.mjs"
+      - "apps/web/package.json"
+      - "apps/bff/package.json"
+      - "apps/bff/src/index.ts"
+      - "apps/web/src/routes/+page.svelte"
+      - "tests/e2e/smoke.spec.ts"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - run: node scripts/docs/validate-v4-quickstart.mjs

--- a/docs/public/QUICKSTART_V4.md
+++ b/docs/public/QUICKSTART_V4.md
@@ -1,0 +1,127 @@
+---
+title: v4 local Quickstart
+audience: user
+status: reviewed-source
+sourceOfTruth:
+  - apps/web/package.json
+  - apps/bff/package.json
+  - apps/bff/src/index.ts
+  - apps/web/src/routes/+page.svelte
+  - tests/e2e/smoke.spec.ts
+---
+
+# Run the v4 web app and BFF locally
+
+This Quickstart proves only the current local web shell, BFF health route, and anonymous home page. It does not configure a provider, claim an external deployment, or test an authenticated API request.
+
+## Prerequisites
+
+- Git
+- Bun 1.3.14, matching the current v4 CI pin
+- A shell that supports POSIX-style environment assignment for the BFF command below
+- local ports 4321 and 4322 available
+
+## 1. Get a clean checkout
+
+```sh
+git clone https://github.com/KooshaPari/OmniRoute.git
+cd OmniRoute
+git switch main
+```
+
+Confirm that the worktree is clean before continuing:
+
+```sh
+git status --short
+```
+
+The command should print nothing.
+
+## 2. Install the locked v4 dependencies
+
+```sh
+bun install --frozen-lockfile --cwd packages/api-contracts --ignore-scripts
+bun install --frozen-lockfile --cwd apps/bff --ignore-scripts
+bun install --frozen-lockfile --cwd apps/web --ignore-scripts
+```
+
+These are the package-local install forms used by the current v4 CI. This Quickstart does not require provider credentials.
+
+## 3. Start the BFF
+
+In terminal 1:
+
+```sh
+PORT=4322 bun run --cwd apps/bff start
+```
+
+Verify the implemented health route:
+
+```sh
+curl --fail --silent http://localhost:4322/healthz
+```
+
+The JSON response has `status` equal to `ok` and `service` equal to `argismonitor-bff`.
+
+## 4. Start the web app
+
+In terminal 2:
+
+```sh
+bun run --cwd apps/web dev
+```
+
+The current web package pins its development server to port 4321.
+
+## 5. Run the anonymous home smoke
+
+In terminal 3:
+
+```sh
+curl --fail --silent http://localhost:4321/ | grep -F "Welcome to argismonitor v4"
+```
+
+You can also open <http://localhost:4321/>. The first heading is `Welcome to argismonitor v4`, and the BFF health panel should become `healthy` after the browser reaches the local health route.
+
+> The existing `tests/e2e/smoke.spec.ts` currently expects different heading text. That test is stale relative to `apps/web/src/routes/+page.svelte`; this Quickstart follows the implemented route and records the mismatch instead of claiming that the Playwright smoke is green.
+
+## 6. Teardown
+
+Press `Ctrl+C` in the web and BFF terminals. Then verify that both local listeners are gone:
+
+```sh
+curl --fail http://localhost:4321/ || true
+curl --fail http://localhost:4322/healthz || true
+```
+
+Both requests should fail after teardown.
+
+## Troubleshooting
+
+### Port 4321 is already in use
+
+Stop the existing process using port 4321. Do not change the port for this smoke: the package script and BFF CORS configuration explicitly use `http://localhost:4321`.
+
+### The page loads but BFF health says unreachable
+
+Confirm that terminal 1 is still running with `PORT=4322`, then retry:
+
+```sh
+curl --fail --silent http://localhost:4322/healthz
+```
+
+The home source fetches that exact URL.
+
+### Install fails with a frozen-lockfile error
+
+Do not remove `--frozen-lockfile` or regenerate locks as part of the Quickstart. Confirm you are on current `main` with a clean worktree and retry. A lock mismatch is a repository state problem that should be reported rather than silently rewritten.
+
+## Provenance validation
+
+Run:
+
+```sh
+node scripts/docs/validate-v4-quickstart.mjs
+```
+
+The validator checks the documented package commands, ports, health route/response, home heading, and the explicitly recorded stale-test mismatch against current source.

--- a/scripts/docs/validate-v4-quickstart.mjs
+++ b/scripts/docs/validate-v4-quickstart.mjs
@@ -1,0 +1,44 @@
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+const read = (file) => readFile(file, "utf8");
+const [doc, webPackageText, bffPackageText, bffSource, homeSource, smokeTest] = await Promise.all([
+  read("docs/public/QUICKSTART_V4.md"),
+  read("apps/web/package.json"),
+  read("apps/bff/package.json"),
+  read("apps/bff/src/index.ts"),
+  read("apps/web/src/routes/+page.svelte"),
+  read("tests/e2e/smoke.spec.ts"),
+]);
+const webPackage = JSON.parse(webPackageText);
+const bffPackage = JSON.parse(bffPackageText);
+const failures = [];
+const requireEvidence = (condition, message) => {
+  if (!condition) failures.push(message);
+};
+
+requireEvidence(webPackage.scripts?.dev === "vite dev --port 4321", "web dev command/port changed");
+requireEvidence(bffPackage.scripts?.start === "bun run src/index.ts", "BFF start command changed");
+requireEvidence(doc.includes("bun run --cwd apps/web dev"), "documented web command missing");
+requireEvidence(doc.includes("PORT=4322 bun run --cwd apps/bff start"), "documented BFF command missing");
+for (const packagePath of ["packages/api-contracts", "apps/bff", "apps/web"]) {
+  requireEvidence(
+    doc.includes(`bun install --frozen-lockfile --cwd ${packagePath} --ignore-scripts`),
+    `locked install missing for ${packagePath}`
+  );
+}
+requireEvidence(bffSource.includes("app.get('/healthz'"), "BFF /healthz route changed");
+requireEvidence(bffSource.includes("status: 'ok'") && bffSource.includes("service: 'argismonitor-bff'"), "BFF health contract changed");
+requireEvidence(homeSource.includes("fetch('http://localhost:4322/healthz')"), "home BFF URL changed");
+requireEvidence(homeSource.includes("Welcome to argismonitor v4"), "implemented home heading changed");
+requireEvidence(doc.includes("Welcome to argismonitor v4"), "documented home heading missing");
+
+const smokeMatchesSource = smokeTest.includes("Welcome to argismonitor v4");
+requireEvidence(!smokeMatchesSource, "remove the stale-test warning: smoke test now matches source");
+requireEvidence(doc.includes("test is stale relative"), "known test/source mismatch is not disclosed");
+
+if (failures.length) {
+  console.error(failures.map((failure) => `- ${failure}`).join("\n"));
+  process.exit(1);
+}
+console.log("Validated v4 Quickstart commands and provenance; stale smoke-test mismatch remains explicitly disclosed.");


### PR DESCRIPTION
## Summary

First reviewed public content slice for #329 and #322:

- clean checkout and locked package-local dependency install
- existing BFF startup and implemented `/healthz` contract
- existing SvelteKit dev startup on port 4321
- anonymous root-route smoke using the exact current source heading
- bounded teardown and evidence-backed troubleshooting
- dependency-free provenance validation plus pinned read-only CI

## Evidence boundary

Commands and assertions are checked against current package manifests, BFF source, home route source, and Playwright smoke source. No provider credentials, external domains, capability counts, authenticated requests, or deployment claims are included.

The content explicitly records that the existing Playwright smoke heading is stale relative to current home source; it does not claim that test is green.

## Independence

This PR does not touch #329 scaffold files. A later integration may import this reviewed source only after the scaffold/content boundary is approved.
