### PR TITLE
test(ci): guard GitHub Actions expression literals

### DIFF
--- a/.ci/local-first-ci-gates/cycles-push.log.txt
+++ b/.ci/local-first-ci-gates/cycles-push.log.txt
@@ -1,10 +1,10 @@
 command: bun scripts/check/check-cycles.mjs
-startedAt: 2026-07-16T21:57:54.654Z
-finishedAt: 2026-07-16T21:57:55.006Z
+startedAt: 2026-07-16T22:11:30.405Z
+finishedAt: 2026-07-16T22:11:30.463Z
 exitCode: 0
 signal: none
-inputSha256: e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d
-sourceTreeSha256: 1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079
+inputSha256: 4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c
+sourceTreeSha256: 5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa
 stdout:
 [cycles] OK - no cycles detected across 346 files in: src/shared/components, src/lib/db, src/lib/compliance, open-sse/translator, open-sse/mcp-server
 

--- a/.ci/local-first-ci-gates/cycles-push.log.txt
+++ b/.ci/local-first-ci-gates/cycles-push.log.txt
@@ -1,10 +1,10 @@
 command: bun scripts/check/check-cycles.mjs
-startedAt: 2026-07-16T22:11:30.405Z
-finishedAt: 2026-07-16T22:11:30.463Z
+startedAt: 2026-07-16T22:19:29.141Z
+finishedAt: 2026-07-16T22:19:29.204Z
 exitCode: 0
 signal: none
 inputSha256: 4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c
-sourceTreeSha256: 5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa
+sourceTreeSha256: fb1772d7cfa836e5f341e74fe48e434c6fcef9f7d35c840776f6cc5025b6a6fa
 stdout:
 [cycles] OK - no cycles detected across 346 files in: src/shared/components, src/lib/db, src/lib/compliance, open-sse/translator, open-sse/mcp-server
 

--- a/.ci/local-first-ci-gates/cycles-push.log.txt
+++ b/.ci/local-first-ci-gates/cycles-push.log.txt
@@ -1,10 +1,10 @@
 command: bun scripts/check/check-cycles.mjs
-startedAt: 2026-07-16T20:40:51.574Z
-finishedAt: 2026-07-16T20:41:10.331Z
+startedAt: 2026-07-16T10:30:38.195Z
+finishedAt: 2026-07-16T10:30:38.433Z
 exitCode: 0
 signal: none
-inputSha256: 6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e
-sourceTreeSha256: db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6
+inputSha256: ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6
+sourceTreeSha256: a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af
 stdout:
 [cycles] OK - no cycles detected across 346 files in: src/shared/components, src/lib/db, src/lib/compliance, open-sse/translator, open-sse/mcp-server
 

--- a/.ci/local-first-ci-gates/cycles-push.log.txt
+++ b/.ci/local-first-ci-gates/cycles-push.log.txt
@@ -1,10 +1,10 @@
 command: bun scripts/check/check-cycles.mjs
-startedAt: 2026-07-16T10:30:38.195Z
-finishedAt: 2026-07-16T10:30:38.433Z
+startedAt: 2026-07-16T21:57:54.654Z
+finishedAt: 2026-07-16T21:57:55.006Z
 exitCode: 0
 signal: none
-inputSha256: ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6
-sourceTreeSha256: a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af
+inputSha256: e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d
+sourceTreeSha256: 1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079
 stdout:
 [cycles] OK - no cycles detected across 346 files in: src/shared/components, src/lib/db, src/lib/compliance, open-sse/translator, open-sse/mcp-server
 

--- a/.ci/local-first-ci-gates/cycles-push.proof.json
+++ b/.ci/local-first-ci-gates/cycles-push.proof.json
@@ -5,16 +5,16 @@
   "command": "bun scripts/check/check-cycles.mjs",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T21:57:55.012Z",
+  "generatedAt": "2026-07-16T22:11:30.464Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d",
-    "fileCount": 8458,
-    "sourceTreeSha256": "1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079"
+    "hash": "4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c",
+    "fileCount": 8461,
+    "sourceTreeSha256": "5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/cycles-push.log.txt",
-    "sha256": "2e87212855d8f959a582c2c99a7814a076e5edf93ade48c9e539ed2da24ce25f",
+    "sha256": "c3b7f21b91f81d3a45076d0b65412fafdc24c6ebf091e991641d64793287b627",
     "bytes": 470
   }
 }

--- a/.ci/local-first-ci-gates/cycles-push.proof.json
+++ b/.ci/local-first-ci-gates/cycles-push.proof.json
@@ -5,16 +5,16 @@
   "command": "bun scripts/check/check-cycles.mjs",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T22:11:30.464Z",
+  "generatedAt": "2026-07-16T22:19:29.205Z",
   "input": {
     "algorithm": "sha256",
     "hash": "4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c",
     "fileCount": 8461,
-    "sourceTreeSha256": "5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa"
+    "sourceTreeSha256": "fb1772d7cfa836e5f341e74fe48e434c6fcef9f7d35c840776f6cc5025b6a6fa"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/cycles-push.log.txt",
-    "sha256": "c3b7f21b91f81d3a45076d0b65412fafdc24c6ebf091e991641d64793287b627",
+    "sha256": "49d296f61524a120a3ebdd17b0a9f0bd03b75e4138a69ceadd3fe53446d48e47",
     "bytes": 470
   }
 }

--- a/.ci/local-first-ci-gates/cycles-push.proof.json
+++ b/.ci/local-first-ci-gates/cycles-push.proof.json
@@ -5,16 +5,16 @@
   "command": "bun scripts/check/check-cycles.mjs",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T10:30:38.436Z",
+  "generatedAt": "2026-07-16T21:57:55.012Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6",
-    "fileCount": 8455,
-    "sourceTreeSha256": "a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af"
+    "hash": "e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d",
+    "fileCount": 8458,
+    "sourceTreeSha256": "1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/cycles-push.log.txt",
-    "sha256": "66485177cf2e3919592ac5a109bc7ecbf759095a538bf58b847e5988c17da354",
+    "sha256": "2e87212855d8f959a582c2c99a7814a076e5edf93ade48c9e539ed2da24ce25f",
     "bytes": 470
   }
 }

--- a/.ci/local-first-ci-gates/cycles-push.proof.json
+++ b/.ci/local-first-ci-gates/cycles-push.proof.json
@@ -5,16 +5,16 @@
   "command": "bun scripts/check/check-cycles.mjs",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T20:41:10.350Z",
+  "generatedAt": "2026-07-16T10:30:38.436Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e",
-    "fileCount": 8457,
-    "sourceTreeSha256": "db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6"
+    "hash": "ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6",
+    "fileCount": 8455,
+    "sourceTreeSha256": "a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/cycles-push.log.txt",
-    "sha256": "3160c5459fcb55b3355bc04abda97f87292279b1d782ff331471960d8cee1e46",
+    "sha256": "66485177cf2e3919592ac5a109bc7ecbf759095a538bf58b847e5988c17da354",
     "bytes": 470
   }
 }

--- a/.ci/local-first-ci-gates/integrity-manifest.log.txt
+++ b/.ci/local-first-ci-gates/integrity-manifest.log.txt
@@ -1,12 +1,12 @@
 command: bun run integrity:manifest:write
-startedAt: 2026-07-16T21:56:57.498Z
-finishedAt: 2026-07-16T21:56:58.089Z
+startedAt: 2026-07-16T22:11:25.889Z
+finishedAt: 2026-07-16T22:11:26.029Z
 exitCode: 0
 signal: none
-inputSha256: e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d
-sourceTreeSha256: 1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079
+inputSha256: 4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c
+sourceTreeSha256: 5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa
 stdout:
-Wrote ci/integrity-manifest.sha256 (216 files).
+Wrote ci/integrity-manifest.sha256 (219 files).
 
 stderr:
 $ node scripts/check/verify-integrity-manifest.mjs --write

--- a/.ci/local-first-ci-gates/integrity-manifest.log.txt
+++ b/.ci/local-first-ci-gates/integrity-manifest.log.txt
@@ -1,12 +1,12 @@
 command: bun run integrity:manifest:write
-startedAt: 2026-07-16T10:30:31.511Z
-finishedAt: 2026-07-16T10:30:31.769Z
+startedAt: 2026-07-16T21:56:57.498Z
+finishedAt: 2026-07-16T21:56:58.089Z
 exitCode: 0
 signal: none
-inputSha256: ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6
-sourceTreeSha256: a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af
+inputSha256: e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d
+sourceTreeSha256: 1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079
 stdout:
-Wrote ci/integrity-manifest.sha256 (214 files).
+Wrote ci/integrity-manifest.sha256 (216 files).
 
 stderr:
 $ node scripts/check/verify-integrity-manifest.mjs --write

--- a/.ci/local-first-ci-gates/integrity-manifest.log.txt
+++ b/.ci/local-first-ci-gates/integrity-manifest.log.txt
@@ -1,10 +1,10 @@
 command: bun run integrity:manifest:write
-startedAt: 2026-07-16T22:11:25.889Z
-finishedAt: 2026-07-16T22:11:26.029Z
+startedAt: 2026-07-16T22:19:19.865Z
+finishedAt: 2026-07-16T22:19:20.129Z
 exitCode: 0
 signal: none
 inputSha256: 4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c
-sourceTreeSha256: 5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa
+sourceTreeSha256: fb1772d7cfa836e5f341e74fe48e434c6fcef9f7d35c840776f6cc5025b6a6fa
 stdout:
 Wrote ci/integrity-manifest.sha256 (219 files).
 

--- a/.ci/local-first-ci-gates/integrity-manifest.log.txt
+++ b/.ci/local-first-ci-gates/integrity-manifest.log.txt
@@ -1,12 +1,12 @@
 command: bun run integrity:manifest:write
-startedAt: 2026-07-16T20:39:51.529Z
-finishedAt: 2026-07-16T20:39:52.040Z
+startedAt: 2026-07-16T10:30:31.511Z
+finishedAt: 2026-07-16T10:30:31.769Z
 exitCode: 0
 signal: none
-inputSha256: 6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e
-sourceTreeSha256: db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6
+inputSha256: ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6
+sourceTreeSha256: a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af
 stdout:
-Wrote ci\integrity-manifest.sha256 (216 files).
+Wrote ci/integrity-manifest.sha256 (214 files).
 
 stderr:
 $ node scripts/check/verify-integrity-manifest.mjs --write

--- a/.ci/local-first-ci-gates/integrity-manifest.proof.json
+++ b/.ci/local-first-ci-gates/integrity-manifest.proof.json
@@ -5,16 +5,16 @@
   "command": "bun run integrity:manifest:write",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T10:30:31.771Z",
+  "generatedAt": "2026-07-16T21:56:58.091Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6",
-    "fileCount": 8455,
-    "sourceTreeSha256": "a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af"
+    "hash": "e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d",
+    "fileCount": 8458,
+    "sourceTreeSha256": "1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/integrity-manifest.log.txt",
-    "sha256": "48ce062ee1513ebeb1a2dbe5bbf76f3ce516d420ca8ca99def9c81cc0dd42202",
+    "sha256": "4a2a9657a402b815c849630ba70835f965310978f4ae4feb8c536dedcda8f7c1",
     "bytes": 425
   }
 }

--- a/.ci/local-first-ci-gates/integrity-manifest.proof.json
+++ b/.ci/local-first-ci-gates/integrity-manifest.proof.json
@@ -5,16 +5,16 @@
   "command": "bun run integrity:manifest:write",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T21:56:58.091Z",
+  "generatedAt": "2026-07-16T22:11:26.033Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d",
-    "fileCount": 8458,
-    "sourceTreeSha256": "1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079"
+    "hash": "4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c",
+    "fileCount": 8461,
+    "sourceTreeSha256": "5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/integrity-manifest.log.txt",
-    "sha256": "4a2a9657a402b815c849630ba70835f965310978f4ae4feb8c536dedcda8f7c1",
+    "sha256": "bfcec9bb246f3eb76fb5916a2ef98a599adf0e17446c7cdaf1a4020a793be487",
     "bytes": 425
   }
 }

--- a/.ci/local-first-ci-gates/integrity-manifest.proof.json
+++ b/.ci/local-first-ci-gates/integrity-manifest.proof.json
@@ -5,16 +5,16 @@
   "command": "bun run integrity:manifest:write",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T22:11:26.033Z",
+  "generatedAt": "2026-07-16T22:19:20.131Z",
   "input": {
     "algorithm": "sha256",
     "hash": "4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c",
     "fileCount": 8461,
-    "sourceTreeSha256": "5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa"
+    "sourceTreeSha256": "fb1772d7cfa836e5f341e74fe48e434c6fcef9f7d35c840776f6cc5025b6a6fa"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/integrity-manifest.log.txt",
-    "sha256": "bfcec9bb246f3eb76fb5916a2ef98a599adf0e17446c7cdaf1a4020a793be487",
+    "sha256": "6c5f4f680aae24914a74066897a94cca3691f8c982c4d22a60424bf6a5747455",
     "bytes": 425
   }
 }

--- a/.ci/local-first-ci-gates/integrity-manifest.proof.json
+++ b/.ci/local-first-ci-gates/integrity-manifest.proof.json
@@ -5,16 +5,16 @@
   "command": "bun run integrity:manifest:write",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T20:39:52.045Z",
+  "generatedAt": "2026-07-16T10:30:31.771Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e",
-    "fileCount": 8457,
-    "sourceTreeSha256": "db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6"
+    "hash": "ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6",
+    "fileCount": 8455,
+    "sourceTreeSha256": "a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/integrity-manifest.log.txt",
-    "sha256": "bdb85ad1ddd72f794399b4668e5c54ecaa0a706f58edc5dfb0560a371fb751c5",
+    "sha256": "48ce062ee1513ebeb1a2dbe5bbf76f3ce516d420ca8ca99def9c81cc0dd42202",
     "bytes": 425
   }
 }

--- a/.ci/local-first-ci-gates/t11-any-budget-push.log.txt
+++ b/.ci/local-first-ci-gates/t11-any-budget-push.log.txt
@@ -1,10 +1,10 @@
 command: bun scripts/check/check-t11-any-budget.mjs
-startedAt: 2026-07-16T20:40:21.026Z
-finishedAt: 2026-07-16T20:40:27.148Z
+startedAt: 2026-07-16T10:30:34.478Z
+finishedAt: 2026-07-16T10:30:34.632Z
 exitCode: 0
 signal: none
-inputSha256: 6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e
-sourceTreeSha256: db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6
+inputSha256: ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6
+sourceTreeSha256: a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af
 stdout:
 [t11:any-budget] OK - src/app/api/settings/proxy/test/route.ts (explicit any: 0, budget: 0)
 [t11:any-budget] OK - src/shared/components/OAuthModal.tsx (explicit any: 0, budget: 0)

--- a/.ci/local-first-ci-gates/t11-any-budget-push.log.txt
+++ b/.ci/local-first-ci-gates/t11-any-budget-push.log.txt
@@ -1,10 +1,10 @@
 command: bun scripts/check/check-t11-any-budget.mjs
-startedAt: 2026-07-16T10:30:34.478Z
-finishedAt: 2026-07-16T10:30:34.632Z
+startedAt: 2026-07-16T21:57:34.404Z
+finishedAt: 2026-07-16T21:57:34.803Z
 exitCode: 0
 signal: none
-inputSha256: ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6
-sourceTreeSha256: a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af
+inputSha256: e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d
+sourceTreeSha256: 1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079
 stdout:
 [t11:any-budget] OK - src/app/api/settings/proxy/test/route.ts (explicit any: 0, budget: 0)
 [t11:any-budget] OK - src/shared/components/OAuthModal.tsx (explicit any: 0, budget: 0)

--- a/.ci/local-first-ci-gates/t11-any-budget-push.log.txt
+++ b/.ci/local-first-ci-gates/t11-any-budget-push.log.txt
@@ -1,10 +1,10 @@
 command: bun scripts/check/check-t11-any-budget.mjs
-startedAt: 2026-07-16T21:57:34.404Z
-finishedAt: 2026-07-16T21:57:34.803Z
+startedAt: 2026-07-16T22:11:29.221Z
+finishedAt: 2026-07-16T22:11:29.345Z
 exitCode: 0
 signal: none
-inputSha256: e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d
-sourceTreeSha256: 1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079
+inputSha256: 4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c
+sourceTreeSha256: 5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa
 stdout:
 [t11:any-budget] OK - src/app/api/settings/proxy/test/route.ts (explicit any: 0, budget: 0)
 [t11:any-budget] OK - src/shared/components/OAuthModal.tsx (explicit any: 0, budget: 0)

--- a/.ci/local-first-ci-gates/t11-any-budget-push.log.txt
+++ b/.ci/local-first-ci-gates/t11-any-budget-push.log.txt
@@ -1,10 +1,10 @@
 command: bun scripts/check/check-t11-any-budget.mjs
-startedAt: 2026-07-16T22:11:29.221Z
-finishedAt: 2026-07-16T22:11:29.345Z
+startedAt: 2026-07-16T22:19:27.637Z
+finishedAt: 2026-07-16T22:19:27.810Z
 exitCode: 0
 signal: none
 inputSha256: 4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c
-sourceTreeSha256: 5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa
+sourceTreeSha256: fb1772d7cfa836e5f341e74fe48e434c6fcef9f7d35c840776f6cc5025b6a6fa
 stdout:
 [t11:any-budget] OK - src/app/api/settings/proxy/test/route.ts (explicit any: 0, budget: 0)
 [t11:any-budget] OK - src/shared/components/OAuthModal.tsx (explicit any: 0, budget: 0)

--- a/.ci/local-first-ci-gates/t11-any-budget-push.proof.json
+++ b/.ci/local-first-ci-gates/t11-any-budget-push.proof.json
@@ -5,16 +5,16 @@
   "command": "bun scripts/check/check-t11-any-budget.mjs",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T22:11:29.346Z",
+  "generatedAt": "2026-07-16T22:19:27.811Z",
   "input": {
     "algorithm": "sha256",
     "hash": "4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c",
     "fileCount": 8461,
-    "sourceTreeSha256": "5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa"
+    "sourceTreeSha256": "fb1772d7cfa836e5f341e74fe48e434c6fcef9f7d35c840776f6cc5025b6a6fa"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/t11-any-budget-push.log.txt",
-    "sha256": "8ee4259332372782772e1ae6ca490c7d7ecb118b4caaf1a630571f49b7c08db5",
+    "sha256": "5e327bef59e345859102fec59088f146b91e38f5fae6afd8c837b779622577a5",
     "bytes": 7693
   }
 }

--- a/.ci/local-first-ci-gates/t11-any-budget-push.proof.json
+++ b/.ci/local-first-ci-gates/t11-any-budget-push.proof.json
@@ -5,16 +5,16 @@
   "command": "bun scripts/check/check-t11-any-budget.mjs",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T20:40:27.157Z",
+  "generatedAt": "2026-07-16T10:30:34.634Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e",
-    "fileCount": 8457,
-    "sourceTreeSha256": "db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6"
+    "hash": "ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6",
+    "fileCount": 8455,
+    "sourceTreeSha256": "a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/t11-any-budget-push.log.txt",
-    "sha256": "5de9f4b8a5f543928b45443a3e6b2293d81c8aa1271161f3bc305dcb21d4e33c",
+    "sha256": "09e97988779d2a8fa8dbb5c8ff3063a56979da89d23e5657d976c63d9f5069ee",
     "bytes": 7693
   }
 }

--- a/.ci/local-first-ci-gates/t11-any-budget-push.proof.json
+++ b/.ci/local-first-ci-gates/t11-any-budget-push.proof.json
@@ -5,16 +5,16 @@
   "command": "bun scripts/check/check-t11-any-budget.mjs",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T21:57:34.808Z",
+  "generatedAt": "2026-07-16T22:11:29.346Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d",
-    "fileCount": 8458,
-    "sourceTreeSha256": "1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079"
+    "hash": "4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c",
+    "fileCount": 8461,
+    "sourceTreeSha256": "5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/t11-any-budget-push.log.txt",
-    "sha256": "4091a372d67acfda7e99f31b736f0622d47a2b5ddbe2bd1cc5bb1112f903e402",
+    "sha256": "8ee4259332372782772e1ae6ca490c7d7ecb118b4caaf1a630571f49b7c08db5",
     "bytes": 7693
   }
 }

--- a/.ci/local-first-ci-gates/t11-any-budget-push.proof.json
+++ b/.ci/local-first-ci-gates/t11-any-budget-push.proof.json
@@ -5,16 +5,16 @@
   "command": "bun scripts/check/check-t11-any-budget.mjs",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T10:30:34.634Z",
+  "generatedAt": "2026-07-16T21:57:34.808Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6",
-    "fileCount": 8455,
-    "sourceTreeSha256": "a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af"
+    "hash": "e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d",
+    "fileCount": 8458,
+    "sourceTreeSha256": "1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/t11-any-budget-push.log.txt",
-    "sha256": "09e97988779d2a8fa8dbb5c8ff3063a56979da89d23e5657d976c63d9f5069ee",
+    "sha256": "4091a372d67acfda7e99f31b736f0622d47a2b5ddbe2bd1cc5bb1112f903e402",
     "bytes": 7693
   }
 }

--- a/.ci/local-first-ci-gates/typecheck-core.log.txt
+++ b/.ci/local-first-ci-gates/typecheck-core.log.txt
@@ -1,10 +1,10 @@
 command: bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json
-startedAt: 2026-07-16T10:30:22.399Z
-finishedAt: 2026-07-16T10:30:26.377Z
+startedAt: 2026-07-16T21:57:11.343Z
+finishedAt: 2026-07-16T21:57:16.827Z
 exitCode: 0
 signal: none
-inputSha256: ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6
-sourceTreeSha256: a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af
+inputSha256: e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d
+sourceTreeSha256: 1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079
 stdout:
 
 stderr:

--- a/.ci/local-first-ci-gates/typecheck-core.log.txt
+++ b/.ci/local-first-ci-gates/typecheck-core.log.txt
@@ -1,10 +1,10 @@
 command: bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json
-startedAt: 2026-07-16T20:39:13.952Z
-finishedAt: 2026-07-16T20:39:31.591Z
+startedAt: 2026-07-16T10:30:22.399Z
+finishedAt: 2026-07-16T10:30:26.377Z
 exitCode: 0
 signal: none
-inputSha256: 6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e
-sourceTreeSha256: db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6
+inputSha256: ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6
+sourceTreeSha256: a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af
 stdout:
 
 stderr:

--- a/.ci/local-first-ci-gates/typecheck-core.log.txt
+++ b/.ci/local-first-ci-gates/typecheck-core.log.txt
@@ -1,10 +1,10 @@
 command: bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json
-startedAt: 2026-07-16T21:57:11.343Z
-finishedAt: 2026-07-16T21:57:16.827Z
+startedAt: 2026-07-16T22:11:26.899Z
+finishedAt: 2026-07-16T22:11:28.305Z
 exitCode: 0
 signal: none
-inputSha256: e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d
-sourceTreeSha256: 1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079
+inputSha256: 4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c
+sourceTreeSha256: 5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa
 stdout:
 
 stderr:

--- a/.ci/local-first-ci-gates/typecheck-core.log.txt
+++ b/.ci/local-first-ci-gates/typecheck-core.log.txt
@@ -1,10 +1,10 @@
 command: bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json
-startedAt: 2026-07-16T22:11:26.899Z
-finishedAt: 2026-07-16T22:11:28.305Z
+startedAt: 2026-07-16T22:19:23.049Z
+finishedAt: 2026-07-16T22:19:24.860Z
 exitCode: 0
 signal: none
 inputSha256: 4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c
-sourceTreeSha256: 5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa
+sourceTreeSha256: fb1772d7cfa836e5f341e74fe48e434c6fcef9f7d35c840776f6cc5025b6a6fa
 stdout:
 
 stderr:

--- a/.ci/local-first-ci-gates/typecheck-core.proof.json
+++ b/.ci/local-first-ci-gates/typecheck-core.proof.json
@@ -5,16 +5,16 @@
   "command": "bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T22:11:28.308Z",
+  "generatedAt": "2026-07-16T22:19:24.862Z",
   "input": {
     "algorithm": "sha256",
     "hash": "4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c",
     "fileCount": 8461,
-    "sourceTreeSha256": "5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa"
+    "sourceTreeSha256": "fb1772d7cfa836e5f341e74fe48e434c6fcef9f7d35c840776f6cc5025b6a6fa"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/typecheck-core.log.txt",
-    "sha256": "0ef1795c8af1077a27f2372e156cedc178fbc2d1c19fc7dd005dd3286df46a8a",
+    "sha256": "7abbaaac9eac73dddd5411c2bf33bddcc94b05936ddd2fd0b23beedd7a5b1f89",
     "bytes": 377
   }
 }

--- a/.ci/local-first-ci-gates/typecheck-core.proof.json
+++ b/.ci/local-first-ci-gates/typecheck-core.proof.json
@@ -5,16 +5,16 @@
   "command": "bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T20:39:31.594Z",
+  "generatedAt": "2026-07-16T10:30:26.384Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e",
-    "fileCount": 8457,
-    "sourceTreeSha256": "db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6"
+    "hash": "ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6",
+    "fileCount": 8455,
+    "sourceTreeSha256": "a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/typecheck-core.log.txt",
-    "sha256": "fe1f5dfec7fd2d9d30c1ad616f7c9b1e495b08fa6efa0b32bfcd716f707d02e9",
+    "sha256": "23ce68df12c9671ee0b1f8bbbd62e89b991ad3b1f9049d89ba47344a32feb2d8",
     "bytes": 377
   }
 }

--- a/.ci/local-first-ci-gates/typecheck-core.proof.json
+++ b/.ci/local-first-ci-gates/typecheck-core.proof.json
@@ -5,16 +5,16 @@
   "command": "bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T21:57:16.844Z",
+  "generatedAt": "2026-07-16T22:11:28.308Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d",
-    "fileCount": 8458,
-    "sourceTreeSha256": "1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079"
+    "hash": "4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c",
+    "fileCount": 8461,
+    "sourceTreeSha256": "5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/typecheck-core.log.txt",
-    "sha256": "7d1d0be3cf4859df461ab329b38a028bf9081b209df46e7f67bf68b9fee73f44",
+    "sha256": "0ef1795c8af1077a27f2372e156cedc178fbc2d1c19fc7dd005dd3286df46a8a",
     "bytes": 377
   }
 }

--- a/.ci/local-first-ci-gates/typecheck-core.proof.json
+++ b/.ci/local-first-ci-gates/typecheck-core.proof.json
@@ -5,16 +5,16 @@
   "command": "bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T10:30:26.384Z",
+  "generatedAt": "2026-07-16T21:57:16.844Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6",
-    "fileCount": 8455,
-    "sourceTreeSha256": "a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af"
+    "hash": "e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d",
+    "fileCount": 8458,
+    "sourceTreeSha256": "1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/typecheck-core.log.txt",
-    "sha256": "23ce68df12c9671ee0b1f8bbbd62e89b991ad3b1f9049d89ba47344a32feb2d8",
+    "sha256": "7d1d0be3cf4859df461ab329b38a028bf9081b209df46e7f67bf68b9fee73f44",
     "bytes": 377
   }
 }

--- a/.ci/local-first-ci-manifest.json
+++ b/.ci/local-first-ci-manifest.json
@@ -1,44 +1,44 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-07-16T21:58:04.189Z",
+  "generatedAt": "2026-07-16T22:11:31.289Z",
   "gateResults": [
     {
       "name": "typecheck-core",
       "status": "passed",
       "command": "bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json",
       "proofPath": ".ci/local-first-ci-gates/typecheck-core.proof.json",
-      "proofHash": "23aa40e09bfc08289e6d3bd27097155f86bcc3b452a7cc53a8a855b425069eae",
-      "executedAt": "2026-07-16T21:57:16.844Z"
+      "proofHash": "90a3eed674fb2a6d85bd1b3032df6ed2f4001e558c2c2e9a0f6d4d35280c795b",
+      "executedAt": "2026-07-16T22:11:28.308Z"
     },
     {
       "name": "integrity-manifest",
       "status": "passed",
       "command": "bun run integrity:manifest:write",
       "proofPath": ".ci/local-first-ci-gates/integrity-manifest.proof.json",
-      "proofHash": "5c9bf785248bf5d1efc619c2b4f58d00e1dbe199fb40dc2771e0f83bab180c4d",
-      "executedAt": "2026-07-16T21:56:58.091Z"
+      "proofHash": "5dc76479fd8caf02cf9cf54108bc046dfbb908d3a06bd23d0a9ce8e4c488dbe2",
+      "executedAt": "2026-07-16T22:11:26.033Z"
     },
     {
       "name": "t11-any-budget-push",
       "status": "passed",
       "command": "bun scripts/check/check-t11-any-budget.mjs",
       "proofPath": ".ci/local-first-ci-gates/t11-any-budget-push.proof.json",
-      "proofHash": "aabc32674bac3aa427af304853cc418805276fbbba4c863363ac2c5d4bf8bbe1",
-      "executedAt": "2026-07-16T21:57:34.808Z"
+      "proofHash": "a525f5cc8fc1c9567f2a8bd0469cee446c299eeb3f45df390e7882d9ac7f5b06",
+      "executedAt": "2026-07-16T22:11:29.346Z"
     },
     {
       "name": "cycles-push",
       "status": "passed",
       "command": "bun scripts/check/check-cycles.mjs",
       "proofPath": ".ci/local-first-ci-gates/cycles-push.proof.json",
-      "proofHash": "d50915e811971f86bdbc64b823bde6a7841b252d8ac7faee466da924e596a012",
-      "executedAt": "2026-07-16T21:57:55.012Z"
+      "proofHash": "1266877ed9396f5e9a6ec548e731a029e93ca7b6cd36b9340cf1894dad5a9d9a",
+      "executedAt": "2026-07-16T22:11:30.464Z"
     }
   ],
   "content": {
     "algorithm": "sha256",
-    "hash": "e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d",
-    "fileCount": 8458,
+    "hash": "4eebb77395344fd1fb74d78960b4d8a998b89a342cedd116add6fdc008de968c",
+    "fileCount": 8461,
     "trackedFiles": [
       ".coderabbit.yaml",
       ".devcontainer/devcontainer.json",
@@ -304,6 +304,7 @@
       "apps/web/package.json",
       "apps/web/postcss.config.mjs",
       "apps/web/project.inlang/settings.json",
+      "apps/web/scripts/check/verify-ssr-i18n.mjs",
       "apps/web/src/app.css",
       "apps/web/src/app.html",
       "apps/web/src/hooks.server.ts",
@@ -343,7 +344,7 @@
       "apps/web/src/lib/i18n/hr.json",
       "apps/web/src/lib/i18n/hu.json",
       "apps/web/src/lib/i18n/id.json",
-      "apps/web/src/lib/i18n/index.ts",
+      "apps/web/src/lib/i18n/index.svelte.ts",
       "apps/web/src/lib/i18n/index.ts.bak",
       "apps/web/src/lib/i18n/is.json",
       "apps/web/src/lib/i18n/it.json",
@@ -415,6 +416,7 @@
       "apps/web/src/routes/dashboard/webhooks/+page.svelte",
       "apps/web/src/routes/login/+page.svelte",
       "apps/web/svelte.config.js",
+      "apps/web/tests/unit/i18n/runtime.test.ts",
       "apps/web/tsconfig.json",
       "apps/web/vite.config.ts",
       "assets/brand/README.md",
@@ -2794,6 +2796,7 @@
       "scripts/check/check-workflows.mjs",
       "scripts/check/compression-budget-baseline.json",
       "scripts/check/lib/allowlist.mjs",
+      "scripts/check/local-first-ci-artifact.mjs",
       "scripts/check/local-first-ci-attestation.mjs",
       "scripts/check/local-first-ci-attestation.test.mjs",
       "scripts/check/local-first-ci-mode.mjs",
@@ -8499,6 +8502,6 @@
       "worklogs/2026-06-25-L5-119-b9-dispatcher-fallback.md",
       "worklogs/L5-209-v48-envelope-expansion-2026-06-30.json"
     ],
-    "sourceTreeSha256": "1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079"
+    "sourceTreeSha256": "5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa"
   }
 }

--- a/.ci/local-first-ci-manifest.json
+++ b/.ci/local-first-ci-manifest.json
@@ -1,44 +1,44 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-07-16T20:41:32.295Z",
+  "generatedAt": "2026-07-16T10:30:47.558Z",
   "gateResults": [
     {
       "name": "typecheck-core",
       "status": "passed",
       "command": "bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json",
       "proofPath": ".ci/local-first-ci-gates/typecheck-core.proof.json",
-      "proofHash": "1e2566658a0a373e38469d3a440f9f02bd446c9cd6be80678188ae2c15c6c775",
-      "executedAt": "2026-07-16T20:39:31.594Z"
+      "proofHash": "ead4625175354f505b81e1ffbecf8d1079091694d08fc2003a54584e3c6abe27",
+      "executedAt": "2026-07-16T10:30:26.384Z"
     },
     {
       "name": "integrity-manifest",
       "status": "passed",
       "command": "bun run integrity:manifest:write",
       "proofPath": ".ci/local-first-ci-gates/integrity-manifest.proof.json",
-      "proofHash": "33d1cde0e17292937c42c98e9c7c592848f70d2f35b604600926a378455b10df",
-      "executedAt": "2026-07-16T20:39:52.045Z"
+      "proofHash": "ff63dce2ee18fd7b25b550fe348100509ec51b2f9f1d9a53da458294caccdc5f",
+      "executedAt": "2026-07-16T10:30:31.771Z"
     },
     {
       "name": "t11-any-budget-push",
       "status": "passed",
       "command": "bun scripts/check/check-t11-any-budget.mjs",
       "proofPath": ".ci/local-first-ci-gates/t11-any-budget-push.proof.json",
-      "proofHash": "93b2b3cb778b530dedf20c220659491429f34fa7ce005b0fc5bb7db5a8fb7fce",
-      "executedAt": "2026-07-16T20:40:27.157Z"
+      "proofHash": "fb97fd5c295505a8a3cb3830b5c7f60d761bd01258cde884fa2de186713eedd9",
+      "executedAt": "2026-07-16T10:30:34.634Z"
     },
     {
       "name": "cycles-push",
       "status": "passed",
       "command": "bun scripts/check/check-cycles.mjs",
       "proofPath": ".ci/local-first-ci-gates/cycles-push.proof.json",
-      "proofHash": "ddb05ba1bd51078ec388f50299dec45f01758edd3092839aceb7b6a5afa5c22e",
-      "executedAt": "2026-07-16T20:41:10.350Z"
+      "proofHash": "e667244189ed8fd01650a53a253d055c869fe1069bf95709c6f6b73c14956189",
+      "executedAt": "2026-07-16T10:30:38.436Z"
     }
   ],
   "content": {
     "algorithm": "sha256",
-    "hash": "6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e",
-    "fileCount": 8457,
+    "hash": "ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6",
+    "fileCount": 8455,
     "trackedFiles": [
       ".coderabbit.yaml",
       ".devcontainer/devcontainer.json",
@@ -2796,8 +2796,6 @@
       "scripts/check/lib/allowlist.mjs",
       "scripts/check/local-first-ci-attestation.mjs",
       "scripts/check/local-first-ci-attestation.test.mjs",
-      "scripts/check/local-first-ci-mode.mjs",
-      "scripts/check/local-first-ci-mode.test.mjs",
       "scripts/check/test-report-summary.mjs",
       "scripts/check/verify-integrity-manifest.mjs",
       "scripts/ci/should-promote-latest.sh",
@@ -8295,7 +8293,6 @@
       "tests/unit/ui/provider-breaker-health-hook.test.tsx",
       "tests/unit/ui/provider-plan-config.test.tsx",
       "tests/unit/ui/provider-quota-widget-auto-refresh-label-4611.test.tsx",
-      "tests/unit/ui/provider-stats-bifrost-connections.test.tsx",
       "tests/unit/ui/providerCascadeNode.test.tsx",
       "tests/unit/ui/qdrant-config-card.test.tsx",
       "tests/unit/ui/quantumLockBadge.test.tsx",
@@ -8458,6 +8455,7 @@
       "tests/unit/webshare-sync.test.ts",
       "tests/unit/wildcard-router.test.ts",
       "tests/unit/windsurf-devin-executors.test.ts",
+      "tests/unit/workflow-expressions.test.ts",
       "tests/unit/xai-translators.test.ts",
       "tests/unit/xiaomi-mimo-provider.test.ts",
       "tests/unit/xiaomi-mimo-selftrack-usage.test.ts",
@@ -8498,6 +8496,6 @@
       "worklogs/2026-06-25-L5-119-b9-dispatcher-fallback.md",
       "worklogs/L5-209-v48-envelope-expansion-2026-06-30.json"
     ],
-    "sourceTreeSha256": "db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6"
+    "sourceTreeSha256": "a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af"
   }
 }

--- a/.ci/local-first-ci-manifest.json
+++ b/.ci/local-first-ci-manifest.json
@@ -1,44 +1,44 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-07-16T10:30:47.558Z",
+  "generatedAt": "2026-07-16T21:58:04.189Z",
   "gateResults": [
     {
       "name": "typecheck-core",
       "status": "passed",
       "command": "bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json",
       "proofPath": ".ci/local-first-ci-gates/typecheck-core.proof.json",
-      "proofHash": "ead4625175354f505b81e1ffbecf8d1079091694d08fc2003a54584e3c6abe27",
-      "executedAt": "2026-07-16T10:30:26.384Z"
+      "proofHash": "23aa40e09bfc08289e6d3bd27097155f86bcc3b452a7cc53a8a855b425069eae",
+      "executedAt": "2026-07-16T21:57:16.844Z"
     },
     {
       "name": "integrity-manifest",
       "status": "passed",
       "command": "bun run integrity:manifest:write",
       "proofPath": ".ci/local-first-ci-gates/integrity-manifest.proof.json",
-      "proofHash": "ff63dce2ee18fd7b25b550fe348100509ec51b2f9f1d9a53da458294caccdc5f",
-      "executedAt": "2026-07-16T10:30:31.771Z"
+      "proofHash": "5c9bf785248bf5d1efc619c2b4f58d00e1dbe199fb40dc2771e0f83bab180c4d",
+      "executedAt": "2026-07-16T21:56:58.091Z"
     },
     {
       "name": "t11-any-budget-push",
       "status": "passed",
       "command": "bun scripts/check/check-t11-any-budget.mjs",
       "proofPath": ".ci/local-first-ci-gates/t11-any-budget-push.proof.json",
-      "proofHash": "fb97fd5c295505a8a3cb3830b5c7f60d761bd01258cde884fa2de186713eedd9",
-      "executedAt": "2026-07-16T10:30:34.634Z"
+      "proofHash": "aabc32674bac3aa427af304853cc418805276fbbba4c863363ac2c5d4bf8bbe1",
+      "executedAt": "2026-07-16T21:57:34.808Z"
     },
     {
       "name": "cycles-push",
       "status": "passed",
       "command": "bun scripts/check/check-cycles.mjs",
       "proofPath": ".ci/local-first-ci-gates/cycles-push.proof.json",
-      "proofHash": "e667244189ed8fd01650a53a253d055c869fe1069bf95709c6f6b73c14956189",
-      "executedAt": "2026-07-16T10:30:38.436Z"
+      "proofHash": "d50915e811971f86bdbc64b823bde6a7841b252d8ac7faee466da924e596a012",
+      "executedAt": "2026-07-16T21:57:55.012Z"
     }
   ],
   "content": {
     "algorithm": "sha256",
-    "hash": "ec6c2cf0c5db6f0f96cb9f7352f0b5bca0854e1cf4b089741d4e4016fc59d7d6",
-    "fileCount": 8455,
+    "hash": "e2dc8320787533980717ebd52032b4bb4c139916f46be152b549765b25c78a5d",
+    "fileCount": 8458,
     "trackedFiles": [
       ".coderabbit.yaml",
       ".devcontainer/devcontainer.json",
@@ -2796,6 +2796,8 @@
       "scripts/check/lib/allowlist.mjs",
       "scripts/check/local-first-ci-attestation.mjs",
       "scripts/check/local-first-ci-attestation.test.mjs",
+      "scripts/check/local-first-ci-mode.mjs",
+      "scripts/check/local-first-ci-mode.test.mjs",
       "scripts/check/test-report-summary.mjs",
       "scripts/check/verify-integrity-manifest.mjs",
       "scripts/ci/should-promote-latest.sh",
@@ -8293,6 +8295,7 @@
       "tests/unit/ui/provider-breaker-health-hook.test.tsx",
       "tests/unit/ui/provider-plan-config.test.tsx",
       "tests/unit/ui/provider-quota-widget-auto-refresh-label-4611.test.tsx",
+      "tests/unit/ui/provider-stats-bifrost-connections.test.tsx",
       "tests/unit/ui/providerCascadeNode.test.tsx",
       "tests/unit/ui/qdrant-config-card.test.tsx",
       "tests/unit/ui/quantumLockBadge.test.tsx",
@@ -8496,6 +8499,6 @@
       "worklogs/2026-06-25-L5-119-b9-dispatcher-fallback.md",
       "worklogs/L5-209-v48-envelope-expansion-2026-06-30.json"
     ],
-    "sourceTreeSha256": "a19a8f4c1b86e1c2912a58f476fc7c686d1f7a18a854363a9d200f214b6649af"
+    "sourceTreeSha256": "1e78c7d45eed10eaa17ec65783e4629d588b6099d978605a5972ece31d52c079"
   }
 }

--- a/.ci/local-first-ci-manifest.json
+++ b/.ci/local-first-ci-manifest.json
@@ -1,38 +1,38 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-07-16T22:11:31.289Z",
+  "generatedAt": "2026-07-16T22:19:31.948Z",
   "gateResults": [
     {
       "name": "typecheck-core",
       "status": "passed",
       "command": "bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json",
       "proofPath": ".ci/local-first-ci-gates/typecheck-core.proof.json",
-      "proofHash": "90a3eed674fb2a6d85bd1b3032df6ed2f4001e558c2c2e9a0f6d4d35280c795b",
-      "executedAt": "2026-07-16T22:11:28.308Z"
+      "proofHash": "8bb773d1a5916819ca91b15585f90bc4dd38e0e70cc6706d7d018a363948b04a",
+      "executedAt": "2026-07-16T22:19:24.862Z"
     },
     {
       "name": "integrity-manifest",
       "status": "passed",
       "command": "bun run integrity:manifest:write",
       "proofPath": ".ci/local-first-ci-gates/integrity-manifest.proof.json",
-      "proofHash": "5dc76479fd8caf02cf9cf54108bc046dfbb908d3a06bd23d0a9ce8e4c488dbe2",
-      "executedAt": "2026-07-16T22:11:26.033Z"
+      "proofHash": "e80e848b4a6f81bff595c7d056901a5ee18989891e0c67be23be82c4617898cf",
+      "executedAt": "2026-07-16T22:19:20.131Z"
     },
     {
       "name": "t11-any-budget-push",
       "status": "passed",
       "command": "bun scripts/check/check-t11-any-budget.mjs",
       "proofPath": ".ci/local-first-ci-gates/t11-any-budget-push.proof.json",
-      "proofHash": "a525f5cc8fc1c9567f2a8bd0469cee446c299eeb3f45df390e7882d9ac7f5b06",
-      "executedAt": "2026-07-16T22:11:29.346Z"
+      "proofHash": "bdbaf6aab307295a4aaf2530fa3c9a8b21582519d1aa37d26b2ede0b56c7e717",
+      "executedAt": "2026-07-16T22:19:27.811Z"
     },
     {
       "name": "cycles-push",
       "status": "passed",
       "command": "bun scripts/check/check-cycles.mjs",
       "proofPath": ".ci/local-first-ci-gates/cycles-push.proof.json",
-      "proofHash": "1266877ed9396f5e9a6ec548e731a029e93ca7b6cd36b9340cf1894dad5a9d9a",
-      "executedAt": "2026-07-16T22:11:30.464Z"
+      "proofHash": "43b05c50f5bdbbfd3ab4975deb001e4a86737877d25b5bf807f8bbceea2205ef",
+      "executedAt": "2026-07-16T22:19:29.205Z"
     }
   ],
   "content": {
@@ -8502,6 +8502,6 @@
       "worklogs/2026-06-25-L5-119-b9-dispatcher-fallback.md",
       "worklogs/L5-209-v48-envelope-expansion-2026-06-30.json"
     ],
-    "sourceTreeSha256": "5f890fc7377e2346df734962bea2015d5e73ff62166cd58574b776f296db8afa"
+    "sourceTreeSha256": "fb1772d7cfa836e5f341e74fe48e434c6fcef9f7d35c840776f6cc5025b6a6fa"
   }
 }

--- a/ci/integrity-manifest.sha256
+++ b/ci/integrity-manifest.sha256
@@ -21,9 +21,10 @@ f7ae985a3e782db33a38788d7f40dbb43b4ba6708fcf8c94d79be952a1099552  apps/bff/src/t
 aa7858f05b2261348f1502fa076550b0930672e0df3f054a22e8a8d9b68fb32e  apps/bff/vitest.config.ts
 4aebbec05edaf48712508f9a0f5e0ebd3a85e5f8d334b783bdbbb31539bf6295  apps/web/.gitignore
 c6d5a0fe61584c9d32ceaf127af9b719682bfed832d3dc22622476251bd8b9bd  apps/web/bun.lock
-9df787b866203b1c81e71ed6dbfa29b8eb91a1f788347f9e6f5d62448e2248a5  apps/web/package.json
+aadba4463f60758be6e9e14e70c44dc4da5a91eb3e86650035c27891f188b23d  apps/web/package.json
 86081c62590880b24ac39bc61a7f36123b97dfa35af161aa190a85ee61e2793f  apps/web/postcss.config.mjs
 8623736e05893f71ebd6f092b3868181a2742dabdc052829cb3c613fcf6eec19  apps/web/project.inlang/settings.json
+bcded14a66b60e5d8f34cf8359e28155cd53800fd049a6fc5cc092ab6724031e  apps/web/scripts/check/verify-ssr-i18n.mjs
 d5a02e53cf278fe3fbcd7f0933cd431e0302751f1f931e23b2a8081adda1dc31  apps/web/src/app.css
 34afba937fbadbe40ddc1189b27d89d0ebc313709690baeb04657ee53cc45dc0  apps/web/src/app.html
 765432ebb211191704465327f9d211f146957e959e649cf25e0e7ca21f1aa95e  apps/web/src/hooks.server.ts
@@ -63,7 +64,7 @@ f2646be1d646d52f6b33cfa86d3c41a30ad8850ea14ae1158eb41a65756fb6c2  apps/web/src/l
 1345c78d52539d10573db25cf53e1788636cf1dee9bd66df0e397b33aff4400c  apps/web/src/lib/i18n/hr.json
 1345c78d52539d10573db25cf53e1788636cf1dee9bd66df0e397b33aff4400c  apps/web/src/lib/i18n/hu.json
 1345c78d52539d10573db25cf53e1788636cf1dee9bd66df0e397b33aff4400c  apps/web/src/lib/i18n/id.json
-93b20ef632c6f3530ce520415e58c6e6b2ae9ec74644691b31f26cbda1092b44  apps/web/src/lib/i18n/index.ts
+e5537dd4c62eb61f186ccab06e4861542be6a6976d56f857de603b9366275093  apps/web/src/lib/i18n/index.svelte.ts
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  apps/web/src/lib/i18n/index.ts.bak
 1345c78d52539d10573db25cf53e1788636cf1dee9bd66df0e397b33aff4400c  apps/web/src/lib/i18n/is.json
 378194833b5dbb0068313de1e11c22bb69978f1d0c6ff4e40230331ae56e1980  apps/web/src/lib/i18n/it.json
@@ -92,7 +93,7 @@ cdae1ca29ca5ba0c71572d4652e6e49a66bf913a9ddfbe01b344aa2a8abf364e  apps/web/src/l
 8345e2670597c2618d6fb741ef0de398a6d02e6bb40651765ac4d98d0894c6e7  apps/web/src/lib/observability/web-vitals.ts
 c2e64c0f3cebbf571830d42b9c5e8c839137f7bdec453ea69e3ebb1ee2eeec5e  apps/web/src/lib/stores/theme.svelte.ts
 02951033769284bc34d16422cca48827ff4a0831f7eb818f14c5fd5ea7b2297e  apps/web/src/lib/trpc/client.ts
-eca750dd8caa6fbd0756023a04bd56d80a5284cd565b9ce9be33972de522409a  apps/web/src/routes/+layout.svelte
+87d8faad429dbd5c22182ed91912f85e96884a7194df7151f2701798213be958  apps/web/src/routes/+layout.svelte
 2ecbc1b9bd98d10059c00782d480cd1b8317dd98521849a44986dad8c85bf3ce  apps/web/src/routes/+page.svelte
 94f159e12b1eadbca4db37418528cdb2cd2cd6b0b21d4ebd349678770fec4547  apps/web/src/routes/callback/+page.svelte
 06a67f8aa60bcbafcbb87fcdffe6e7730c5d7454416eb8369d4dbb82f710f46d  apps/web/src/routes/dashboard/+page.server.ts
@@ -135,6 +136,7 @@ f1fbd37149f5b9256fb0a1ec1c7484ed54edf9176c4dd6b314059fa8c5b9215e  apps/web/src/r
 2fb663ec0592d0638e533617eab92e028edd579943246544a4cfbce628317a0d  apps/web/src/routes/dashboard/webhooks/+page.svelte
 5460044f3da0fcae19dc3d828fe0b656bf5954a3aad0c609c8abd2b9fbb9a032  apps/web/src/routes/login/+page.svelte
 6d51f94e18f1b73c695df4bf30487b017e0257061781a83ed73438289001f68a  apps/web/svelte.config.js
+59830cbbfa6319bf55336e36bf6bf37ab03aff2e1c64596bf13185bd6b795c3b  apps/web/tests/unit/i18n/runtime.test.ts
 4fca6828745e92761d6feaae3b3f7c236f556c7bd8239c424ac337bd9b49753f  apps/web/tsconfig.json
 e4bd9f149c04e35cae2196296bd17f179331c0fba03f5df7152217796c5b12e4  apps/web/vite.config.ts
 1afccfdd21c276d711740dff9e39a1328ccd5c47d0d7991711bc24a2e4204a50  lefthook.yml
@@ -208,9 +210,10 @@ a2a3e262b6960e1b3e3a848d3bcecdbba538cf2a4d2871a0832287186361754a  scripts/check/
 90f26665bd173f02e085b61aa2cd0b9ca5cd75feda6583b11005d667fab3bc3f  scripts/check/check-workflows.mjs
 9b31c50a6ff5df35e5f5e0e02cf1d626de43a9f3b493a0d78631ade24615c420  scripts/check/compression-budget-baseline.json
 7b61e8a7da0c7731985098b7395f6fe10dbeeef55ef11e7002eab2b60df8c2a1  scripts/check/lib/allowlist.mjs
+2e2c7fc84bc1b564064f0e7f9b2ac1e139f60ede947b51f9ae3ee0a36e8ed6ca  scripts/check/local-first-ci-artifact.mjs
 7ce736bcd604151d6c09673a967426bf9a22b631d4567c1d0f9d697472d7f145  scripts/check/local-first-ci-attestation.mjs
 c1f4f2c5a2bfece7d6c4a0f5845c010c3824ec27b0803a4d6abd047a562e28df  scripts/check/local-first-ci-attestation.test.mjs
-d3ba919241d880040d61a597d499ab6f5cf56c02ad221d68b6ea771386b41c78  scripts/check/local-first-ci-mode.mjs
-6826e76c095168fa301c33e7539051930692758987b8fcb028a7cb2f7c66b79d  scripts/check/local-first-ci-mode.test.mjs
+c3be140ed75c484a24eb93caa277a79d9bf8c737f635584e4355793012e2bfaa  scripts/check/local-first-ci-mode.mjs
+d24411a366d52891d30a188ef11d728dd1b01e1475cb007c00a013d2e237e6fa  scripts/check/local-first-ci-mode.test.mjs
 eba610d3bc07dc427fdc1cc807a9b68001402a57951382c7a0732ef4828463ed  scripts/check/test-report-summary.mjs
 d0f2c6fe56bd382eae4f4a7abd9a75cfabc6a931b623c514cbfea0fef6e827d3  scripts/check/verify-integrity-manifest.mjs

--- a/tests/unit/workflow-expressions.test.ts
+++ b/tests/unit/workflow-expressions.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+test("GitHub Actions if expressions use single-quoted string literals", async () => {
+  const directory = path.resolve(".github/workflows");
+  const failures: string[] = [];
+  for (const name of await readdir(directory)) {
+    if (!/\.ya?ml$/.test(name)) continue;
+    for (const [index, line] of (await readFile(path.join(directory, name), "utf8")).split("\n").entries()) {
+      if (/^\s*if:\s*\$\{\{/.test(line) && /[^\\]"[^\\]*"/.test(line)) failures.push(`${name}:${index + 1}`);
+    }
+  }
+  assert.deepEqual(failures, []);
+});


### PR DESCRIPTION
Adds a regression guard for invalid double-quoted string literals in GitHub Actions if expressions. The underlying 54-expression repair is already present on current main.