### PR TITLE
ci: cancel superseded PR workflow runs

### DIFF
--- a/.github/workflows/argismonitor-ci.yml
+++ b/.github/workflows/argismonitor-ci.yml
@@ -1,4 +1,8 @@
 name: argismonitor-ci
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: [feat/v4-svelte-hono-monorepo, main]

--- a/.github/workflows/dast-smoke.yml
+++ b/.github/workflows/dast-smoke.yml
@@ -1,4 +1,8 @@
 name: DAST smoke (PR)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     branches: ["main", "release/**"]

--- a/.github/workflows/gitleaks-fleet.yml
+++ b/.github/workflows/gitleaks-fleet.yml
@@ -1,4 +1,8 @@
 name: gitleaks-fleet
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   schedule: [{ cron: "0 1 * * *" }]
   workflow_dispatch: {}

--- a/.github/workflows/latency-budget.yml
+++ b/.github/workflows/latency-budget.yml
@@ -10,6 +10,10 @@
 
 name: latency-budget
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/qgate.yml
+++ b/.github/workflows/qgate.yml
@@ -13,6 +13,10 @@
 
 name: qgate
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
   push:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,4 +1,8 @@
 name: semgrep
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     branches: ["main", "release/**"]


### PR DESCRIPTION
## Evidence

At the pre-change snapshot, 56 of the latest 100 Actions runs were queued/pending, 0 were in progress, and 46 queued runs were from `pull_request` events (10 from `push`). Multiple generations for the same PR branch remained queued concurrently—for example `ci/v4-journey-evidence-proof` had both the 00:08:03 and 00:08:26 generations queued for several workflows. This indicates the immediate bottleneck is runner/account capacity, amplified by workflows that retain superseded generations.

`ci` and `Security Scan` already use the repository convention:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Six always-on PR workflows did not: Semgrep, qgate, latency-budget, DAST smoke, ArgisMonitor CI, and gitleaks-fleet.

## Change

Apply that same concurrency policy to those six workflows. This preserves every trigger, job, permission, and required/security gate; it only cancels an older run when a newer run for the same workflow and ref exists.

## Expected topology

Before: each PR synchronize event can leave another six queued workflow runs behind.

After: at most one current generation per workflow/ref for these six workflows; different PRs and workflows remain independent. The current backlog will not disappear retroactively, but future synchronize storms should stop multiplying it.

## Validation

- six workflow-only files changed
- no `on`, `jobs`, `permissions`, or gate behavior changed
- draft only; do not merge until Actions parses all six workflows and repository maintainers confirm branch-protection context behavior