### PR TITLE
fix(db): bootstrap proxy assignments schema

### DIFF
--- a/src/lib/db/migrations/123_create_proxy_assignments.sql
+++ b/src/lib/db/migrations/123_create_proxy_assignments.sql
@@ -1,0 +1,21 @@
+-- Migration 123: Create the proxy assignment table for installations that
+-- applied migration 040 before proxy assignments were introduced.
+--
+-- Keep this in a new migration rather than changing 040: existing databases
+-- already record 040 as applied and would otherwise never receive this table.
+
+CREATE TABLE IF NOT EXISTS proxy_assignments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  proxy_id TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  scope_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (proxy_id) REFERENCES proxy_registry(id) ON DELETE CASCADE,
+  UNIQUE(scope, scope_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_proxy_assignments_proxy_id
+  ON proxy_assignments(proxy_id);
+CREATE INDEX IF NOT EXISTS idx_proxy_assignments_scope
+  ON proxy_assignments(scope, scope_id);

--- a/tests/unit/proxy-management-v1-route.test.ts
+++ b/tests/unit/proxy-management-v1-route.test.ts
@@ -43,6 +43,31 @@ async function resetStorage() {
   fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
 }
 
+test("proxy assignment schema is available after fresh bootstrap and reopen", async () => {
+  await resetStorage();
+
+  const freshDb = core.getDbInstance();
+  const freshTable = freshDb
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'proxy_assignments'")
+    .get() as { name?: string } | undefined;
+  assert.equal(freshTable?.name, "proxy_assignments");
+
+  const freshIndexes = freshDb
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name IN (?, ?)")
+    .all("idx_proxy_assignments_proxy_id", "idx_proxy_assignments_scope") as Array<{ name: string }>;
+  assert.deepEqual(
+    freshIndexes.map(({ name }) => name).sort(),
+    ["idx_proxy_assignments_proxy_id", "idx_proxy_assignments_scope"]
+  );
+
+  core.resetDbInstance();
+  const reopenedDb = core.getDbInstance();
+  const reopenedTable = reopenedDb
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'proxy_assignments'")
+    .get() as { name?: string } | undefined;
+  assert.equal(reopenedTable?.name, "proxy_assignments");
+});
+
 async function withPrepareFailure(match, message, fn) {
   const db = core.getDbInstance();
   const originalPrepare = db.prepare.bind(db);


### PR DESCRIPTION
## Summary
- add migration 123 to create the missing proxy_assignments table and indexes
- preserve migration 040 because existing installations already record it as applied
- cover fresh database bootstrap and reopen schema availability

## Why
The table was previously added to migration 040 on a stale branch. Editing that applied migration would not repair existing databases, so this PR adds a new idempotent migration instead.

## Validation
- Focused test was attempted but the local Bun process hung without output and was terminated; it remains unverified locally.
- The migration uses CREATE TABLE/INDEX IF NOT EXISTS for safe application to current installations.