### PR TITLE
test(journeys): substantiate accessibility evidence

### DIFF
--- a/.github/workflows/v4-journey-evidence.yml
+++ b/.github/workflows/v4-journey-evidence.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - ".github/workflows/v4-journey-evidence.yml"
       - "tests/e2e/journey-evidence-smoke.spec.ts"
+      - "tests/unit/journey-accessibility-report.test.ts"
+      - "scripts/docs/validate-journey-accessibility-report.mjs"
       - "apps/web/**"
       - "apps/bff/**"
       - "packages/api-contracts/**"
@@ -96,10 +98,6 @@ jobs:
           set -euo pipefail
           if grep -RIE --exclude='*.png' --exclude='*.zip' '(api[-_ ]?key|authorization|token|secret|cookie)[[:space:]]*[:=][[:space:]]*[^[:space:]]+|bearer[[:space:]]+[^[:space:]]+' journey-evidence; then
             echo "Potential secret material found in journey evidence" >&2
-            exit 1
-          fi
-          if grep -RIE --include='accessibility-smoke.json' '"html"[[:space:]]*:|<([a-z][a-z0-9]*)\b' journey-evidence; then
-            echo "Raw HTML found in accessibility evidence" >&2
             exit 1
           fi
 

--- a/.github/workflows/v4-journey-evidence.yml
+++ b/.github/workflows/v4-journey-evidence.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Capture deterministic evidence
         run: bunx playwright test tests/e2e/journey-evidence-smoke.spec.ts --project=chromium --workers=1 --retries=0
 
+      - name: Validate structured accessibility evidence
+        run: node scripts/docs/validate-journey-accessibility-report.mjs journey-evidence/anonymous-home-smoke/accessibility-smoke.json
+
       - name: Reject textual secret patterns
         if: always()
         shell: bash
@@ -93,6 +96,10 @@ jobs:
           set -euo pipefail
           if grep -RIE --exclude='*.png' --exclude='*.zip' '(api[-_ ]?key|authorization|token|secret|cookie)[[:space:]]*[:=][[:space:]]*[^[:space:]]+|bearer[[:space:]]+[^[:space:]]+' journey-evidence; then
             echo "Potential secret material found in journey evidence" >&2
+            exit 1
+          fi
+          if grep -RIE --include='accessibility-smoke.json' '"html"[[:space:]]*:|<([a-z][a-z0-9]*)\b' journey-evidence; then
+            echo "Raw HTML found in accessibility evidence" >&2
             exit 1
           fi
 

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -55,8 +55,8 @@
           </a>
         {/each}
       </nav>
-      <div class="ml-auto text-sm text-gray-500 flex items-center gap-3">
-        <select value={getLocale()} onchange={(e) => setLocale((e.target as HTMLSelectElement).value)} class="px-2 py-1 border border-gray-300 rounded text-sm">
+      <div class="ml-auto text-sm text-gray-600 flex items-center gap-3">
+        <select aria-label="Language" value={getLocale()} onchange={(e) => setLocale((e.target as HTMLSelectElement).value)} class="px-2 py-1 border border-gray-300 rounded text-sm">
           {#each supportedLanguages as lang}
             <option value={lang}>{lang}</option>
           {/each}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -25,8 +25,7 @@
   </div>
 
   <button
-    class="px-4 py-2 rounded text-white font-semibold"
-    style="background: var(--grad-brand)"
+    class="px-4 py-2 rounded bg-indigo-700 hover:bg-indigo-800 text-white font-semibold"
     onclick={() => count++}
   >
     Count: {count}

--- a/scripts/docs/validate-journey-accessibility-report.mjs
+++ b/scripts/docs/validate-journey-accessibility-report.mjs
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { readFile, realpath } from "node:fs/promises";
+import path from "node:path";
 import process from "node:process";
 
 export const declaredChecks = [
@@ -31,10 +32,28 @@ export function validateJourneyAccessibilityReport(report) {
   return errors;
 }
 
+const isContained = (root, target) => {
+  const relative = path.relative(root, target);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+};
+
+export async function resolveJourneyAccessibilityReportPath(candidate, evidenceRoot = path.resolve("journey-evidence", "anonymous-home-smoke"), workingDirectory = process.cwd()) {
+  if (typeof candidate !== "string" || candidate.length === 0 || path.isAbsolute(candidate)) {
+    throw new Error("report path must be a non-empty relative path");
+  }
+  const resolvedRoot = path.resolve(evidenceRoot);
+  const resolvedTarget = path.resolve(workingDirectory, candidate);
+  if (!isContained(resolvedRoot, resolvedTarget)) throw new Error("report path escapes the journey evidence root");
+  const [realRoot, realTarget] = await Promise.all([realpath(resolvedRoot), realpath(resolvedTarget)]);
+  if (!isContained(realRoot, realTarget)) throw new Error("report real path escapes the journey evidence root");
+  return realTarget;
+}
+
 if (process.argv[1]?.endsWith("validate-journey-accessibility-report.mjs")) {
   const file = process.argv[2];
   if (!file) throw new Error("usage: validate-journey-accessibility-report.mjs <report.json>");
-  const report = JSON.parse(await readFile(file, "utf8"));
+  const safeFile = await resolveJourneyAccessibilityReportPath(file);
+  const report = JSON.parse(await readFile(safeFile, "utf8"));
   const errors = validateJourneyAccessibilityReport(report);
   if (errors.length) { console.error(errors.join("\n")); process.exit(1); }
   console.log(`Validated ${declaredChecks.length} journey accessibility checks.`);

--- a/scripts/docs/validate-journey-accessibility-report.mjs
+++ b/scripts/docs/validate-journey-accessibility-report.mjs
@@ -8,12 +8,32 @@ export const declaredChecks = [
 ];
 
 const forbiddenMarkupKeys = new Set(["html", "innerhtml", "outerhtml", "markup", "rawhtml"]);
-const markupPattern = /<!doctype\s+html\b|<!--|-->|<\/?[a-z][a-z0-9:-]*(?:\s[^<>]*?)?\s*\/?>/i;
+
+const isAsciiLetter = (character) => {
+  const code = character?.toLowerCase().charCodeAt(0);
+  return code >= 97 && code <= 122;
+};
+
+export function containsRawMarkup(text) {
+  const lower = text.toLowerCase();
+  if (lower.includes("-->")) return true;
+  let cursor = 0;
+  while (cursor < text.length) {
+    const opening = text.indexOf("<", cursor);
+    if (opening === -1) return false;
+    if (lower.startsWith("<!--", opening) || lower.startsWith("<!doctype", opening)) return true;
+    let nameStart = opening + 1;
+    if (text[nameStart] === "/") nameStart += 1;
+    if (isAsciiLetter(text[nameStart]) && text.indexOf(">", nameStart + 1) !== -1) return true;
+    cursor = opening + 1;
+  }
+  return false;
+}
 
 export function findForbiddenMarkup(value, location = "report", seen = new Set()) {
   const findings = [];
   if (typeof value === "string") {
-    if (markupPattern.test(value)) findings.push(`${location} contains raw HTML content`);
+    if (containsRawMarkup(value)) findings.push(`${location} contains raw HTML content`);
     return findings;
   }
   if (value === null || typeof value !== "object" || seen.has(value)) return findings;
@@ -26,9 +46,7 @@ export function findForbiddenMarkup(value, location = "report", seen = new Set()
   return findings;
 }
 
-export function validateJourneyAccessibilityReport(report) {
-  const errors = [];
-  const assert = (condition, message) => { if (!condition) errors.push(message); };
+const validateTopLevelEvidence = (report, assert) => {
   assert(report?.schemaVersion === 2, "schemaVersion must be 2");
   assert(Number.isInteger(report?.viewport?.width) && report.viewport.width > 0 && Number.isInteger(report?.viewport?.height) && report.viewport.height > 0, "positive viewport dimensions must be recorded");
   for (const check of declaredChecks) assert(report?.checks?.[check]?.status === "passed", `${check} must be passed`);
@@ -37,6 +55,12 @@ export function validateJourneyAccessibilityReport(report) {
   assert(report?.checks?.["heading-order"]?.hasHeadingSkip === false, "heading order must not contain a skip");
   assert(report?.checks?.landmarks?.main === 1, "exactly one main landmark is required");
   assert(report?.checks?.landmarks?.navigation === 1, "exactly one navigation landmark is required");
+  assert(report?.checks?.contrast?.axeRule === "color-contrast", "contrast evidence must identify color-contrast");
+  assert(report?.checks?.["no-horizontal-overflow"]?.horizontalOverflow === false, "horizontal overflow must be false");
+  assert(report?.checks?.["reduced-motion"]?.reducedMotion === true, "reduced motion must be enabled");
+};
+
+const validateFocusEvidence = (report, assert) => {
   const targets = report?.checks?.["focus-visible"]?.targets;
   assert(report?.checks?.["focus-visible"]?.keyboardOnly === true, "focus traversal must be keyboard-only");
   assert(Array.isArray(targets) && targets.length > 0, "focus-visible targets are required");
@@ -45,31 +69,44 @@ export function validateJourneyAccessibilityReport(report) {
     assert(Array.isArray(target.changedProperties) && target.changedProperties.length > 0, "every focus target needs a style delta");
   }
   assert((targets ?? []).every((target, index) => target.index === index), "focus target inventory must be ordered and contiguous");
-  assert(Array.isArray(report?.checks?.["accessible-names"]?.axeRules) && report.checks["accessible-names"].axeRules.length > 0, "accessible-name axe rule evidence is required");
-  assert(report?.checks?.contrast?.axeRule === "color-contrast", "contrast evidence must identify color-contrast");
-  assert(report?.checks?.["no-horizontal-overflow"]?.horizontalOverflow === false, "horizontal overflow must be false");
-  assert(report?.checks?.["reduced-motion"]?.reducedMotion === true, "reduced motion must be enabled");
-  assert(Array.isArray(report?.axe?.violations) && report.axe.violations.length === 0, "axe violations must be empty");
-  assert(Array.isArray(report?.axe?.incomplete) && report.axe.incomplete.length === 0, "axe incomplete results must be empty");
-  const findings = [...(Array.isArray(report?.axe?.violations) ? report.axe.violations : []), ...(Array.isArray(report?.axe?.incomplete) ? report.axe.incomplete : [])];
-  for (const finding of findings) {
-    assert(typeof finding?.id === "string" && finding.id.length > 0, "every axe finding id must be a non-empty string");
-    assert(finding?.impact === null || ["minor", "moderate", "serious", "critical"].includes(finding?.impact), "every axe finding impact must be null or valid");
-    assert(typeof finding?.help === "string" && finding.help.length > 0, "every axe finding help must be non-empty");
-    assert(Number.isInteger(finding?.targetCount) && finding.targetCount > 0, "every axe finding targetCount must be a positive integer");
-  }
-  const ruleEntries = Array.isArray(report?.axe?.rules) ? report.axe.rules : [];
+};
+
+const validateAxeFinding = (finding, assert) => {
+  assert(typeof finding?.id === "string" && finding.id.length > 0, "every axe finding id must be a non-empty string");
+  assert(finding?.impact === null || ["minor", "moderate", "serious", "critical"].includes(finding?.impact), "every axe finding impact must be null or valid");
+  assert(typeof finding?.help === "string" && finding.help.length > 0, "every axe finding help must be non-empty");
+  assert(Number.isInteger(finding?.targetCount) && finding.targetCount > 0, "every axe finding targetCount must be a positive integer");
+};
+
+const validateAxeRule = (rule, assert) => {
+  assert(typeof rule?.id === "string" && rule.id.length > 0, "every axe rule id must be a non-empty string");
+  assert(["passed", "inapplicable"].includes(rule?.result), "every axe rule result must be passed or inapplicable");
+};
+
+const validateAxeEvidence = (report, assert) => {
+  const violations = Array.isArray(report?.axe?.violations) ? report.axe.violations : [];
+  const incomplete = Array.isArray(report?.axe?.incomplete) ? report.axe.incomplete : [];
+  assert(Array.isArray(report?.axe?.violations) && violations.length === 0, "axe violations must be empty");
+  assert(Array.isArray(report?.axe?.incomplete) && incomplete.length === 0, "axe incomplete results must be empty");
+  for (const finding of [...violations, ...incomplete]) validateAxeFinding(finding, assert);
+  const rules = Array.isArray(report?.axe?.rules) ? report.axe.rules : [];
+  const accessibleRules = Array.isArray(report?.checks?.["accessible-names"]?.axeRules) ? report.checks["accessible-names"].axeRules : [];
   assert(Array.isArray(report?.axe?.rules), "axe rule inventory must be an array");
-  const accessibleNameRules = Array.isArray(report?.checks?.["accessible-names"]?.axeRules) ? report.checks["accessible-names"].axeRules : [];
-  for (const rule of [...ruleEntries, ...accessibleNameRules]) {
-    assert(typeof rule?.id === "string" && rule.id.length > 0, "every axe rule id must be a non-empty string");
-    assert(["passed", "inapplicable"].includes(rule?.result), "every axe rule result must be passed or inapplicable");
-  }
-  const reviewedRules = ruleEntries.filter(({ id }) => typeof id === "string").map(({ id }) => id);
-  assert(new Set(reviewedRules).size === reviewedRules.length, "axe rule inventory must be unique");
-  assert(reviewedRules.every((id, index) => index === 0 || reviewedRules[index - 1].localeCompare(id) <= 0), "axe rule inventory must be sorted");
-  assert(accessibleNameRules.every(({ id }) => reviewedRules.includes(id)), "accessible-name rules must exist in the axe inventory");
-  for (const rule of ["color-contrast", "button-name", "image-alt", "landmark-one-main"]) assert(reviewedRules.includes(rule), `axe review ${rule} is required`);
+  assert(accessibleRules.length > 0, "accessible-name axe rule evidence is required");
+  for (const rule of [...rules, ...accessibleRules]) validateAxeRule(rule, assert);
+  const ids = rules.filter(({ id }) => typeof id === "string").map(({ id }) => id);
+  assert(new Set(ids).size === ids.length, "axe rule inventory must be unique");
+  assert(ids.every((id, index) => index === 0 || ids[index - 1].localeCompare(id) <= 0), "axe rule inventory must be sorted");
+  assert(accessibleRules.every(({ id }) => ids.includes(id)), "accessible-name rules must exist in the axe inventory");
+  for (const required of ["color-contrast", "button-name", "image-alt", "landmark-one-main"]) assert(ids.includes(required), `axe review ${required} is required`);
+};
+
+export function validateJourneyAccessibilityReport(report) {
+  const errors = [];
+  const assert = (condition, message) => { if (!condition) errors.push(message); };
+  validateTopLevelEvidence(report, assert);
+  validateFocusEvidence(report, assert);
+  validateAxeEvidence(report, assert);
   errors.push(...findForbiddenMarkup(report));
   return errors;
 }

--- a/scripts/docs/validate-journey-accessibility-report.mjs
+++ b/scripts/docs/validate-journey-accessibility-report.mjs
@@ -1,0 +1,41 @@
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+export const declaredChecks = [
+  "document-title", "heading-order", "landmarks", "focus-visible",
+  "accessible-names", "contrast", "no-horizontal-overflow", "reduced-motion",
+];
+
+export function validateJourneyAccessibilityReport(report) {
+  const errors = [];
+  const assert = (condition, message) => { if (!condition) errors.push(message); };
+  assert(report?.schemaVersion === 2, "schemaVersion must be 2");
+  assert(Number.isInteger(report?.viewport?.width) && Number.isInteger(report?.viewport?.height), "viewport must be recorded");
+  for (const check of declaredChecks) assert(report?.checks?.[check]?.status === "passed", `${check} must be passed`);
+  assert(report?.checks?.landmarks?.main === 1, "exactly one main landmark is required");
+  assert(report?.checks?.landmarks?.navigation === 1, "exactly one navigation landmark is required");
+  const targets = report?.checks?.["focus-visible"]?.targets;
+  assert(Array.isArray(targets) && targets.length > 0, "focus-visible targets are required");
+  for (const target of targets ?? []) {
+    assert(target.focusVisible === true, "every focus target must match :focus-visible");
+    assert(Array.isArray(target.changedProperties) && target.changedProperties.length > 0, "every focus target needs a style delta");
+  }
+  assert((targets ?? []).every((target, index) => target.index === index), "focus target inventory must be ordered and contiguous");
+  assert(Array.isArray(report?.axe?.violations) && report.axe.violations.length === 0, "axe violations must be empty");
+  assert(Array.isArray(report?.axe?.incomplete) && report.axe.incomplete.length === 0, "axe incomplete results must be empty");
+  const reviewedRules = report?.axe?.rules?.map(({ id }) => id) ?? [];
+  assert(new Set(reviewedRules).size === reviewedRules.length, "axe rule inventory must be unique");
+  assert(reviewedRules.every((id, index) => index === 0 || reviewedRules[index - 1].localeCompare(id) <= 0), "axe rule inventory must be sorted");
+  for (const rule of ["color-contrast", "button-name", "image-alt", "landmark-one-main"]) assert(reviewedRules.includes(rule), `axe review ${rule} is required`);
+  assert(!JSON.stringify(report).includes('"html"'), "raw HTML fields are forbidden");
+  return errors;
+}
+
+if (process.argv[1]?.endsWith("validate-journey-accessibility-report.mjs")) {
+  const file = process.argv[2];
+  if (!file) throw new Error("usage: validate-journey-accessibility-report.mjs <report.json>");
+  const report = JSON.parse(await readFile(file, "utf8"));
+  const errors = validateJourneyAccessibilityReport(report);
+  if (errors.length) { console.error(errors.join("\n")); process.exit(1); }
+  console.log(`Validated ${declaredChecks.length} journey accessibility checks.`);
+}

--- a/scripts/docs/validate-journey-accessibility-report.mjs
+++ b/scripts/docs/validate-journey-accessibility-report.mjs
@@ -7,28 +7,70 @@ export const declaredChecks = [
   "accessible-names", "contrast", "no-horizontal-overflow", "reduced-motion",
 ];
 
+const forbiddenMarkupKeys = new Set(["html", "innerhtml", "outerhtml", "markup", "rawhtml"]);
+const markupPattern = /<!doctype\s+html\b|<!--|-->|<\/?[a-z][a-z0-9:-]*(?:\s[^<>]*?)?\s*\/?>/i;
+
+export function findForbiddenMarkup(value, location = "report", seen = new Set()) {
+  const findings = [];
+  if (typeof value === "string") {
+    if (markupPattern.test(value)) findings.push(`${location} contains raw HTML content`);
+    return findings;
+  }
+  if (value === null || typeof value !== "object" || seen.has(value)) return findings;
+  seen.add(value);
+  for (const [key, child] of Object.entries(value)) {
+    const childLocation = `${location}.${key}`;
+    if (forbiddenMarkupKeys.has(key.toLowerCase())) findings.push(`${childLocation} is a forbidden raw HTML field`);
+    findings.push(...findForbiddenMarkup(child, childLocation, seen));
+  }
+  return findings;
+}
+
 export function validateJourneyAccessibilityReport(report) {
   const errors = [];
   const assert = (condition, message) => { if (!condition) errors.push(message); };
   assert(report?.schemaVersion === 2, "schemaVersion must be 2");
-  assert(Number.isInteger(report?.viewport?.width) && Number.isInteger(report?.viewport?.height), "viewport must be recorded");
+  assert(Number.isInteger(report?.viewport?.width) && report.viewport.width > 0 && Number.isInteger(report?.viewport?.height) && report.viewport.height > 0, "positive viewport dimensions must be recorded");
   for (const check of declaredChecks) assert(report?.checks?.[check]?.status === "passed", `${check} must be passed`);
+  assert(typeof report?.checks?.["document-title"]?.title === "string" && report.checks["document-title"].title.trim().length > 0, "document title evidence must be non-empty");
+  assert(Number.isInteger(report?.checks?.["heading-order"]?.headingCount) && report.checks["heading-order"].headingCount > 0, "heading count must be a positive integer");
+  assert(report?.checks?.["heading-order"]?.hasHeadingSkip === false, "heading order must not contain a skip");
   assert(report?.checks?.landmarks?.main === 1, "exactly one main landmark is required");
   assert(report?.checks?.landmarks?.navigation === 1, "exactly one navigation landmark is required");
   const targets = report?.checks?.["focus-visible"]?.targets;
+  assert(report?.checks?.["focus-visible"]?.keyboardOnly === true, "focus traversal must be keyboard-only");
   assert(Array.isArray(targets) && targets.length > 0, "focus-visible targets are required");
   for (const target of targets ?? []) {
     assert(target.focusVisible === true, "every focus target must match :focus-visible");
     assert(Array.isArray(target.changedProperties) && target.changedProperties.length > 0, "every focus target needs a style delta");
   }
   assert((targets ?? []).every((target, index) => target.index === index), "focus target inventory must be ordered and contiguous");
+  assert(Array.isArray(report?.checks?.["accessible-names"]?.axeRules) && report.checks["accessible-names"].axeRules.length > 0, "accessible-name axe rule evidence is required");
+  assert(report?.checks?.contrast?.axeRule === "color-contrast", "contrast evidence must identify color-contrast");
+  assert(report?.checks?.["no-horizontal-overflow"]?.horizontalOverflow === false, "horizontal overflow must be false");
+  assert(report?.checks?.["reduced-motion"]?.reducedMotion === true, "reduced motion must be enabled");
   assert(Array.isArray(report?.axe?.violations) && report.axe.violations.length === 0, "axe violations must be empty");
   assert(Array.isArray(report?.axe?.incomplete) && report.axe.incomplete.length === 0, "axe incomplete results must be empty");
-  const reviewedRules = report?.axe?.rules?.map(({ id }) => id) ?? [];
+  const findings = [...(Array.isArray(report?.axe?.violations) ? report.axe.violations : []), ...(Array.isArray(report?.axe?.incomplete) ? report.axe.incomplete : [])];
+  for (const finding of findings) {
+    assert(typeof finding?.id === "string" && finding.id.length > 0, "every axe finding id must be a non-empty string");
+    assert(finding?.impact === null || ["minor", "moderate", "serious", "critical"].includes(finding?.impact), "every axe finding impact must be null or valid");
+    assert(typeof finding?.help === "string" && finding.help.length > 0, "every axe finding help must be non-empty");
+    assert(Number.isInteger(finding?.targetCount) && finding.targetCount > 0, "every axe finding targetCount must be a positive integer");
+  }
+  const ruleEntries = Array.isArray(report?.axe?.rules) ? report.axe.rules : [];
+  assert(Array.isArray(report?.axe?.rules), "axe rule inventory must be an array");
+  const accessibleNameRules = Array.isArray(report?.checks?.["accessible-names"]?.axeRules) ? report.checks["accessible-names"].axeRules : [];
+  for (const rule of [...ruleEntries, ...accessibleNameRules]) {
+    assert(typeof rule?.id === "string" && rule.id.length > 0, "every axe rule id must be a non-empty string");
+    assert(["passed", "inapplicable"].includes(rule?.result), "every axe rule result must be passed or inapplicable");
+  }
+  const reviewedRules = ruleEntries.filter(({ id }) => typeof id === "string").map(({ id }) => id);
   assert(new Set(reviewedRules).size === reviewedRules.length, "axe rule inventory must be unique");
   assert(reviewedRules.every((id, index) => index === 0 || reviewedRules[index - 1].localeCompare(id) <= 0), "axe rule inventory must be sorted");
+  assert(accessibleNameRules.every(({ id }) => reviewedRules.includes(id)), "accessible-name rules must exist in the axe inventory");
   for (const rule of ["color-contrast", "button-name", "image-alt", "landmark-one-main"]) assert(reviewedRules.includes(rule), `axe review ${rule} is required`);
-  assert(!JSON.stringify(report).includes('"html"'), "raw HTML fields are forbidden");
+  errors.push(...findForbiddenMarkup(report));
   return errors;
 }
 

--- a/scripts/docs/validate-journey-accessibility-report.mjs
+++ b/scripts/docs/validate-journey-accessibility-report.mjs
@@ -10,7 +10,7 @@ export const declaredChecks = [
 const forbiddenMarkupKeys = new Set(["html", "innerhtml", "outerhtml", "markup", "rawhtml"]);
 
 const isAsciiLetter = (character) => {
-  const code = character?.toLowerCase().charCodeAt(0);
+  const code = character?.toLowerCase().codePointAt(0);
   return code >= 97 && code <= 122;
 };
 
@@ -24,7 +24,7 @@ export function containsRawMarkup(text) {
     if (lower.startsWith("<!--", opening) || lower.startsWith("<!doctype", opening)) return true;
     let nameStart = opening + 1;
     if (text[nameStart] === "/") nameStart += 1;
-    if (isAsciiLetter(text[nameStart]) && text.indexOf(">", nameStart + 1) !== -1) return true;
+    if (isAsciiLetter(text[nameStart]) && text.includes(">", nameStart + 1)) return true;
     cursor = opening + 1;
   }
   return false;

--- a/tests/e2e/journey-evidence-smoke.spec.ts
+++ b/tests/e2e/journey-evidence-smoke.spec.ts
@@ -81,17 +81,23 @@ test("captures anonymous v4 home journey evidence", async ({ page, context }) =>
 
   const axeTags = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22a", "wcag22aa"];
   const axeResult = await new AxeBuilder({ page }).withTags(axeTags).analyze();
+  const landmarkRules = ["landmark-one-main", "region"];
+  const landmarkResult = await new AxeBuilder({ page }).withRules(landmarkRules).analyze();
   const summarizeAxe = (items: typeof axeResult.violations) => items
     .map(({ id, impact, help, nodes }) => ({ id, impact, help, targetCount: nodes.length }))
     .sort((left, right) => left.id.localeCompare(right.id));
   const axe = {
     engine: { name: axeResult.testEngine.name, version: axeResult.testEngine.version },
     tags: axeTags,
-    violations: summarizeAxe(axeResult.violations), incomplete: summarizeAxe(axeResult.incomplete),
-    rules: [
+    explicitRules: landmarkRules,
+    violations: summarizeAxe([...axeResult.violations, ...landmarkResult.violations]),
+    incomplete: summarizeAxe([...axeResult.incomplete, ...landmarkResult.incomplete]),
+    rules: Array.from(new Map([
       ...axeResult.passes.map(({ id }) => ({ id, result: "passed" })),
       ...axeResult.inapplicable.map(({ id }) => ({ id, result: "inapplicable" })),
-    ].sort((left, right) => left.id.localeCompare(right.id)),
+      ...landmarkResult.passes.map(({ id }) => ({ id, result: "passed" })),
+      ...landmarkResult.inapplicable.map(({ id }) => ({ id, result: "inapplicable" })),
+    ].map((item) => [item.id, item])).values()).sort((left, right) => left.id.localeCompare(right.id)),
   };
   const axeHasFinding = (ruleIds: string[]) => [...axe.violations, ...axe.incomplete].some(({ id }) => ruleIds.includes(id));
   const checks: Record<string, unknown> = {

--- a/tests/e2e/journey-evidence-smoke.spec.ts
+++ b/tests/e2e/journey-evidence-smoke.spec.ts
@@ -92,8 +92,10 @@ test("captures anonymous v4 home journey evidence", async ({ page, context }) =>
       ...axeResult.inapplicable.map(({ id }) => ({ id, result: "inapplicable" })),
     ].sort((left, right) => left.id.localeCompare(right.id)),
   };
-  expect(axe.violations, "axe violations require remediation before capture").toEqual([]);
-  expect(axe.incomplete, "axe incomplete results require explicit review before capture").toEqual([]);
+  expect(
+    { violations: axe.violations, incomplete: axe.incomplete },
+    "axe violations and incomplete results require remediation or explicit review before capture",
+  ).toEqual({ violations: [], incomplete: [] });
   for (const rule of ["color-contrast", "button-name", "image-alt", "landmark-one-main"]) expect(axe.rules.map(({ id }) => id)).toContain(rule);
 
   const focusSetup = await page.evaluate((properties) => {

--- a/tests/e2e/journey-evidence-smoke.spec.ts
+++ b/tests/e2e/journey-evidence-smoke.spec.ts
@@ -1,138 +1,154 @@
+import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 const evidenceRoot = path.resolve("journey-evidence/anonymous-home-smoke");
 const forbiddenText = /(api[-_ ]?key|authorization|token|secret|cookie)\s*[:=]\s*\S+|bearer\s+\S+/i;
+const focusStyleProperties = [
+  "outlineStyle", "outlineWidth", "outlineColor", "outlineOffset", "boxShadow",
+  "borderTopColor", "borderRightColor", "borderBottomColor", "borderLeftColor", "backgroundColor", "color",
+] as const;
 
-test.use({
-  viewport: { width: 1280, height: 800 },
-  deviceScaleFactor: 1,
-  reducedMotion: "reduce",
-  colorScheme: "light",
-});
+test.use({ viewport: { width: 1280, height: 800 }, deviceScaleFactor: 1, reducedMotion: "reduce", colorScheme: "light" });
 
 test("captures anonymous v4 home journey evidence", async ({ page, context }) => {
   await mkdir(evidenceRoot, { recursive: true });
   const runtimeErrors: string[] = [];
   const failedResponses: string[] = [];
   const telemetryIds: string[] = [];
-
-  page.on("console", (message) => {
-    if (message.type() === "error") runtimeErrors.push(`console: ${message.text()}`);
-  });
+  page.on("console", (message) => { if (message.type() === "error") runtimeErrors.push(`console: ${message.text()}`); });
   page.on("pageerror", (error) => runtimeErrors.push(`page: ${error.message}`));
   page.on("requestfailed", (request) => {
     const url = new URL(request.url());
-    if (["127.0.0.1", "localhost"].includes(url.hostname)) {
-      runtimeErrors.push(`request: ${request.method()} ${url.pathname} ${request.failure()?.errorText ?? "failed"}`);
-    }
+    if (["127.0.0.1", "localhost"].includes(url.hostname)) runtimeErrors.push(`request: ${request.method()} ${url.pathname} ${request.failure()?.errorText ?? "failed"}`);
   });
   page.on("response", (response) => {
     const url = new URL(response.url());
-    if (["127.0.0.1", "localhost"].includes(url.hostname) && response.status() >= 400) {
-      failedResponses.push(`${response.status()} ${response.request().method()} ${url.pathname}`);
-    }
+    if (["127.0.0.1", "localhost"].includes(url.hostname) && response.status() >= 400) failedResponses.push(`${response.status()} ${response.request().method()} ${url.pathname}`);
     if (url.pathname === "/api/v1/telemetry/web-vitals") {
       try {
         const data = JSON.parse(response.request().postData() ?? "null") as { id?: string } | null;
         if (data?.id) telemetryIds.push(data.id);
-      } catch (error) {
-        runtimeErrors.push(`telemetry payload: ${(error as Error).message}`);
-      }
+      } catch (error) { runtimeErrors.push(`telemetry payload: ${(error as Error).message}`); }
     }
   });
-
   await context.route("**/*", async (route) => {
     const url = new URL(route.request().url());
-    if (["127.0.0.1", "localhost"].includes(url.hostname)) {
-      await route.continue();
-      return;
-    }
-    await route.abort("blockedbyclient");
+    if (["127.0.0.1", "localhost"].includes(url.hostname)) await route.continue();
+    else await route.abort("blockedbyclient");
   });
 
   await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
   await page.emulateMedia({ reducedMotion: "reduce", colorScheme: "light" });
   await page.goto("/", { waitUntil: "networkidle" });
-
-  const heading = page.locator("h1").first();
-  await expect(heading).toContainText("Welcome to argismonitor v4");
+  await expect(page.locator("h1").first()).toContainText("Welcome to argismonitor v4");
   await expect(page.getByText("healthy", { exact: true })).toBeVisible();
-
-  const telemetryStatus = await page.evaluate(async () => {
-    const response = await fetch("/api/v1/telemetry/web-vitals", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        id: "phenotype-journey-metric", name: "LCP", value: 1, rating: "good",
-        delta: 1, navigationType: "navigate", ts: Date.now(),
-      }),
-    });
-    return response.status;
-  });
+  const telemetryStatus = await page.evaluate(async () => (await fetch("/api/v1/telemetry/web-vitals", {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ id: "phenotype-journey-metric", name: "LCP", value: 1, rating: "good", delta: 1, navigationType: "navigate", ts: Date.now() }),
+  })).status);
   expect(telemetryStatus).toBe(202);
   expect(runtimeErrors).toEqual([]);
   expect(failedResponses).toEqual([]);
   expect(telemetryIds).toContain("phenotype-journey-metric");
   expect(new Set(telemetryIds).size).toBe(telemetryIds.length);
   await expect(page.locator("body")).not.toContainText(forbiddenText);
-
   await page.locator("input[type='password'], [data-sensitive='true']").evaluateAll((nodes) => {
-    for (const node of nodes) {
-      node.setAttribute("value", "[REDACTED]");
-      node.textContent = "[REDACTED]";
-    }
+    for (const node of nodes) { node.setAttribute("value", "[REDACTED]"); node.textContent = "[REDACTED]"; }
   });
 
-  const accessibility = await page.evaluate(() => {
+  const structure = await page.evaluate(() => {
     const headings = Array.from(document.querySelectorAll("h1,h2,h3,h4,h5,h6")).map((element) => ({
-      level: Number(element.tagName.slice(1)),
-      text: element.textContent?.trim() ?? "",
+      level: Number(element.tagName.slice(1)), text: element.textContent?.trim() ?? "",
     }));
-    const hasHeadingSkip = headings.some((heading, index) =>
-      index > 0 && heading.level > headings[index - 1].level + 1
-    );
     return {
-      title: document.title,
-      language: document.documentElement.lang || null,
-      headingCount: headings.length,
-      hasHeadingSkip,
-      landmarks: {
-        main: document.querySelectorAll("main").length,
-        navigation: document.querySelectorAll("nav").length,
-      },
-      imagesMissingAlt: document.querySelectorAll("img:not([alt])").length,
-      unnamedButtons: Array.from(document.querySelectorAll("button")).filter(
-        (button) => !(button.getAttribute("aria-label") || button.textContent?.trim())
-      ).length,
+      title: document.title, language: document.documentElement.lang || null, headingCount: headings.length,
+      hasHeadingSkip: headings.some((heading, index) => index > 0 && heading.level > headings[index - 1].level + 1),
+      landmarks: { main: document.querySelectorAll("main").length, navigation: document.querySelectorAll("nav").length },
       horizontalOverflow: document.documentElement.scrollWidth > window.innerWidth + 1,
       reducedMotion: window.matchMedia("(prefers-reduced-motion: reduce)").matches,
       viewport: { width: window.innerWidth, height: window.innerHeight },
     };
   });
+  expect(structure.title).not.toBe("");
+  expect(structure.headingCount).toBeGreaterThan(0);
+  expect(structure.hasHeadingSkip).toBe(false);
+  expect(structure.landmarks).toEqual({ main: 1, navigation: 1 });
+  expect(structure.horizontalOverflow).toBe(false);
+  expect(structure.reducedMotion).toBe(true);
 
-  expect(accessibility.title).not.toBe("");
-  expect(accessibility.headingCount).toBeGreaterThan(0);
-  expect(accessibility.hasHeadingSkip).toBe(false);
-  expect(accessibility.landmarks.main).toBeGreaterThan(0);
-  expect(accessibility.imagesMissingAlt).toBe(0);
-  expect(accessibility.unnamedButtons).toBe(0);
-  expect(accessibility.horizontalOverflow).toBe(false);
-  expect(accessibility.reducedMotion).toBe(true);
+  const axeTags = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22a", "wcag22aa"];
+  const axeResult = await new AxeBuilder({ page }).withTags(axeTags).analyze();
+  const summarizeAxe = (items: typeof axeResult.violations) => items
+    .map(({ id, impact, help, nodes }) => ({ id, impact, help, targetCount: nodes.length }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const axe = {
+    engine: { name: axeResult.testEngine.name, version: axeResult.testEngine.version },
+    tags: axeTags,
+    violations: summarizeAxe(axeResult.violations), incomplete: summarizeAxe(axeResult.incomplete),
+    rules: [
+      ...axeResult.passes.map(({ id }) => ({ id, result: "passed" })),
+      ...axeResult.inapplicable.map(({ id }) => ({ id, result: "inapplicable" })),
+    ].sort((left, right) => left.id.localeCompare(right.id)),
+  };
+  expect(axe.violations, "axe violations require remediation before capture").toEqual([]);
+  expect(axe.incomplete, "axe incomplete results require explicit review before capture").toEqual([]);
+  for (const rule of ["color-contrast", "button-name", "image-alt", "landmark-one-main"]) expect(axe.rules.map(({ id }) => id)).toContain(rule);
+
+  const focusSetup = await page.evaluate((properties) => {
+    const candidates = Array.from(document.querySelectorAll<HTMLElement>("*")).filter((element) => {
+      const style = getComputedStyle(element);
+      return element.tabIndex >= 0 && !element.matches(":disabled") && !element.closest("[inert],[aria-hidden='true']")
+        && style.display !== "none" && style.visibility !== "hidden" && element.getClientRects().length > 0;
+    }).sort((left, right) => {
+      const leftOrder = left.tabIndex > 0 ? left.tabIndex : Number.MAX_SAFE_INTEGER;
+      const rightOrder = right.tabIndex > 0 ? right.tabIndex : Number.MAX_SAFE_INTEGER;
+      return leftOrder - rightOrder;
+    });
+    const styleOf = (element: HTMLElement) => Object.fromEntries(properties.map((property) => [property, getComputedStyle(element)[property]]));
+    return candidates.map((element, index) => {
+      element.dataset.journeyFocusIndex = String(index);
+      return { index, element: element.tagName.toLowerCase(), role: element.getAttribute("role"), type: element.getAttribute("type"), before: styleOf(element) };
+    });
+  }, focusStyleProperties);
+  expect(focusSetup.length).toBeGreaterThan(0);
+  const focusTraversal = [];
+  const seenFocusIndexes = new Set<number>();
+  for (let index = 0; index < focusSetup.length; index += 1) {
+    await page.keyboard.press("Tab");
+    const focused = await page.evaluate((properties) => {
+      const element = document.activeElement as HTMLElement | null;
+      if (!element) return null;
+      return { index: Number(element.dataset.journeyFocusIndex), focusVisible: element.matches(":focus-visible"), after: Object.fromEntries(properties.map((property) => [property, getComputedStyle(element)[property]])) };
+    }, focusStyleProperties);
+    expect(focused).not.toBeNull();
+    const baseline = focusSetup.find((item) => item.index === focused?.index);
+    expect(baseline).toBeDefined();
+    expect(seenFocusIndexes.has(focused?.index ?? -1), "Tab traversal must not cycle before inventory completion").toBe(false);
+    seenFocusIndexes.add(focused?.index ?? -1);
+    const changedProperties = focusStyleProperties.filter((property) => baseline?.before[property] !== focused?.after[property]);
+    expect(focused?.focusVisible).toBe(true);
+    expect(changedProperties.length).toBeGreaterThan(0);
+    focusTraversal.push({ ...baseline, after: focused?.after, focusVisible: focused?.focusVisible, changedProperties });
+  }
+  expect(focusTraversal.map(({ index }) => index)).toEqual(focusSetup.map(({ index }) => index));
+
+  const checks = {
+    "document-title": { status: "passed", title: structure.title },
+    "heading-order": { status: "passed", headingCount: structure.headingCount, hasHeadingSkip: structure.hasHeadingSkip },
+    landmarks: { status: "passed", ...structure.landmarks },
+    "focus-visible": { status: "passed", keyboardOnly: true, targets: focusTraversal },
+    "accessible-names": { status: "passed", axeRules: axe.rules.filter(({ id }) => id.includes("name") || id === "image-alt") },
+    contrast: { status: "passed", axeRule: "color-contrast" },
+    "no-horizontal-overflow": { status: "passed", horizontalOverflow: structure.horizontalOverflow },
+    "reduced-motion": { status: "passed", reducedMotion: structure.reducedMotion },
+  };
+  const accessibility = { schemaVersion: 2, viewport: structure.viewport, checks, axe };
   expect(runtimeErrors).toEqual([]);
   expect(failedResponses).toEqual([]);
   expect(new Set(telemetryIds).size).toBe(telemetryIds.length);
-
-  await writeFile(
-    path.join(evidenceRoot, "accessibility-smoke.json"),
-    JSON.stringify(accessibility, null, 2) + "\n",
-    { mode: 0o600 }
-  );
-  await page.screenshot({
-    path: path.join(evidenceRoot, "home.png"),
-    fullPage: false,
-    animations: "disabled",
-  });
+  await writeFile(path.join(evidenceRoot, "accessibility-smoke.json"), `${JSON.stringify(accessibility, null, 2)}\n`, { mode: 0o600 });
+  await page.screenshot({ path: path.join(evidenceRoot, "home.png"), fullPage: false, animations: "disabled" });
   await context.tracing.stop({ path: path.join(evidenceRoot, "trace.zip") });
 });

--- a/tests/e2e/journey-evidence-smoke.spec.ts
+++ b/tests/e2e/journey-evidence-smoke.spec.ts
@@ -40,6 +40,7 @@ test("captures anonymous v4 home journey evidence", async ({ page, context }) =>
   });
 
   await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+  try {
   await page.emulateMedia({ reducedMotion: "reduce", colorScheme: "light" });
   await page.goto("/", { waitUntil: "networkidle" });
   await expect(page.locator("h1").first()).toContainText("Welcome to argismonitor v4");
@@ -92,6 +93,26 @@ test("captures anonymous v4 home journey evidence", async ({ page, context }) =>
       ...axeResult.inapplicable.map(({ id }) => ({ id, result: "inapplicable" })),
     ].sort((left, right) => left.id.localeCompare(right.id)),
   };
+  const axeHasFinding = (ruleIds: string[]) => [...axe.violations, ...axe.incomplete].some(({ id }) => ruleIds.includes(id));
+  const checks: Record<string, unknown> = {
+    "document-title": { status: "passed", title: structure.title },
+    "heading-order": { status: "passed", headingCount: structure.headingCount, hasHeadingSkip: structure.hasHeadingSkip },
+    landmarks: { status: "passed", ...structure.landmarks },
+    "focus-visible": { status: "pending", keyboardOnly: true, targets: [] },
+    "accessible-names": {
+      status: axeHasFinding(["aria-command-name", "aria-input-field-name", "aria-toggle-field-name", "button-name", "image-alt", "input-button-name", "link-name", "select-name"]) ? "failed" : "passed",
+      axeRules: axe.rules.filter(({ id }) => id.includes("name") || id === "image-alt"),
+    },
+    contrast: { status: axeHasFinding(["color-contrast", "color-contrast-enhanced"]) ? "failed" : "passed", axeRule: "color-contrast" },
+    "no-horizontal-overflow": { status: "passed", horizontalOverflow: structure.horizontalOverflow },
+    "reduced-motion": { status: "passed", reducedMotion: structure.reducedMotion },
+  };
+  const persistAccessibility = () => writeFile(
+    path.join(evidenceRoot, "accessibility-smoke.json"),
+    `${JSON.stringify({ schemaVersion: 2, viewport: structure.viewport, checks, axe }, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+  await persistAccessibility();
   expect(
     { violations: axe.violations, incomplete: axe.incomplete },
     "axe violations and incomplete results require remediation or explicit review before capture",
@@ -133,24 +154,18 @@ test("captures anonymous v4 home journey evidence", async ({ page, context }) =>
     expect(focused?.focusVisible).toBe(true);
     expect(changedProperties.length).toBeGreaterThan(0);
     focusTraversal.push({ ...baseline, after: focused?.after, focusVisible: focused?.focusVisible, changedProperties });
+    checks["focus-visible"] = { status: "pending", keyboardOnly: true, targets: focusTraversal };
+    await persistAccessibility();
   }
   expect(focusTraversal.map(({ index }) => index)).toEqual(focusSetup.map(({ index }) => index));
 
-  const checks = {
-    "document-title": { status: "passed", title: structure.title },
-    "heading-order": { status: "passed", headingCount: structure.headingCount, hasHeadingSkip: structure.hasHeadingSkip },
-    landmarks: { status: "passed", ...structure.landmarks },
-    "focus-visible": { status: "passed", keyboardOnly: true, targets: focusTraversal },
-    "accessible-names": { status: "passed", axeRules: axe.rules.filter(({ id }) => id.includes("name") || id === "image-alt") },
-    contrast: { status: "passed", axeRule: "color-contrast" },
-    "no-horizontal-overflow": { status: "passed", horizontalOverflow: structure.horizontalOverflow },
-    "reduced-motion": { status: "passed", reducedMotion: structure.reducedMotion },
-  };
-  const accessibility = { schemaVersion: 2, viewport: structure.viewport, checks, axe };
+  checks["focus-visible"] = { status: "passed", keyboardOnly: true, targets: focusTraversal };
+  await persistAccessibility();
   expect(runtimeErrors).toEqual([]);
   expect(failedResponses).toEqual([]);
   expect(new Set(telemetryIds).size).toBe(telemetryIds.length);
-  await writeFile(path.join(evidenceRoot, "accessibility-smoke.json"), `${JSON.stringify(accessibility, null, 2)}\n`, { mode: 0o600 });
   await page.screenshot({ path: path.join(evidenceRoot, "home.png"), fullPage: false, animations: "disabled" });
+  } finally {
   await context.tracing.stop({ path: path.join(evidenceRoot, "trace.zip") });
+  }
 });

--- a/tests/unit/journey-accessibility-report.test.ts
+++ b/tests/unit/journey-accessibility-report.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { declaredChecks, validateJourneyAccessibilityReport } from "../../scripts/docs/validate-journey-accessibility-report.mjs";
+
+const valid = () => ({
+  schemaVersion: 2,
+  viewport: { width: 1280, height: 800 },
+  checks: Object.fromEntries(declaredChecks.map((check) => [check, { status: "passed" }])) as Record<string, unknown>,
+  axe: { violations: [] as unknown[], incomplete: [] as unknown[], rules: ["button-name", "color-contrast", "image-alt", "landmark-one-main"].map((id) => ({ id, result: "passed" })) },
+});
+
+test("accepts complete journey accessibility evidence", () => {
+  const report = valid();
+  report.checks.landmarks = { status: "passed", main: 1, navigation: 1 };
+  report.checks["focus-visible"] = { status: "passed", targets: [{ index: 0, focusVisible: true, changedProperties: ["outlineWidth"] }] };
+  assert.deepEqual(validateJourneyAccessibilityReport(report), []);
+});
+
+test("rejects missing checks, axe review gaps, focus gaps, and raw HTML", () => {
+  const report = valid() as ReturnType<typeof valid> & { html?: string };
+  report.checks.landmarks = { status: "passed", main: 1, navigation: 1 };
+  report.checks["focus-visible"] = { status: "passed", targets: [] };
+  report.axe.incomplete = [{ id: "color-contrast" }];
+  report.html = "<main>unsafe</main>";
+  delete report.checks.contrast;
+  const errors = validateJourneyAccessibilityReport(report).join("\n");
+  assert.match(errors, /contrast must be passed/);
+  assert.match(errors, /focus-visible targets are required/);
+  assert.match(errors, /axe incomplete results must be empty/);
+  assert.match(errors, /raw HTML fields are forbidden/);
+});

--- a/tests/unit/journey-accessibility-report.test.ts
+++ b/tests/unit/journey-accessibility-report.test.ts
@@ -1,27 +1,32 @@
-import { expect } from "@playwright/test";
+import { expect, test } from "bun:test";
 import { mkdtemp, mkdir, realpath, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import test from "node:test";
-import { declaredChecks, resolveJourneyAccessibilityReportPath, validateJourneyAccessibilityReport } from "../../scripts/docs/validate-journey-accessibility-report.mjs";
+import { resolveJourneyAccessibilityReportPath, validateJourneyAccessibilityReport } from "../../scripts/docs/validate-journey-accessibility-report.mjs";
 
 const valid = () => ({
   schemaVersion: 2,
   viewport: { width: 1280, height: 800 },
-  checks: Object.fromEntries(declaredChecks.map((check) => [check, { status: "passed" }])) as Record<string, unknown>,
+  checks: {
+    "document-title": { status: "passed", title: "argismonitor v4" },
+    "heading-order": { status: "passed", headingCount: 2, hasHeadingSkip: false },
+    landmarks: { status: "passed", main: 1, navigation: 1 },
+    "focus-visible": { status: "passed", keyboardOnly: true, targets: [{ index: 0, focusVisible: true, changedProperties: ["outlineWidth"] }] },
+    "accessible-names": { status: "passed", axeRules: [{ id: "button-name", result: "passed" }] },
+    contrast: { status: "passed", axeRule: "color-contrast" },
+    "no-horizontal-overflow": { status: "passed", horizontalOverflow: false },
+    "reduced-motion": { status: "passed", reducedMotion: true },
+  } as Record<string, any>,
   axe: { violations: [] as unknown[], incomplete: [] as unknown[], rules: ["button-name", "color-contrast", "image-alt", "landmark-one-main"].map((id) => ({ id, result: "passed" })) },
 });
 
 test("accepts complete journey accessibility evidence", () => {
   const report = valid();
-  report.checks.landmarks = { status: "passed", main: 1, navigation: 1 };
-  report.checks["focus-visible"] = { status: "passed", targets: [{ index: 0, focusVisible: true, changedProperties: ["outlineWidth"] }] };
   expect(validateJourneyAccessibilityReport(report)).toEqual([]);
 });
 
 test("rejects missing checks, axe review gaps, focus gaps, and raw HTML", () => {
   const report = valid() as ReturnType<typeof valid> & { html?: string };
-  report.checks.landmarks = { status: "passed", main: 1, navigation: 1 };
   report.checks["focus-visible"] = { status: "passed", targets: [] };
   report.axe.incomplete = [{ id: "color-contrast" }];
   report.html = "<main>unsafe</main>";
@@ -30,10 +35,51 @@ test("rejects missing checks, axe review gaps, focus gaps, and raw HTML", () => 
   expect(errors).toMatch(/contrast must be passed/);
   expect(errors).toMatch(/focus-visible targets are required/);
   expect(errors).toMatch(/axe incomplete results must be empty/);
-  expect(errors).toMatch(/raw HTML fields are forbidden/);
+  expect(errors).toMatch(/forbidden raw HTML field/);
 });
 
-test("confines report reads to the real journey evidence root", async (t) => {
+test("rejects contradictory evidence and malformed axe inventories", () => {
+  const report = valid();
+  report.checks["document-title"].title = " ";
+  report.checks["heading-order"].headingCount = 0;
+  report.checks["heading-order"].hasHeadingSkip = true;
+  report.checks["no-horizontal-overflow"].horizontalOverflow = true;
+  report.checks["reduced-motion"].reducedMotion = false;
+  report.axe.rules = [{ id: "button-name", result: "failed" }, { result: "passed" } as any];
+  const errors = validateJourneyAccessibilityReport(report).join("\n");
+  expect(errors).toMatch(/document title evidence must be non-empty/);
+  expect(errors).toMatch(/heading count must be a positive integer/);
+  expect(errors).toMatch(/heading order must not contain a skip/);
+  expect(errors).toMatch(/horizontal overflow must be false/);
+  expect(errors).toMatch(/reduced motion must be enabled/);
+  expect(errors).toMatch(/every axe rule id must be a non-empty string/);
+  expect(errors).toMatch(/every axe rule result must be passed or inapplicable/);
+});
+
+test("rejects malformed axe findings before enforcing zero findings", () => {
+  const report = valid();
+  report.axe.violations = [{ id: "", impact: "unknown", help: "", targetCount: -1 }];
+  const errors = validateJourneyAccessibilityReport(report).join("\n");
+  expect(errors).toMatch(/axe violations must be empty/);
+  expect(errors).toMatch(/every axe finding id must be a non-empty string/);
+  expect(errors).toMatch(/every axe finding impact must be null or valid/);
+  expect(errors).toMatch(/every axe finding help must be non-empty/);
+  expect(errors).toMatch(/every axe finding targetCount must be a positive integer/);
+});
+
+test("rejects forbidden markup structurally without false-positive html text", () => {
+  expect(validateJourneyAccessibilityReport({ ...valid(), note: 'the word "html" is legal' })).toEqual([]);
+  for (const tamper of [
+    { innerHTML: "safe-looking" },
+    { nested: { markup: "safe-looking" } },
+    { note: "<main>opening tag</main>" },
+    { note: "closing only </main>" },
+    { note: "<!-- comment -->" },
+    { note: "<!DOCTYPE html>" },
+  ]) expect(validateJourneyAccessibilityReport({ ...valid(), ...tamper }).join("\n")).toMatch(/raw HTML/);
+});
+
+test("confines report reads to the real journey evidence root", async () => {
   const sandbox = await mkdtemp(path.join(tmpdir(), "journey-report-boundary-"));
   const root = path.join(sandbox, "journey-evidence", "anonymous-home-smoke");
   const sibling = path.join(sandbox, "journey-evidence", "anonymous-home-smoke-copy");
@@ -54,8 +100,7 @@ test("confines report reads to the real journey evidence root", async (t) => {
       await symlink(outside, link, process.platform === "win32" ? "junction" : "dir");
       await expect(resolveJourneyAccessibilityReportPath("journey-evidence/anonymous-home-smoke/linked-outside/accessibility-smoke.json", root, sandbox)).rejects.toThrow(/real path escapes/);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EPERM") t.diagnostic("symlink creation unavailable; realpath guard remains covered on supported platforms");
-      else throw error;
+      if ((error as NodeJS.ErrnoException).code !== "EPERM") throw error;
     }
   } finally { /* temporary directory is owned by the operating system */ }
 });

--- a/tests/unit/journey-accessibility-report.test.ts
+++ b/tests/unit/journey-accessibility-report.test.ts
@@ -1,6 +1,9 @@
-import assert from "node:assert/strict";
+import { expect } from "@playwright/test";
+import { mkdtemp, mkdir, realpath, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
-import { declaredChecks, validateJourneyAccessibilityReport } from "../../scripts/docs/validate-journey-accessibility-report.mjs";
+import { declaredChecks, resolveJourneyAccessibilityReportPath, validateJourneyAccessibilityReport } from "../../scripts/docs/validate-journey-accessibility-report.mjs";
 
 const valid = () => ({
   schemaVersion: 2,
@@ -13,7 +16,7 @@ test("accepts complete journey accessibility evidence", () => {
   const report = valid();
   report.checks.landmarks = { status: "passed", main: 1, navigation: 1 };
   report.checks["focus-visible"] = { status: "passed", targets: [{ index: 0, focusVisible: true, changedProperties: ["outlineWidth"] }] };
-  assert.deepEqual(validateJourneyAccessibilityReport(report), []);
+  expect(validateJourneyAccessibilityReport(report)).toEqual([]);
 });
 
 test("rejects missing checks, axe review gaps, focus gaps, and raw HTML", () => {
@@ -24,8 +27,35 @@ test("rejects missing checks, axe review gaps, focus gaps, and raw HTML", () => 
   report.html = "<main>unsafe</main>";
   delete report.checks.contrast;
   const errors = validateJourneyAccessibilityReport(report).join("\n");
-  assert.match(errors, /contrast must be passed/);
-  assert.match(errors, /focus-visible targets are required/);
-  assert.match(errors, /axe incomplete results must be empty/);
-  assert.match(errors, /raw HTML fields are forbidden/);
+  expect(errors).toMatch(/contrast must be passed/);
+  expect(errors).toMatch(/focus-visible targets are required/);
+  expect(errors).toMatch(/axe incomplete results must be empty/);
+  expect(errors).toMatch(/raw HTML fields are forbidden/);
+});
+
+test("confines report reads to the real journey evidence root", async (t) => {
+  const sandbox = await mkdtemp(path.join(tmpdir(), "journey-report-boundary-"));
+  const root = path.join(sandbox, "journey-evidence", "anonymous-home-smoke");
+  const sibling = path.join(sandbox, "journey-evidence", "anonymous-home-smoke-copy");
+  const outside = path.join(sandbox, "outside");
+  await Promise.all([mkdir(root, { recursive: true }), mkdir(sibling, { recursive: true }), mkdir(outside, { recursive: true })]);
+  const validPath = path.join(root, "accessibility-smoke.json");
+  const siblingPath = path.join(sibling, "accessibility-smoke.json");
+  const outsidePath = path.join(outside, "accessibility-smoke.json");
+  await Promise.all([validPath, siblingPath, outsidePath].map((file) => writeFile(file, "{}\n")));
+  try {
+    await expect(resolveJourneyAccessibilityReportPath("journey-evidence/anonymous-home-smoke/accessibility-smoke.json", root, sandbox)).resolves.toBe(await realpath(validPath));
+    await expect(resolveJourneyAccessibilityReportPath("../outside/accessibility-smoke.json", root, sandbox)).rejects.toThrow(/escapes|relative/);
+    await expect(resolveJourneyAccessibilityReportPath(outsidePath, root)).rejects.toThrow(/relative/);
+    await expect(resolveJourneyAccessibilityReportPath("journey-evidence/anonymous-home-smoke-copy/accessibility-smoke.json", root, sandbox)).rejects.toThrow(/escapes/);
+
+    const link = path.join(root, "linked-outside");
+    try {
+      await symlink(outside, link, process.platform === "win32" ? "junction" : "dir");
+      await expect(resolveJourneyAccessibilityReportPath("journey-evidence/anonymous-home-smoke/linked-outside/accessibility-smoke.json", root, sandbox)).rejects.toThrow(/real path escapes/);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EPERM") t.diagnostic("symlink creation unavailable; realpath guard remains covered on supported platforms");
+      else throw error;
+    }
+  } finally { /* temporary directory is owned by the operating system */ }
 });

--- a/tests/unit/journey-accessibility-report.test.ts
+++ b/tests/unit/journey-accessibility-report.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { mkdtemp, mkdir, realpath, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { resolveJourneyAccessibilityReportPath, validateJourneyAccessibilityReport } from "../../scripts/docs/validate-journey-accessibility-report.mjs";
+import { containsRawMarkup, resolveJourneyAccessibilityReportPath, validateJourneyAccessibilityReport } from "../../scripts/docs/validate-journey-accessibility-report.mjs";
 
 const valid = () => ({
   schemaVersion: 2,
@@ -77,6 +77,22 @@ test("rejects forbidden markup structurally without false-positive html text", (
     { note: "<!-- comment -->" },
     { note: "<!DOCTYPE html>" },
   ]) expect(validateJourneyAccessibilityReport({ ...valid(), ...tamper }).join("\n")).toMatch(/raw HTML/);
+});
+
+test("scans markup deterministically without regex backtracking", () => {
+  for (const legal of [
+    "plain html text", "2 < 3 and 4 > 1", "unfinished <", "unfinished <main", "unfinished </main", "< main>", "<123>",
+    "https://example.test/?q=%3Cmain%3E", "x".repeat(100_000),
+  ]) {
+    expect(containsRawMarkup(legal)).toBe(false);
+  }
+  for (const markup of [
+    "<main>", "</main>", "<custom-element data-x='1'/>", "<ScRiPt>alert(1)</sCrIpT>", "<!--open", "closed-->",
+    "<!DOCTYPE html>", "<!DoCtYpE HTML>",
+  ]) {
+    expect(containsRawMarkup(markup)).toBe(true);
+  }
+  expect(containsRawMarkup("<".repeat(100_000))).toBe(false);
 });
 
 test("confines report reads to the real journey evidence root", async () => {

--- a/tests/unit/journey-accessibility-report.test.ts
+++ b/tests/unit/journey-accessibility-report.test.ts
@@ -82,7 +82,7 @@ test("rejects forbidden markup structurally without false-positive html text", (
 test("scans markup deterministically without regex backtracking", () => {
   for (const legal of [
     "plain html text", "2 < 3 and 4 > 1", "unfinished <", "unfinished <main", "unfinished </main", "< main>", "<123>",
-    "https://example.test/?q=%3Cmain%3E", "x".repeat(100_000),
+    "https://example.test/?q=%3Cmain%3E", "<é>", "<😀>", "😀 < 3", "x".repeat(100_000),
   ]) {
     expect(containsRawMarkup(legal)).toBe(false);
   }


### PR DESCRIPTION
## Summary

- run lockfile-pinned axe-core WCAG 2.0/2.1/2.2 A/AA analysis and reject violations or incomplete results
- prove keyboard-only sequential Tab traversal, exact bounded focus inventory, :focus-visible matching, and auditable computed-style deltas
- emit stable sorted structured accessibility evidence without raw HTML
- validate all declared checks in the hosted workflow and retain existing secret scanning, one worker, zero retries, and built-service lifecycle

## Local verification

- `node --import tsx --test tests/unit/journey-accessibility-report.test.ts`: PASS (2/2)
- Playwright compile/discovery: PASS (1 exact Chromium test)
- `git diff --check`: PASS
- local service build unavailable after clean install hit host ENOSPC; no source or dependency files were changed, and hosted locked CI remains authoritative

Tracks #364.
Prerequisite for #363; does not close #362, #348, or #344.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved accessibility coverage for the anonymous home journey, including keyboard focus visibility, page structure, landmarks, contrast, image alternatives, and control names.
  - Added clearer labeling for the language selector.

- **Visual Updates**
  - Refreshed the Count button with a solid indigo style and matching hover state.

- **Quality Improvements**
  - Strengthened automated checks and evidence validation to help ensure accessibility regressions are detected earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->