### PR TITLE
docs: correct anonymous home journey provenance

### DIFF
--- a/docs/journeys/manifests/anonymous-home-smoke.json
+++ b/docs/journeys/manifests/anonymous-home-smoke.json
@@ -25,7 +25,7 @@
       "action": "goto",
       "target": "/",
       "assertions": [
-        "The first h1 contains the exact text 'Welcome to OmniRoute v4'.",
+        "The first h1 contains the exact text 'Welcome to argismonitor v4'.",
         "The document has no horizontal overflow at the declared viewport."
       ]
     }
@@ -67,11 +67,11 @@
       },
       {
         "kind": "accessibility-report",
-        "path": "journey-evidence/anonymous-home-smoke/accessibility.json"
+        "path": "journey-evidence/anonymous-home-smoke/accessibility-smoke.json"
       }
     ],
     "retentionDays": 14,
-    "blocker": "Current Playwright configuration disables its webServer in CI, and no dedicated journey job currently starts the v4 BFF/web preview. Artifact capture must not be claimed until that service lifecycle is proven stable in CI."
+    "blocker": "The dedicated v4 journey evidence workflow is merged, but its latest run has not completed or produced an artifact. The merged evidence spec also retains the pre-#335 heading expectation; capture must remain blocked until a later run uses current provenance and its screenshot, trace, accessibility report, and redaction review are verified."
   },
   "provenance": {
     "baseBranch": "main",


### PR DESCRIPTION
## Summary

Minimal corrective follow-up to #325, #327, and #335 for #322:

- changes the manifest assertion to the actual current home heading
- aligns the accessibility artifact path with the merged evidence workflow output
- retains the current green source-backed smoke test as manifest provenance
- records that the merged evidence spec still has stale heading provenance and the latest dedicated run produced no artifact

## Evidence state

`captureStatus` remains **blocked**. This PR does not claim, create, or publish a screenshot.

## Scope

One manifest file only. No production heading, Playwright assertion, schema, validator implementation, workflow, or captured asset changes.
