### PR TITLE
fix(v4): prove phenotype service health

### DIFF
--- a/.github/workflows/v4-journey-evidence.yml
+++ b/.github/workflows/v4-journey-evidence.yml
@@ -28,6 +28,7 @@ jobs:
     env:
       CI: "true"
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:4321
+      BFF_ORIGIN: http://127.0.0.1:4322
       NO_COLOR: "1"
     steps:
       - name: Check out source
@@ -59,22 +60,25 @@ jobs:
       - name: Start BFF and web preview
         run: |
           mkdir -p journey-evidence/service-logs
-          (cd apps/bff && PORT=4322 bun run start) >journey-evidence/service-logs/bff.log 2>&1 &
+          setsid bash -c 'cd apps/bff && exec env PORT=4322 bun dist/index.js' >journey-evidence/service-logs/bff.log 2>&1 &
           echo $! > journey-evidence/service-logs/bff.pid
-          (cd apps/web && bun run preview --host 127.0.0.1 --port 4321) >journey-evidence/service-logs/web.log 2>&1 &
+          setsid bash -c 'cd apps/web && exec env HOST=127.0.0.1 PORT=4321 BFF_ORIGIN="$BFF_ORIGIN" node build/index.js' >journey-evidence/service-logs/web.log 2>&1 &
           echo $! > journey-evidence/service-logs/web.pid
 
-      - name: Wait for v4 web lifecycle
+      - name: Wait for v4 service lifecycle
         shell: bash
         run: |
           set -euo pipefail
           for attempt in {1..30}; do
-            if curl --fail --silent --show-error http://127.0.0.1:4321/ >/dev/null; then
+            if kill -0 "$(cat journey-evidence/service-logs/bff.pid)" 2>/dev/null \
+              && kill -0 "$(cat journey-evidence/service-logs/web.pid)" 2>/dev/null \
+              && curl --fail --silent --show-error http://127.0.0.1:4322/healthz >/dev/null \
+              && curl --fail --silent --show-error http://127.0.0.1:4321/ >/dev/null; then
               exit 0
             fi
             sleep 1
           done
-          echo "v4 web preview did not become ready" >&2
+          echo "v4 BFF and web preview did not become ready" >&2
           exit 1
 
       - name: Capture deterministic evidence
@@ -90,6 +94,16 @@ jobs:
             exit 1
           fi
 
+      - name: Stop v4 services
+        if: always()
+        shell: bash
+        run: |
+          for pid_file in journey-evidence/service-logs/web.pid journey-evidence/service-logs/bff.pid; do
+            if test -f "$pid_file"; then
+              kill -- "-$(cat "$pid_file")" 2>/dev/null || true
+            fi
+          done
+
       - name: Upload journey evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -103,5 +117,3 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
           include-hidden-files: false
-
-

--- a/.github/workflows/v4-journey-evidence.yml
+++ b/.github/workflows/v4-journey-evidence.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Install locked dependencies
         run: |
           npm ci --ignore-scripts --no-audit --no-fund
+          rm -rf node_modules/bun node_modules/.bin/bun
+          test "$(bun --version)" = "1.3.14"
           bun install --frozen-lockfile --cwd packages/api-contracts --ignore-scripts
           bun install --frozen-lockfile --cwd apps/bff --ignore-scripts
           bun install --frozen-lockfile --cwd apps/web --ignore-scripts

--- a/apps/bff/src/index.test.ts
+++ b/apps/bff/src/index.test.ts
@@ -13,3 +13,36 @@ describe("BFF health endpoint", () => {
     });
   });
 });
+
+describe("BFF web-vitals endpoint", () => {
+  const metric = {
+    id: "journey-metric-1", name: "LCP", value: 123.4, rating: "good",
+    delta: 123.4, navigationType: "navigate", ts: 1,
+  };
+
+  it("accepts a bounded valid metric", async () => {
+    const response = await app.request("http://localhost/api/v1/telemetry/web-vitals", {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(metric),
+    });
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ accepted: true, id: metric.id });
+  });
+
+  it("rejects invalid content types and schemas", async () => {
+    const wrongType = await app.request("http://localhost/api/v1/telemetry/web-vitals", {
+      method: "POST", body: JSON.stringify(metric),
+    });
+    expect(wrongType.status).toBe(415);
+    const invalid = await app.request("http://localhost/api/v1/telemetry/web-vitals", {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ ...metric, name: "SECRET" }),
+    });
+    expect(invalid.status).toBe(400);
+  });
+
+  it("rejects oversized payloads", async () => {
+    const response = await app.request("http://localhost/api/v1/telemetry/web-vitals", {
+      method: "POST", headers: { "content-type": "application/json", "content-length": "4097" }, body: "{}",
+    });
+    expect(response.status).toBe(413);
+  });
+});

--- a/apps/bff/src/index.ts
+++ b/apps/bff/src/index.ts
@@ -5,6 +5,7 @@ import { dashboardRoutes } from './routes/dashboard';
 import { proxyRoutes } from './routes/proxy';
 import { gatewayRoutes } from './routes/gateway/proxy';
 import { trpcRoutes } from './trpc/hono';
+import { z } from 'zod';
 
 const app = new Hono();
 
@@ -12,6 +13,42 @@ app.use('*', logger());
 app.use('*', cors({ origin: ['http://localhost:4321'], credentials: true }));
 
 app.get('/healthz', (c) => c.json({ status: 'ok', service: 'argismonitor-bff' }));
+
+const WebVitalSchema = z.object({
+  id: z.string().min(1).max(128),
+  name: z.enum(['CLS', 'FCP', 'FID', 'INP', 'LCP', 'TTFB']),
+  value: z.number().finite().nonnegative(),
+  rating: z.enum(['good', 'needs-improvement', 'poor']),
+  delta: z.number().finite(),
+  navigationType: z.string().min(1).max(64),
+  ts: z.number().int().positive(),
+}).strict();
+
+app.post('/api/v1/telemetry/web-vitals', async (c) => {
+  if (!c.req.header('content-type')?.toLowerCase().startsWith('application/json')) {
+    return c.json({ error: 'content-type must be application/json' }, 415);
+  }
+
+  const declaredLength = Number(c.req.header('content-length') ?? 0);
+  if (declaredLength > 4096) return c.json({ error: 'payload too large' }, 413);
+
+  const raw = await c.req.text();
+  if (new TextEncoder().encode(raw).byteLength > 4096) {
+    return c.json({ error: 'payload too large' }, 413);
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return c.json({ error: 'invalid JSON' }, 400);
+  }
+  const parsed = WebVitalSchema.safeParse(json);
+  if (!parsed.success) return c.json({ error: 'invalid web vital' }, 400);
+
+  console.info('[bff:telemetry:web-vital]', JSON.stringify(parsed.data));
+  return c.json({ accepted: true, id: parsed.data.id }, 202);
+});
 
 app.route('/api/dashboard', dashboardRoutes);
 app.route('/api/v1', proxyRoutes);

--- a/apps/web/src/lib/observability/web-vitals.test.ts
+++ b/apps/web/src/lib/observability/web-vitals.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const reporters = vi.hoisted(() => ({
+  onLCP: vi.fn(), onFID: vi.fn(), onCLS: vi.fn(),
+  onINP: vi.fn(), onTTFB: vi.fn(), onFCP: vi.fn(),
+}));
+
+vi.mock('web-vitals', () => reporters);
+
+describe('web-vitals initialization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('window', {});
+    Object.values(reporters).forEach((reporter) => reporter.mockClear());
+  });
+
+  it('registers every reporter exactly once', async () => {
+    const { initWebVitals } = await import('./web-vitals');
+    initWebVitals();
+    initWebVitals();
+    Object.values(reporters).forEach((reporter) => expect(reporter).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/web/src/lib/observability/web-vitals.ts
+++ b/apps/web/src/lib/observability/web-vitals.ts
@@ -1,6 +1,7 @@
 import { onLCP, onFID, onCLS, onINP, onTTFB, onFCP, type Metric } from 'web-vitals';
 
 const ENDPOINT = '/api/v1/telemetry/web-vitals';
+let initialized = false;
 
 export function reportMetric(metric: Metric) {
   try {
@@ -14,7 +15,8 @@ export function reportMetric(metric: Metric) {
       ts: Date.now(),
     });
     if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
-      navigator.sendBeacon(ENDPOINT, body);
+      const queued = navigator.sendBeacon(ENDPOINT, new Blob([body], { type: 'application/json' }));
+      if (!queued) throw new Error('web-vitals beacon was not queued');
     } else if (typeof fetch !== 'undefined') {
       fetch(ENDPOINT, { method: 'POST', body, keepalive: true, headers: { 'content-type': 'application/json' } }).catch(() => {});
     }
@@ -24,7 +26,8 @@ export function reportMetric(metric: Metric) {
 }
 
 export function initWebVitals() {
-  if (typeof window === 'undefined') return;
+  if (typeof window === 'undefined' || initialized) return;
+  initialized = true;
   try {
     onLCP(reportMetric);
     onFID(reportMetric);
@@ -32,7 +35,8 @@ export function initWebVitals() {
     onINP(reportMetric);
     onTTFB(reportMetric);
     onFCP(reportMetric);
-  } catch {
-    // web-vitals not loaded
+  } catch (error) {
+    initialized = false;
+    console.error('[web-vitals] initialization failed', error);
   }
 }

--- a/apps/web/src/lib/server/bff.ts
+++ b/apps/web/src/lib/server/bff.ts
@@ -1,0 +1,14 @@
+import { env } from '$env/dynamic/private';
+
+const DEFAULT_BFF_ORIGIN = 'http://127.0.0.1:4322';
+
+export function bffUrl(pathname: string): URL {
+  const origin = new URL(env.BFF_ORIGIN ?? DEFAULT_BFF_ORIGIN);
+  if (!['http:', 'https:'].includes(origin.protocol)) {
+    throw new Error('BFF_ORIGIN must use http or https');
+  }
+  if (origin.username || origin.password) {
+    throw new Error('BFF_ORIGIN must not contain credentials');
+  }
+  return new URL(pathname, origin);
+}

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -37,7 +37,6 @@
     { href: '/dashboard/settings/general', key: 'nav.settings' },
   ];
 
-  onMount(() => { initWebVitals(); });
 </script>
 
 <CommandPalette />

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -5,7 +5,8 @@
 
   onMount(async () => {
     try {
-      const r = await fetch('http://localhost:4322/healthz');
+      const r = await fetch('/api/bff/healthz');
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
       const j = await r.json();
       bffHealthy = j.status === 'ok' ? 'healthy' : `unhealthy: ${JSON.stringify(j)}`;
     } catch (e) {

--- a/apps/web/src/routes/api/bff/healthz/+server.ts
+++ b/apps/web/src/routes/api/bff/healthz/+server.ts
@@ -1,0 +1,11 @@
+import { bffUrl } from '$lib/server/bff';
+import { error } from '@sveltejs/kit';
+
+export async function GET({ fetch }) {
+  const response = await fetch(bffUrl('/healthz'));
+  if (!response.ok) error(502, `BFF health check failed with HTTP ${response.status}`);
+  return new Response(response.body, {
+    status: response.status,
+    headers: { 'content-type': response.headers.get('content-type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/routes/api/v1/telemetry/web-vitals/+server.ts
+++ b/apps/web/src/routes/api/v1/telemetry/web-vitals/+server.ts
@@ -1,0 +1,24 @@
+import { bffUrl } from '$lib/server/bff';
+import { error } from '@sveltejs/kit';
+
+const MAX_BODY_BYTES = 4096;
+
+export async function POST({ request, fetch }) {
+  if (!request.headers.get('content-type')?.toLowerCase().startsWith('application/json')) {
+    error(415, 'content-type must be application/json');
+  }
+  const declaredLength = Number(request.headers.get('content-length') ?? 0);
+  if (declaredLength > MAX_BODY_BYTES) error(413, 'payload too large');
+  const body = await request.arrayBuffer();
+  if (body.byteLength > MAX_BODY_BYTES) error(413, 'payload too large');
+
+  const response = await fetch(bffUrl('/api/v1/telemetry/web-vitals'), {
+    method: 'POST',
+    body,
+    headers: { 'content-type': 'application/json' },
+  });
+  return new Response(response.body, {
+    status: response.status,
+    headers: { 'content-type': response.headers.get('content-type') ?? 'application/json' },
+  });
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: { environment: 'node' },
+});

--- a/tests/e2e/journey-evidence-smoke.spec.ts
+++ b/tests/e2e/journey-evidence-smoke.spec.ts
@@ -53,10 +53,11 @@ test("captures anonymous v4 home journey evidence", async ({ page, context }) =>
   });
 
   await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+  await page.emulateMedia({ reducedMotion: "reduce", colorScheme: "light" });
   await page.goto("/", { waitUntil: "networkidle" });
 
   const heading = page.locator("h1").first();
-  await expect(heading).toContainText("Welcome to OmniRoute v4");
+  await expect(heading).toContainText("Welcome to argismonitor v4");
   await expect(page.getByText("healthy", { exact: true })).toBeVisible();
 
   const telemetryStatus = await page.evaluate(async () => {

--- a/tests/e2e/journey-evidence-smoke.spec.ts
+++ b/tests/e2e/journey-evidence-smoke.spec.ts
@@ -14,6 +14,34 @@ test.use({
 
 test("captures anonymous v4 home journey evidence", async ({ page, context }) => {
   await mkdir(evidenceRoot, { recursive: true });
+  const runtimeErrors: string[] = [];
+  const failedResponses: string[] = [];
+  const telemetryIds: string[] = [];
+
+  page.on("console", (message) => {
+    if (message.type() === "error") runtimeErrors.push(`console: ${message.text()}`);
+  });
+  page.on("pageerror", (error) => runtimeErrors.push(`page: ${error.message}`));
+  page.on("requestfailed", (request) => {
+    const url = new URL(request.url());
+    if (["127.0.0.1", "localhost"].includes(url.hostname)) {
+      runtimeErrors.push(`request: ${request.method()} ${url.pathname} ${request.failure()?.errorText ?? "failed"}`);
+    }
+  });
+  page.on("response", (response) => {
+    const url = new URL(response.url());
+    if (["127.0.0.1", "localhost"].includes(url.hostname) && response.status() >= 400) {
+      failedResponses.push(`${response.status()} ${response.request().method()} ${url.pathname}`);
+    }
+    if (url.pathname === "/api/v1/telemetry/web-vitals") {
+      try {
+        const data = JSON.parse(response.request().postData() ?? "null") as { id?: string } | null;
+        if (data?.id) telemetryIds.push(data.id);
+      } catch (error) {
+        runtimeErrors.push(`telemetry payload: ${(error as Error).message}`);
+      }
+    }
+  });
 
   await context.route("**/*", async (route) => {
     const url = new URL(route.request().url());
@@ -29,6 +57,24 @@ test("captures anonymous v4 home journey evidence", async ({ page, context }) =>
 
   const heading = page.locator("h1").first();
   await expect(heading).toContainText("Welcome to OmniRoute v4");
+  await expect(page.getByText("healthy", { exact: true })).toBeVisible();
+
+  const telemetryStatus = await page.evaluate(async () => {
+    const response = await fetch("/api/v1/telemetry/web-vitals", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "phenotype-journey-metric", name: "LCP", value: 1, rating: "good",
+        delta: 1, navigationType: "navigate", ts: Date.now(),
+      }),
+    });
+    return response.status;
+  });
+  expect(telemetryStatus).toBe(202);
+  expect(runtimeErrors).toEqual([]);
+  expect(failedResponses).toEqual([]);
+  expect(telemetryIds).toContain("phenotype-journey-metric");
+  expect(new Set(telemetryIds).size).toBe(telemetryIds.length);
   await expect(page.locator("body")).not.toContainText(forbiddenText);
 
   await page.locator("input[type='password'], [data-sensitive='true']").evaluateAll((nodes) => {
@@ -73,6 +119,9 @@ test("captures anonymous v4 home journey evidence", async ({ page, context }) =>
   expect(accessibility.unnamedButtons).toBe(0);
   expect(accessibility.horizontalOverflow).toBe(false);
   expect(accessibility.reducedMotion).toBe(true);
+  expect(runtimeErrors).toEqual([]);
+  expect(failedResponses).toEqual([]);
+  expect(new Set(telemetryIds).size).toBe(telemetryIds.length);
 
   await writeFile(
     path.join(evidenceRoot, "accessibility-smoke.json"),


### PR DESCRIPTION
Closes #359

## Outcome

Repairs the browser-visible v4 phenotype service path before PR #348 is recaptured:

- routes BFF health and web-vitals through fixed same-origin SvelteKit endpoints backed by server-private `BFF_ORIGIN`;
- adds strict, bounded BFF web-vitals ingestion with explicit status codes;
- makes web-vitals initialization single/idempotent;
- runs the built BFF and adapter-node web artifacts with readiness and process-group cleanup;
- makes the journey fail on unhealthy BFF state, telemetry failure/duplication, first-party request/HTTP failures, console errors, and page errors.

## Local verification

- Bun 1.3.14 frozen installs: contracts 48, BFF 63, web 170 packages.
- BFF contract tests: 4/4 pass.
- BFF typecheck and production build: pass.
- Web idempotency unit: 1/1 pass using the narrow node-only Vitest config.
- Web adapter-node production build: pass.
- Direct built lifecycle: BFF health 200, web root 200, same-origin health proxy 200, same-origin telemetry 202; logs contained only successful health/telemetry traffic; exact service PIDs stopped and ports cleared.
- Full web `svelte-check` retains two pre-existing errors in unchanged `Button.svelte:37`; no changed-file diagnostic was reported.
- Local Playwright was not run because the existing partial root CLI resolves `bunx playwright` to `unknown command 'test'`. The hosted exact-head journey dispatch is the authoritative integration run.

No client-visible BFF environment or credential is introduced; proxy targets are fixed server routes, credential-bearing origins are rejected, and payloads require JSON with a 4 KiB maximum and a strict schema.

PR #348 remains blocked and must be rebased/recaptured after this prerequisite is independently reviewed and merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added web-vitals telemetry collection and forwarding through the web app.
  * Added validation for telemetry payload type, size, and format.
  * Added a proxied health-check endpoint for improved service connectivity.
  * Added configurable and validated BFF endpoint routing.

* **Bug Fixes**
  * Prevented duplicate web-vitals listener registration.
  * Improved telemetry delivery reliability and retry behavior.

* **Tests**
  * Expanded unit and end-to-end coverage for telemetry, health checks, service readiness, and runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->