### PR TITLE
docs: add versioned offline v4 docset contract

### DIFF
--- a/.github/workflows/v4-offline-docset.yml
+++ b/.github/workflows/v4-offline-docset.yml
@@ -1,0 +1,50 @@
+name: v4 offline docset contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/v4-offline-docset.yml"
+      - "config/docset/v4-docset.json"
+      - "tools/docset/build-v4-docset.mjs"
+      - "apps/web/package.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v4-offline-docset-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Validate contract and prepare stage
+        run: node tools/docset/build-v4-docset.mjs
+      - name: Build deterministic offline archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./apps/web/package.json').version")"
+          tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner -C docset-artifact/stage -cf - . | gzip -n > "docset-artifact/omniroute-v4-docset-${version}.tar.gz"
+          node tools/docset/build-v4-docset.mjs --finalize
+      - name: Enforce non-publication state
+        run: |
+          node -e "const p=require('./docset-artifact/stage/provenance.json'); if(p.deployable||p.releaseAttachable||p.reviewedInputs.length) process.exit(1)"
+          node -e "const fs=require('fs'); const f=fs.readdirSync('docset-artifact').find(x=>x.endsWith('.attachment.json')); const a=require('./docset-artifact/'+f); if(a.releaseAttachable||a.deployment) process.exit(1)"
+          sha256sum --check docset-artifact/*.tar.gz.sha256
+      - name: Upload contract artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v4-offline-docset-contract-${{ github.sha }}
+          path: |
+            docset-artifact/*.tar.gz
+            docset-artifact/*.sha256
+            docset-artifact/*.attachment.json
+          if-no-files-found: error
+          retention-days: 14
+          include-hidden-files: false

--- a/.github/workflows/v4-offline-docset.yml
+++ b/.github/workflows/v4-offline-docset.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           node -e "const p=require('./docset-artifact/stage/provenance.json'); if(p.deployable||p.releaseAttachable||p.reviewedInputs.length) process.exit(1)"
           node -e "const fs=require('fs'); const f=fs.readdirSync('docset-artifact').find(x=>x.endsWith('.attachment.json')); const a=require('./docset-artifact/'+f); if(a.releaseAttachable||a.deployment) process.exit(1)"
-          sha256sum --check docset-artifact/*.tar.gz.sha256
+          (cd docset-artifact && sha256sum --check *.tar.gz.sha256)
       - name: Upload contract artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/config/docset/v4-docset.json
+++ b/config/docset/v4-docset.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 1,
+  "docsetId": "omniroute-v4",
+  "versionSource": "apps/web/package.json",
+  "reviewedInputs": [],
+  "excludedInputs": [
+    "docs/audits/**",
+    "docs/reports/**",
+    "docs/research/**",
+    "docs/sessions/**",
+    "worklogs/**"
+  ],
+  "publication": {
+    "deployable": false,
+    "releaseAttachable": false,
+    "reason": "No reviewed public input is present on current main. PR #329 defines a separate scaffold and PR #334 proposes the first reviewed content slice."
+  },
+  "releaseAttachment": {
+    "mediaType": "application/gzip",
+    "filenameTemplate": "omniroute-v4-docset-{version}.tar.gz",
+    "requiredSidecars": [
+      "omniroute-v4-docset-{version}.tar.gz.sha256",
+      "omniroute-v4-docset-{version}.attachment.json"
+    ]
+  }
+}

--- a/docs/ops/V4_OFFLINE_DOCSET.md
+++ b/docs/ops/V4_OFFLINE_DOCSET.md
@@ -1,0 +1,15 @@
+# v4 offline docset contract
+
+The GitHub wiki is not treated as a source: its public URL does not currently expose a wiki, and enabling the existing legacy sync would import unreviewed/stale material.
+
+This contract produces a deterministic, versioned static archive without deploying or publishing it. Current `main` has no approved public input, so the contract deliberately declares:
+
+- `reviewedInputs: []`
+- `deployable: false`
+- `releaseAttachable: false`
+
+The archive contains an accessible explanatory index, empty search index, and provenance record. Sidecars define the future release attachment filename/media type and SHA-256 checksum while retaining the non-attachable flag.
+
+PR #329 proposes the separate docs-app scaffold. PR #334 proposes reviewed Quickstart content. After those inputs merge and their provenance gates pass, a later PR may add exact reviewed paths and change release attachment readiness. This PR does not make that decision.
+
+Related: #322, #329, #330.

--- a/tools/docset/build-v4-docset.mjs
+++ b/tools/docset/build-v4-docset.mjs
@@ -1,0 +1,71 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+const contractPath = path.join(root, "config/docset/v4-docset.json");
+const contractBytes = await readFile(contractPath);
+const contract = JSON.parse(contractBytes);
+const versionManifestBytes = await readFile(path.join(root, contract.versionSource));
+const version = JSON.parse(versionManifestBytes).version;
+if (!version) throw new Error("Version source has no version");
+if (contract.schemaVersion !== 1) throw new Error("Unsupported docset contract");
+if (contract.reviewedInputs.length === 0 && contract.publication.deployable) {
+  throw new Error("An empty docset cannot be deployable");
+}
+if (contract.reviewedInputs.length === 0 && contract.publication.releaseAttachable) {
+  throw new Error("An empty docset cannot be release-attachable");
+}
+
+const artifactRoot = path.join(root, "docset-artifact");
+const stage = path.join(artifactRoot, "stage");
+const archiveName = contract.releaseAttachment.filenameTemplate.replace("{version}", version);
+const archivePath = path.join(artifactRoot, archiveName);
+
+if (process.argv.includes("--finalize")) {
+  const archive = await readFile(archivePath);
+  const sha256 = createHash("sha256").update(archive).digest("hex");
+  const attachment = {
+    schemaVersion: 1,
+    docsetId: contract.docsetId,
+    version,
+    sourceCommit: process.env.GITHUB_SHA || "local",
+    filename: archiveName,
+    mediaType: contract.releaseAttachment.mediaType,
+    size: (await stat(archivePath)).size,
+    sha256,
+    releaseAttachable: contract.publication.releaseAttachable,
+    deployment: false,
+    reviewedInputs: contract.reviewedInputs,
+  };
+  await writeFile(`${archivePath}.sha256`, `${sha256}  ${archiveName}\n`);
+  await writeFile(
+    path.join(artifactRoot, archiveName.replace(/\.tar\.gz$/, ".attachment.json")),
+    JSON.stringify(attachment, null, 2) + "\n"
+  );
+  console.log(`Finalized ${archiveName}; releaseAttachable=${attachment.releaseAttachable}`);
+  process.exit(0);
+}
+
+await rm(artifactRoot, { recursive: true, force: true });
+await mkdir(stage, { recursive: true });
+const provenance = {
+  schemaVersion: 1,
+  docsetId: contract.docsetId,
+  version,
+  sourceCommit: process.env.GITHUB_SHA || "local",
+  contractSha256: createHash("sha256").update(contractBytes).digest("hex"),
+  versionSource: contract.versionSource,
+  versionSourceSha256: createHash("sha256").update(versionManifestBytes).digest("hex"),
+  reviewedInputs: contract.reviewedInputs,
+  excludedInputs: contract.excludedInputs,
+  deployable: contract.publication.deployable,
+  releaseAttachable: contract.publication.releaseAttachable,
+  reason: contract.publication.reason,
+};
+const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Offline documentation scaffold</title></head><body><main><h1>Offline documentation scaffold</h1><p>No reviewed public documentation input is present in this source revision.</p><p>This artifact is evidence of the docset build contract only. It is not approved for deployment or release attachment.</p></main></body></html>\n`;
+await writeFile(path.join(stage, "index.html"), html);
+await writeFile(path.join(stage, "search-index.json"), "[]\n");
+await writeFile(path.join(stage, "provenance.json"), JSON.stringify(provenance, null, 2) + "\n");
+console.log(`Prepared non-deployable docset ${contract.docsetId} ${version} with ${contract.reviewedInputs.length} reviewed input(s).`);


### PR DESCRIPTION
## Summary

Advances the wiki/docset requirement from #322 without enabling stale wiki sync or publishing content:

- explicit reviewed-input allowlist (currently empty)
- deterministic, versioned static docset archive
- provenance and drift metadata
- SHA-256 sidecar
- release-attachment metadata contract
- pinned, `contents: read` artifact-only workflow

## Current state

The artifact is intentionally non-deployable and non-release-attachable because current `main` has no approved public input. It contains only an explanatory index, empty search index, and provenance record.

PR #329 proposes the docs scaffold; PR #334 proposes the first reviewed content slice; #330 tracks release readiness. A later PR may add those exact inputs only after merge and green provenance checks.

## Non-goals

No wiki initialization/sync, Pages deployment, branding/domain decision, release creation, DNS, secrets, or stale docs import.
