### PR TITLE
test: align v4 home smoke heading with current source

### DIFF
--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test('home page renders', async ({ page }) => {
   await page.goto('/');
-  await expect(page.locator('h1')).toContainText('Welcome to OmniRoute v4');
+  await expect(page.locator('h1')).toContainText('Welcome to argismonitor v4');
 });
 
 test('login page renders', async ({ page }) => {


### PR DESCRIPTION
## Summary

Minimal provenance correction for #334 and #325:

- updates the existing Playwright home smoke expectation from the stale heading to the exact heading currently rendered by `apps/web/src/routes/+page.svelte`

## Scope

- one test assertion only
- no production heading, branding, route, fixture, workflow, docs, or journey manifest changes

The dependent Quickstart/journey branches should update their stale-mismatch notes after this lands; they are intentionally not bundled here.
