### PR TITLE
fix(ci): record main evidence from exact merge tree

### DIFF
--- a/.github/workflows/local-first-ci.yml
+++ b/.github/workflows/local-first-ci.yml
@@ -13,12 +13,13 @@ on:
         options:
           - live
           - verify
+          - record
 
 permissions:
   contents: read
 
 concurrency:
-  group: local-first-ci-${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  group: local-first-ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/local-first-ci.yml
+++ b/.github/workflows/local-first-ci.yml
@@ -4,6 +4,15 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Run live gates or audit the committed snapshot
+        required: true
+        default: live
+        type: choice
+        options:
+          - live
+          - verify
 
 permissions:
   contents: read
@@ -33,6 +42,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DISPATCH_MODE: ${{ inputs.mode }}
         run: node scripts/check/local-first-ci-mode.mjs
 
   verify-committed-evidence:
@@ -85,10 +95,64 @@ jobs:
       - name: Assert live mode did not mutate committed evidence
         run: git diff --exit-code -- .ci/local-first-ci-manifest.json .ci/local-first-ci-gates
 
+  record-main-evidence:
+    name: Record exact-tree evidence
+    needs: mode
+    if: ${{ needs.mode.outputs.selected == 'record' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4.4.0
+        with:
+          node-version: "24"
+          cache: npm
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+      - name: Install pinned dependencies
+        run: npm ci --ignore-scripts
+      - name: Record typecheck proof
+        run: node scripts/check/local-first-ci-attestation.mjs --record --gate typecheck-core --command "bunx --no-install tsc --noEmit --noCheck --ignoreDeprecations 6.0 -p open-sse/tsconfig.json"
+      - name: Record integrity-manifest proof
+        run: node scripts/check/local-first-ci-attestation.mjs --record --gate integrity-manifest --command "bun run integrity:manifest:write"
+      - name: Restore exact merge tree after integrity writer
+        run: git restore --source=HEAD -- ci/integrity-manifest.sha256
+      - name: Record T11 any-budget proof
+        run: node scripts/check/local-first-ci-attestation.mjs --record --gate t11-any-budget-push --command "bun scripts/check/check-t11-any-budget.mjs"
+      - name: Record dependency-cycle proof
+        run: node scripts/check/local-first-ci-attestation.mjs --record --gate cycles-push --command "bun scripts/check/check-cycles.mjs"
+      - name: Write and verify schema-v2 manifest
+        run: |
+          node scripts/check/local-first-ci-attestation.mjs --write
+          node scripts/check/local-first-ci-attestation.mjs
+      - name: Run mode, unit, and tamper tests
+        run: node --test scripts/check/local-first-ci-mode.test.mjs scripts/check/local-first-ci-attestation.test.mjs
+      - name: Assert source tree remained exact
+        run: git diff --exit-code -- . ':!.ci/**'
+      - name: Build checksum and provenance envelope
+        run: node scripts/check/local-first-ci-artifact.mjs
+      - name: Upload commit-addressed evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: local-first-ci-${{ github.sha }}
+          path: |
+            .ci/local-first-ci-manifest.json
+            .ci/local-first-ci-gates/
+            .local-first-ci-artifact/checksums.sha256
+            .local-first-ci-artifact/provenance.json
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 9
+          include-hidden-files: true
+
   terminal:
     name: Local-First CI terminal
     if: ${{ always() }}
-    needs: [mode, verify-committed-evidence, live-gates]
+    needs: [mode, verify-committed-evidence, live-gates, record-main-evidence]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
@@ -96,6 +160,7 @@ jobs:
       SELECTED_MODE: ${{ needs.mode.outputs.selected }}
       VERIFY_RESULT: ${{ needs.verify-committed-evidence.result }}
       LIVE_RESULT: ${{ needs.live-gates.result }}
+      RECORD_RESULT: ${{ needs.record-main-evidence.result }}
     steps:
       - name: Enforce selected mode result
         shell: bash
@@ -107,14 +172,20 @@ jobs:
           fi
           case "$SELECTED_MODE" in
             verify)
-              [[ "$VERIFY_RESULT" == "success" && "$LIVE_RESULT" == "skipped" ]] || {
-                echo "Unexpected verify-mode results: verify=$VERIFY_RESULT live=$LIVE_RESULT" >&2
+              [[ "$VERIFY_RESULT" == "success" && "$LIVE_RESULT" == "skipped" && "$RECORD_RESULT" == "skipped" ]] || {
+                echo "Unexpected verify-mode results: verify=$VERIFY_RESULT live=$LIVE_RESULT record=$RECORD_RESULT" >&2
                 exit 1
               }
               ;;
             live)
-              [[ "$LIVE_RESULT" == "success" && "$VERIFY_RESULT" == "skipped" ]] || {
-                echo "Unexpected live-mode results: live=$LIVE_RESULT verify=$VERIFY_RESULT" >&2
+              [[ "$LIVE_RESULT" == "success" && "$VERIFY_RESULT" == "skipped" && "$RECORD_RESULT" == "skipped" ]] || {
+                echo "Unexpected live-mode results: live=$LIVE_RESULT verify=$VERIFY_RESULT record=$RECORD_RESULT" >&2
+                exit 1
+              }
+              ;;
+            record)
+              [[ "$RECORD_RESULT" == "success" && "$VERIFY_RESULT" == "skipped" && "$LIVE_RESULT" == "skipped" ]] || {
+                echo "Unexpected record-mode results: record=$RECORD_RESULT verify=$VERIFY_RESULT live=$LIVE_RESULT" >&2
                 exit 1
               }
               ;;

--- a/docs/architecture/QUALITY_GATES.md
+++ b/docs/architecture/QUALITY_GATES.md
@@ -24,6 +24,7 @@ The workflow at `.github/workflows/local-first-ci.yml` has two fail-closed modes
 | Push to a non-default branch | `live` | Same live gate and test execution as a pull request |
 | Manual dispatch (`live`) | `live` | Same live gate and test execution for operator diagnosis |
 | Manual dispatch (`verify`) | `verify` | Audit the committed snapshot; stale evidence fails closed |
+| Manual dispatch (`record`) | `record` | Regenerate, verify, and upload exact-tree evidence for the selected commit without changing the branch |
 | Any other event or inconsistent branch metadata | rejected | The terminal aggregate fails closed |
 
 Live mode does not require a branch to commit regenerated `.ci` evidence. Record mode regenerates

--- a/docs/architecture/QUALITY_GATES.md
+++ b/docs/architecture/QUALITY_GATES.md
@@ -19,15 +19,21 @@ The workflow at `.github/workflows/local-first-ci.yml` has two fail-closed modes
 
 | Event | Mode | Required result |
 | --- | --- | --- |
-| Push to the repository default branch | `verify` | Verify committed schema-v2 evidence against the exact checked-out tree |
+| Push to the repository default branch | `record` | Run four canonical gates on the exact merge tree, verify fresh evidence, and upload a commit-addressed artifact |
 | Pull request | `live` | Install pinned tools and dependencies, run all four canonical gates plus unit/tamper tests |
 | Push to a non-default branch | `live` | Same live gate and test execution as a pull request |
-| Manual dispatch | `live` | Same live gate and test execution for operator diagnosis |
+| Manual dispatch (`live`) | `live` | Same live gate and test execution for operator diagnosis |
+| Manual dispatch (`verify`) | `verify` | Audit the committed snapshot; stale evidence fails closed |
 | Any other event or inconsistent branch metadata | rejected | The terminal aggregate fails closed |
 
-Live mode does not require a branch to commit regenerated `.ci` evidence. The terminal aggregate
+Live mode does not require a branch to commit regenerated `.ci` evidence. Record mode regenerates
+evidence only in the runner workspace, verifies it, and uploads the manifest, four proof/log pairs,
+checksums, and workflow provenance as `local-first-ci-<full commit SHA>`. It never commits generated
+evidence, so normal source merges cannot create evidence-repair churn. Committed `.ci` evidence is
+retained only as an explicitly dispatched audit snapshot and does not block normal `main` pushes.
+The terminal aggregate
 requires exactly the selected mode to succeed, the other mode to skip, and rejects cancellation,
-failure, or an unexpected skip. Default-branch verification remains an exact-tree publication gate.
+failure, or an unexpected skip. Default-branch recording is the exact-tree publication gate.
 Manifests and proofs require exact SHA-256 parity with every tracked repository file except the
 generated `.ci/` evidence itself. That single exclusion prevents proofs and their manifest from
 invalidating their own provenance; product source, tests, configuration, workflows, manifests,

--- a/docs/architecture/QUALITY_GATES.md
+++ b/docs/architecture/QUALITY_GATES.md
@@ -17,15 +17,15 @@ Local development pre-push checks now emit committed per-gate proof artifacts in
 (`*.proof.json` + `*.log.txt`) and a manifest at `.ci/local-first-ci-manifest.json`.
 The workflow at `.github/workflows/local-first-ci.yml` has two fail-closed modes:
 
-| Event | Mode | Required result |
-| --- | --- | --- |
-| Push to the repository default branch | `record` | Run four canonical gates on the exact merge tree, verify fresh evidence, and upload a commit-addressed artifact |
-| Pull request | `live` | Install pinned tools and dependencies, run all four canonical gates plus unit/tamper tests |
-| Push to a non-default branch | `live` | Same live gate and test execution as a pull request |
-| Manual dispatch (`live`) | `live` | Same live gate and test execution for operator diagnosis |
-| Manual dispatch (`verify`) | `verify` | Audit the committed snapshot; stale evidence fails closed |
-| Manual dispatch (`record`) | `record` | Regenerate, verify, and upload exact-tree evidence for the selected commit without changing the branch |
-| Any other event or inconsistent branch metadata | rejected | The terminal aggregate fails closed |
+| Event                                           | Mode     | Required result                                                                                                 |
+| ----------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| Push to the repository default branch           | `record` | Run four canonical gates on the exact merge tree, verify fresh evidence, and upload a commit-addressed artifact |
+| Pull request                                    | `live`   | Install pinned tools and dependencies, run all four canonical gates plus unit/tamper tests                      |
+| Push to a non-default branch                    | `live`   | Same live gate and test execution as a pull request                                                             |
+| Manual dispatch (`live`)                        | `live`   | Same live gate and test execution for operator diagnosis                                                        |
+| Manual dispatch (`verify`)                      | `verify` | Audit the committed snapshot; stale evidence fails closed                                                       |
+| Manual dispatch (`record`)                      | `record` | Regenerate, verify, and upload exact-tree evidence for the selected commit without changing the branch          |
+| Any other event or inconsistent branch metadata | rejected | The terminal aggregate fails closed                                                                             |
 
 Live mode does not require a branch to commit regenerated `.ci` evidence. Record mode regenerates
 evidence only in the runner workspace, verifies it, and uploads the manifest, four proof/log pairs,

--- a/scripts/check/local-first-ci-artifact.mjs
+++ b/scripts/check/local-first-ci-artifact.mjs
@@ -19,7 +19,7 @@ async function filesUnder(directory) {
     if (entry.isDirectory()) files.push(...(await filesUnder(path)));
     else if (entry.isFile()) files.push(path);
   }
-  return files.sort();
+  return files.sort((left, right) => left.localeCompare(right, "en"));
 }
 
 function sha256(value) {

--- a/scripts/check/local-first-ci-artifact.mjs
+++ b/scripts/check/local-first-ci-artifact.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { basename, join, relative, resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "../..");
+const evidenceRoot = resolve(root, ".ci");
+const outputRoot = resolve(root, ".local-first-ci-artifact");
+const sha = process.env.GITHUB_SHA || "";
+
+if (!/^[0-9a-f]{40}$/u.test(sha)) throw new Error("GITHUB_SHA must be a full lowercase commit SHA");
+
+async function filesUnder(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...(await filesUnder(path)));
+    else if (entry.isFile()) files.push(path);
+  }
+  return files.sort();
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+await mkdir(outputRoot, { recursive: true });
+const evidenceFiles = await filesUnder(evidenceRoot);
+const checksums = [];
+for (const path of evidenceFiles) {
+  const content = await readFile(path);
+  const artifactPath = relative(root, path).replaceAll("\\", "/");
+  checksums.push(`${sha256(content)}  ${artifactPath}`);
+}
+
+const manifest = JSON.parse(await readFile(resolve(evidenceRoot, "local-first-ci-manifest.json"), "utf8"));
+const provenance = {
+  schemaVersion: 1,
+  artifact: `local-first-ci-${sha}`,
+  commitSha: sha,
+  sourceTreeSha256: manifest.content?.sourceTreeSha256,
+  filesystemSha256: manifest.content?.hash,
+  trackedInputCount: manifest.content?.fileCount,
+  workflow: process.env.GITHUB_WORKFLOW || "",
+  workflowRef: process.env.GITHUB_WORKFLOW_REF || "",
+  runId: process.env.GITHUB_RUN_ID || "",
+  runAttempt: process.env.GITHUB_RUN_ATTEMPT || "",
+  eventName: process.env.GITHUB_EVENT_NAME || "",
+  repository: process.env.GITHUB_REPOSITORY || "",
+};
+
+if (!/^[0-9a-f]{64}$/u.test(provenance.sourceTreeSha256 || "")) {
+  throw new Error("generated manifest is missing source-tree provenance");
+}
+if (!/^[0-9a-f]{64}$/u.test(provenance.filesystemSha256 || "")) {
+  throw new Error("generated manifest is missing filesystem provenance");
+}
+
+await writeFile(resolve(outputRoot, "checksums.sha256"), `${checksums.join("\n")}\n`, "utf8");
+await writeFile(resolve(outputRoot, "provenance.json"), `${JSON.stringify(provenance, null, 2)}\n`, "utf8");
+console.log(`Prepared ${basename(outputRoot)} for ${sha} with ${evidenceFiles.length} evidence files.`);

--- a/scripts/check/local-first-ci-artifact.mjs
+++ b/scripts/check/local-first-ci-artifact.mjs
@@ -35,7 +35,9 @@ for (const path of evidenceFiles) {
   checksums.push(`${sha256(content)}  ${artifactPath}`);
 }
 
-const manifest = JSON.parse(await readFile(resolve(evidenceRoot, "local-first-ci-manifest.json"), "utf8"));
+const manifest = JSON.parse(
+  await readFile(resolve(evidenceRoot, "local-first-ci-manifest.json"), "utf8")
+);
 const provenance = {
   schemaVersion: 1,
   artifact: `local-first-ci-${sha}`,
@@ -59,5 +61,11 @@ if (!/^[0-9a-f]{64}$/u.test(provenance.filesystemSha256 || "")) {
 }
 
 await writeFile(resolve(outputRoot, "checksums.sha256"), `${checksums.join("\n")}\n`, "utf8");
-await writeFile(resolve(outputRoot, "provenance.json"), `${JSON.stringify(provenance, null, 2)}\n`, "utf8");
-console.log(`Prepared ${basename(outputRoot)} for ${sha} with ${evidenceFiles.length} evidence files.`);
+await writeFile(
+  resolve(outputRoot, "provenance.json"),
+  `${JSON.stringify(provenance, null, 2)}\n`,
+  "utf8"
+);
+console.log(
+  `Prepared ${basename(outputRoot)} for ${sha} with ${evidenceFiles.length} evidence files.`
+);

--- a/scripts/check/local-first-ci-mode.mjs
+++ b/scripts/check/local-first-ci-mode.mjs
@@ -3,12 +3,16 @@
 import { appendFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
-export function resolveLocalFirstMode({ eventName, refName, defaultBranch }) {
+export function resolveLocalFirstMode({ eventName, refName, defaultBranch, dispatchMode }) {
   if (eventName === "push") {
     if (!refName || !defaultBranch) throw new Error("push mode requires refName and defaultBranch");
-    return refName === defaultBranch ? "verify" : "live";
+    return refName === defaultBranch ? "record" : "live";
   }
-  if (eventName === "pull_request" || eventName === "workflow_dispatch") return "live";
+  if (eventName === "pull_request") return "live";
+  if (eventName === "workflow_dispatch") {
+    if (dispatchMode === "live" || dispatchMode === "verify") return dispatchMode;
+    throw new Error(`unsupported workflow_dispatch mode: ${dispatchMode || "<empty>"}`);
+  }
   throw new Error(`unsupported Local-First CI event: ${eventName || "<empty>"}`);
 }
 
@@ -17,6 +21,7 @@ function main() {
     eventName: process.env.EVENT_NAME,
     refName: process.env.REF_NAME,
     defaultBranch: process.env.DEFAULT_BRANCH,
+    dispatchMode: process.env.DISPATCH_MODE,
   });
   const output = process.env.GITHUB_OUTPUT;
   if (!output) throw new Error("GITHUB_OUTPUT is required");

--- a/scripts/check/local-first-ci-mode.mjs
+++ b/scripts/check/local-first-ci-mode.mjs
@@ -10,7 +10,9 @@ export function resolveLocalFirstMode({ eventName, refName, defaultBranch, dispa
   }
   if (eventName === "pull_request") return "live";
   if (eventName === "workflow_dispatch") {
-    if (dispatchMode === "live" || dispatchMode === "verify") return dispatchMode;
+    if (dispatchMode === "live" || dispatchMode === "verify" || dispatchMode === "record") {
+      return dispatchMode;
+    }
     throw new Error(`unsupported workflow_dispatch mode: ${dispatchMode || "<empty>"}`);
   }
   throw new Error(`unsupported Local-First CI event: ${eventName || "<empty>"}`);

--- a/scripts/check/local-first-ci-mode.test.mjs
+++ b/scripts/check/local-first-ci-mode.test.mjs
@@ -36,6 +36,7 @@ for (const [name, eventName, refName, defaultBranch, dispatchMode, expected] of 
 }
 
 test("unsupported events, invalid metadata, and invalid dispatch modes fail closed", () => {
+  assert.equal(typeof resolveLocalFirstMode, "function");
   assert.throws(
     () => resolveLocalFirstMode({ eventName: "schedule", refName: "main", defaultBranch: "main" }),
     /unsupported Local-First CI event/u

--- a/scripts/check/local-first-ci-mode.test.mjs
+++ b/scripts/check/local-first-ci-mode.test.mjs
@@ -4,28 +4,36 @@ import test from "node:test";
 import { resolveLocalFirstMode } from "./local-first-ci-mode.mjs";
 
 const cases = [
-  ["default-branch push verifies committed evidence", "push", "main", "main", "verify"],
-  ["non-default push runs gates live", "push", "feature/x", "main", "live"],
-  ["pull request runs gates live", "pull_request", "123/merge", "main", "live"],
-  ["manual dispatch runs gates live", "workflow_dispatch", "main", "main", "live"],
+  ["default-branch push records exact-tree evidence", "push", "main", "main", undefined, "record"],
+  ["non-default push runs gates live", "push", "feature/x", "main", undefined, "live"],
+  ["pull request runs gates live", "pull_request", "123/merge", "main", undefined, "live"],
+  ["manual live dispatch runs gates live", "workflow_dispatch", "main", "main", "live", "live"],
+  ["manual audit dispatch verifies committed evidence", "workflow_dispatch", "main", "main", "verify", "verify"],
 ];
 
-for (const [name, eventName, refName, defaultBranch, expected] of cases) {
+for (const [name, eventName, refName, defaultBranch, dispatchMode, expected] of cases) {
   test(name, () => {
-    assert.equal(resolveLocalFirstMode({ eventName, refName, defaultBranch }), expected);
+    assert.equal(resolveLocalFirstMode({ eventName, refName, defaultBranch, dispatchMode }), expected);
   });
 }
 
-test("unexpected events fail closed", () => {
+test("unsupported events, invalid metadata, and invalid dispatch modes fail closed", () => {
   assert.throws(
     () => resolveLocalFirstMode({ eventName: "schedule", refName: "main", defaultBranch: "main" }),
     /unsupported Local-First CI event/u,
   );
-});
-
-test("push mode fails closed without repository branch metadata", () => {
   assert.throws(
     () => resolveLocalFirstMode({ eventName: "push", refName: "main", defaultBranch: "" }),
     /requires refName and defaultBranch/u,
+  );
+  assert.throws(
+    () =>
+      resolveLocalFirstMode({
+        eventName: "workflow_dispatch",
+        refName: "main",
+        defaultBranch: "main",
+        dispatchMode: "record",
+      }),
+    /unsupported workflow_dispatch mode/u,
   );
 });

--- a/scripts/check/local-first-ci-mode.test.mjs
+++ b/scripts/check/local-first-ci-mode.test.mjs
@@ -8,24 +8,41 @@ const cases = [
   ["non-default push runs gates live", "push", "feature/x", "main", undefined, "live"],
   ["pull request runs gates live", "pull_request", "123/merge", "main", undefined, "live"],
   ["manual live dispatch runs gates live", "workflow_dispatch", "main", "main", "live", "live"],
-  ["manual audit dispatch verifies committed evidence", "workflow_dispatch", "main", "main", "verify", "verify"],
-  ["manual record dispatch emits exact-tree evidence", "workflow_dispatch", "main", "main", "record", "record"],
+  [
+    "manual audit dispatch verifies committed evidence",
+    "workflow_dispatch",
+    "main",
+    "main",
+    "verify",
+    "verify",
+  ],
+  [
+    "manual record dispatch emits exact-tree evidence",
+    "workflow_dispatch",
+    "main",
+    "main",
+    "record",
+    "record",
+  ],
 ];
 
 for (const [name, eventName, refName, defaultBranch, dispatchMode, expected] of cases) {
   test(name, () => {
-    assert.equal(resolveLocalFirstMode({ eventName, refName, defaultBranch, dispatchMode }), expected);
+    assert.equal(
+      resolveLocalFirstMode({ eventName, refName, defaultBranch, dispatchMode }),
+      expected
+    );
   });
 }
 
 test("unsupported events, invalid metadata, and invalid dispatch modes fail closed", () => {
   assert.throws(
     () => resolveLocalFirstMode({ eventName: "schedule", refName: "main", defaultBranch: "main" }),
-    /unsupported Local-First CI event/u,
+    /unsupported Local-First CI event/u
   );
   assert.throws(
     () => resolveLocalFirstMode({ eventName: "push", refName: "main", defaultBranch: "" }),
-    /requires refName and defaultBranch/u,
+    /requires refName and defaultBranch/u
   );
   assert.throws(
     () =>
@@ -35,6 +52,6 @@ test("unsupported events, invalid metadata, and invalid dispatch modes fail clos
         defaultBranch: "main",
         dispatchMode: "unsupported",
       }),
-    /unsupported workflow_dispatch mode/u,
+    /unsupported workflow_dispatch mode/u
   );
 });

--- a/scripts/check/local-first-ci-mode.test.mjs
+++ b/scripts/check/local-first-ci-mode.test.mjs
@@ -9,6 +9,7 @@ const cases = [
   ["pull request runs gates live", "pull_request", "123/merge", "main", undefined, "live"],
   ["manual live dispatch runs gates live", "workflow_dispatch", "main", "main", "live", "live"],
   ["manual audit dispatch verifies committed evidence", "workflow_dispatch", "main", "main", "verify", "verify"],
+  ["manual record dispatch emits exact-tree evidence", "workflow_dispatch", "main", "main", "record", "record"],
 ];
 
 for (const [name, eventName, refName, defaultBranch, dispatchMode, expected] of cases) {
@@ -32,7 +33,7 @@ test("unsupported events, invalid metadata, and invalid dispatch modes fail clos
         eventName: "workflow_dispatch",
         refName: "main",
         defaultBranch: "main",
-        dispatchMode: "record",
+        dispatchMode: "unsupported",
       }),
     /unsupported workflow_dispatch mode/u,
   );


### PR DESCRIPTION
## Summary
- record all four canonical Local-First gates on the exact default-branch merge tree
- verify fresh schema-v2 evidence and upload a full-SHA-addressed artifact with checksums and workflow provenance
- keep PR/non-default pushes in live nonmutation mode and reserve committed-snapshot verification for explicit audit dispatches
- fail closed through the terminal aggregate for unsupported modes, skips, cancellations, or failures

## Local validation
- 12/12 mode and attestation/tamper tests pass
- workflow YAML parses
- artifact envelope dry-run contains nine evidence files, checksums, and exact commit/source-tree/filesystem provenance
- git diff --check passes

No committed .ci evidence is regenerated by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recording mode for local-first CI workflows.
  * Default-branch checks now record and publish commit-addressed evidence artifacts.
  * Manual runs support explicit **live**, **verify**, and **record** modes.
  * Added integrity checks for source trees, manifests, checksums, and provenance.

* **Documentation**
  * Updated quality-gate guidance to reflect recording and verification requirements.

* **Tests**
  * Expanded coverage for mode selection, validation, and evidence-recording scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->