### PR TITLE
ci: refresh exact-main Local-First evidence

### DIFF
--- a/.ci/local-first-ci-gates/cycles-push.log.txt
+++ b/.ci/local-first-ci-gates/cycles-push.log.txt
@@ -1,10 +1,10 @@
 command: bun scripts/check/check-cycles.mjs
-startedAt: 2026-07-16T09:49:16.827Z
-finishedAt: 2026-07-16T09:49:21.302Z
+startedAt: 2026-07-16T20:40:51.574Z
+finishedAt: 2026-07-16T20:41:10.331Z
 exitCode: 0
 signal: none
-inputSha256: 59a15486a1e36443b1fdce5066e7fc46de566b1bf497e0fa132ad4cd11c2b139
-sourceTreeSha256: ab6fa536e274ac4a742d58215d0e45aee883bff4e7402323156d6d6b96337772
+inputSha256: 6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e
+sourceTreeSha256: db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6
 stdout:
 [cycles] OK - no cycles detected across 346 files in: src/shared/components, src/lib/db, src/lib/compliance, open-sse/translator, open-sse/mcp-server
 

--- a/.ci/local-first-ci-gates/cycles-push.proof.json
+++ b/.ci/local-first-ci-gates/cycles-push.proof.json
@@ -5,16 +5,16 @@
   "command": "bun scripts/check/check-cycles.mjs",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T09:49:21.308Z",
+  "generatedAt": "2026-07-16T20:41:10.350Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "59a15486a1e36443b1fdce5066e7fc46de566b1bf497e0fa132ad4cd11c2b139",
-    "fileCount": 8456,
-    "sourceTreeSha256": "ab6fa536e274ac4a742d58215d0e45aee883bff4e7402323156d6d6b96337772"
+    "hash": "6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e",
+    "fileCount": 8457,
+    "sourceTreeSha256": "db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/cycles-push.log.txt",
-    "sha256": "92683aa948dfb49776fd6abd42c79d5bd8540fae860a0a8889a051ae97ae8be8",
+    "sha256": "3160c5459fcb55b3355bc04abda97f87292279b1d782ff331471960d8cee1e46",
     "bytes": 470
   }
 }

--- a/.ci/local-first-ci-gates/integrity-manifest.log.txt
+++ b/.ci/local-first-ci-gates/integrity-manifest.log.txt
@@ -1,10 +1,10 @@
 command: bun run integrity:manifest:write
-startedAt: 2026-07-16T09:49:05.331Z
-finishedAt: 2026-07-16T09:49:13.088Z
+startedAt: 2026-07-16T20:39:51.529Z
+finishedAt: 2026-07-16T20:39:52.040Z
 exitCode: 0
 signal: none
-inputSha256: 59a15486a1e36443b1fdce5066e7fc46de566b1bf497e0fa132ad4cd11c2b139
-sourceTreeSha256: ab6fa536e274ac4a742d58215d0e45aee883bff4e7402323156d6d6b96337772
+inputSha256: 6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e
+sourceTreeSha256: db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6
 stdout:
 Wrote ci\integrity-manifest.sha256 (216 files).
 

--- a/.ci/local-first-ci-gates/integrity-manifest.proof.json
+++ b/.ci/local-first-ci-gates/integrity-manifest.proof.json
@@ -5,16 +5,16 @@
   "command": "bun run integrity:manifest:write",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T09:49:13.095Z",
+  "generatedAt": "2026-07-16T20:39:52.045Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "59a15486a1e36443b1fdce5066e7fc46de566b1bf497e0fa132ad4cd11c2b139",
-    "fileCount": 8456,
-    "sourceTreeSha256": "ab6fa536e274ac4a742d58215d0e45aee883bff4e7402323156d6d6b96337772"
+    "hash": "6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e",
+    "fileCount": 8457,
+    "sourceTreeSha256": "db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/integrity-manifest.log.txt",
-    "sha256": "fc0fe2f5f802bd77f84d8bbb67fe0f1daba828d075ed9928cefa8f5c9408464a",
+    "sha256": "bdb85ad1ddd72f794399b4668e5c54ecaa0a706f58edc5dfb0560a371fb751c5",
     "bytes": 425
   }
 }

--- a/.ci/local-first-ci-gates/t11-any-budget-push.log.txt
+++ b/.ci/local-first-ci-gates/t11-any-budget-push.log.txt
@@ -1,10 +1,10 @@
 command: bun scripts/check/check-t11-any-budget.mjs
-startedAt: 2026-07-16T09:49:20.464Z
-finishedAt: 2026-07-16T09:49:23.927Z
+startedAt: 2026-07-16T20:40:21.026Z
+finishedAt: 2026-07-16T20:40:27.148Z
 exitCode: 0
 signal: none
-inputSha256: 59a15486a1e36443b1fdce5066e7fc46de566b1bf497e0fa132ad4cd11c2b139
-sourceTreeSha256: ab6fa536e274ac4a742d58215d0e45aee883bff4e7402323156d6d6b96337772
+inputSha256: 6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e
+sourceTreeSha256: db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6
 stdout:
 [t11:any-budget] OK - src/app/api/settings/proxy/test/route.ts (explicit any: 0, budget: 0)
 [t11:any-budget] OK - src/shared/components/OAuthModal.tsx (explicit any: 0, budget: 0)

--- a/.ci/local-first-ci-gates/t11-any-budget-push.proof.json
+++ b/.ci/local-first-ci-gates/t11-any-budget-push.proof.json
@@ -5,16 +5,16 @@
   "command": "bun scripts/check/check-t11-any-budget.mjs",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T09:49:23.938Z",
+  "generatedAt": "2026-07-16T20:40:27.157Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "59a15486a1e36443b1fdce5066e7fc46de566b1bf497e0fa132ad4cd11c2b139",
-    "fileCount": 8456,
-    "sourceTreeSha256": "ab6fa536e274ac4a742d58215d0e45aee883bff4e7402323156d6d6b96337772"
+    "hash": "6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e",
+    "fileCount": 8457,
+    "sourceTreeSha256": "db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/t11-any-budget-push.log.txt",
-    "sha256": "3f13088f905067431939e84bb06fff715c26770a14d04b7bf3bb270d7942d3fd",
+    "sha256": "5de9f4b8a5f543928b45443a3e6b2293d81c8aa1271161f3bc305dcb21d4e33c",
     "bytes": 7693
   }
 }

--- a/.ci/local-first-ci-gates/typecheck-core.log.txt
+++ b/.ci/local-first-ci-gates/typecheck-core.log.txt
@@ -1,10 +1,10 @@
 command: bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json
-startedAt: 2026-07-16T09:49:23.870Z
-finishedAt: 2026-07-16T09:51:50.978Z
+startedAt: 2026-07-16T20:39:13.952Z
+finishedAt: 2026-07-16T20:39:31.591Z
 exitCode: 0
 signal: none
-inputSha256: 59a15486a1e36443b1fdce5066e7fc46de566b1bf497e0fa132ad4cd11c2b139
-sourceTreeSha256: ab6fa536e274ac4a742d58215d0e45aee883bff4e7402323156d6d6b96337772
+inputSha256: 6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e
+sourceTreeSha256: db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6
 stdout:
 
 stderr:

--- a/.ci/local-first-ci-gates/typecheck-core.proof.json
+++ b/.ci/local-first-ci-gates/typecheck-core.proof.json
@@ -5,16 +5,16 @@
   "command": "bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json",
   "exitCode": 0,
   "signal": null,
-  "generatedAt": "2026-07-16T09:51:50.984Z",
+  "generatedAt": "2026-07-16T20:39:31.594Z",
   "input": {
     "algorithm": "sha256",
-    "hash": "59a15486a1e36443b1fdce5066e7fc46de566b1bf497e0fa132ad4cd11c2b139",
-    "fileCount": 8456,
-    "sourceTreeSha256": "ab6fa536e274ac4a742d58215d0e45aee883bff4e7402323156d6d6b96337772"
+    "hash": "6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e",
+    "fileCount": 8457,
+    "sourceTreeSha256": "db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6"
   },
   "log": {
     "path": ".ci/local-first-ci-gates/typecheck-core.log.txt",
-    "sha256": "78c79e1174411cdf86d35126373902cea07b4444d44b3e2b5ac0194195610830",
+    "sha256": "fe1f5dfec7fd2d9d30c1ad616f7c9b1e495b08fa6efa0b32bfcd716f707d02e9",
     "bytes": 377
   }
 }

--- a/.ci/local-first-ci-manifest.json
+++ b/.ci/local-first-ci-manifest.json
@@ -1,44 +1,44 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-07-16T09:59:11.118Z",
+  "generatedAt": "2026-07-16T20:41:32.295Z",
   "gateResults": [
     {
       "name": "typecheck-core",
       "status": "passed",
       "command": "bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json",
       "proofPath": ".ci/local-first-ci-gates/typecheck-core.proof.json",
-      "proofHash": "c643f9e22d5f26467dff0fcc05306d1937c3af1595853708f389cc4f9691afb8",
-      "executedAt": "2026-07-16T09:51:50.984Z"
+      "proofHash": "1e2566658a0a373e38469d3a440f9f02bd446c9cd6be80678188ae2c15c6c775",
+      "executedAt": "2026-07-16T20:39:31.594Z"
     },
     {
       "name": "integrity-manifest",
       "status": "passed",
       "command": "bun run integrity:manifest:write",
       "proofPath": ".ci/local-first-ci-gates/integrity-manifest.proof.json",
-      "proofHash": "75b90bed0aab9da58c353c4e378a81af05d5d82221fd0ae8d58d55970acc6eb1",
-      "executedAt": "2026-07-16T09:49:13.095Z"
+      "proofHash": "33d1cde0e17292937c42c98e9c7c592848f70d2f35b604600926a378455b10df",
+      "executedAt": "2026-07-16T20:39:52.045Z"
     },
     {
       "name": "t11-any-budget-push",
       "status": "passed",
       "command": "bun scripts/check/check-t11-any-budget.mjs",
       "proofPath": ".ci/local-first-ci-gates/t11-any-budget-push.proof.json",
-      "proofHash": "9dc8d38ab11c850b5e412c059f1542670b23f6eff1a63c86fa2ba9b0834cfb25",
-      "executedAt": "2026-07-16T09:49:23.938Z"
+      "proofHash": "93b2b3cb778b530dedf20c220659491429f34fa7ce005b0fc5bb7db5a8fb7fce",
+      "executedAt": "2026-07-16T20:40:27.157Z"
     },
     {
       "name": "cycles-push",
       "status": "passed",
       "command": "bun scripts/check/check-cycles.mjs",
       "proofPath": ".ci/local-first-ci-gates/cycles-push.proof.json",
-      "proofHash": "748c31183cb5a4de936e6d1eae077d5fd522806362806d6b3a6f4bf119f1ff3f",
-      "executedAt": "2026-07-16T09:49:21.308Z"
+      "proofHash": "ddb05ba1bd51078ec388f50299dec45f01758edd3092839aceb7b6a5afa5c22e",
+      "executedAt": "2026-07-16T20:41:10.350Z"
     }
   ],
   "content": {
     "algorithm": "sha256",
-    "hash": "59a15486a1e36443b1fdce5066e7fc46de566b1bf497e0fa132ad4cd11c2b139",
-    "fileCount": 8456,
+    "hash": "6458642f431bbca0c33bb97fca99042fee523535f69b6ef45434d6ea6bc3ab2e",
+    "fileCount": 8457,
     "trackedFiles": [
       ".coderabbit.yaml",
       ".devcontainer/devcontainer.json",
@@ -8295,6 +8295,7 @@
       "tests/unit/ui/provider-breaker-health-hook.test.tsx",
       "tests/unit/ui/provider-plan-config.test.tsx",
       "tests/unit/ui/provider-quota-widget-auto-refresh-label-4611.test.tsx",
+      "tests/unit/ui/provider-stats-bifrost-connections.test.tsx",
       "tests/unit/ui/providerCascadeNode.test.tsx",
       "tests/unit/ui/qdrant-config-card.test.tsx",
       "tests/unit/ui/quantumLockBadge.test.tsx",
@@ -8497,6 +8498,6 @@
       "worklogs/2026-06-25-L5-119-b9-dispatcher-fallback.md",
       "worklogs/L5-209-v48-envelope-expansion-2026-06-30.json"
     ],
-    "sourceTreeSha256": "ab6fa536e274ac4a742d58215d0e45aee883bff4e7402323156d6d6b96337772"
+    "sourceTreeSha256": "db8f4cf3fc96d22e55df7a137af2cd4e0ea67869c67b8c9852f25e935d32f7a6"
   }
 }


### PR DESCRIPTION
## Summary
- regenerate the four canonical Local-First gate proof/log pairs on exact main after #353
- refresh the attestation manifest for 8,457 tracked inputs
- change generated evidence only; no product, workflow, or policy files

## Validation
- four canonical recorders passed
- manifest write and standalone verification passed
- detached exact-commit verification passed
- 12/12 mode and attestation tests passed
- 72 workflow YAML files parse
- structural actionlint passed; zero mutable non-local action refs
- effective diff is exactly nine .ci files