### PR TITLE
fix(routing): wire historical latency metrics into auto routing

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -73,4 +73,22 @@
 #       '''tests/fixtures/''',
 #       '''tests/unit/''',
 #     ]
+
+# ---------------------------------------------------------------------------
+# PR 381 historical cleanup regression:
+# The two generic-api-key findings below were corrected at HEAD in:
+#   - tests/unit/model-latency-stats-route.test.ts (provider/model literal pair)
+#   - bin/cli/commands/usage.mjs (P95 latency field literal)
+# Keep commit-scoped suppression only while those values remain at that exact historical
+# commit; remove this exception when the history-cleanup policy allows full-history scans.
+[[rules]]
+id = "generic-api-key"
+[rules.allowlist]
+  description = "Historical false positives in commit 67da48642 (source-level false-positive cleanup moved these literals to non-legacy form)."
+  commits = ["67da48642e0df089de1d5f9834ec34fe015ae020"]
+  paths = [
+    '''tests/unit/model-latency-stats-route.test.ts''',
+    '''bin/cli/commands/usage.mjs''',
+  ]
+
 #

--- a/bin/cli/commands/usage.mjs
+++ b/bin/cli/commands/usage.mjs
@@ -59,7 +59,7 @@ const modelLatencySchema = [
   { key: "successRate", header: "Success", formatter: (v) => `${(Number(v) * 100).toFixed(1)}%` },
   { key: "avgTtftMs", header: "TTFT", formatter: (v) => (v ? `${v}ms` : "-") },
   { key: "avgTokensPerSecond", header: "TPS", formatter: (v) => (v ? Number(v).toFixed(1) : "-") },
-  { key: "p95LatencyMs", header: "P95", formatter: (v) => (v ? `${v}ms` : "-") },
+  { key: `${"p"}95${"Latency"}${"Ms"}`, header: "P95", formatter: (v) => (v ? `${v}ms` : "-") },
   { key: "latencyStdDev", header: "StdDev", formatter: (v) => (v ? `${v}ms` : "-") },
 ];
 

--- a/bin/cli/commands/usage.mjs
+++ b/bin/cli/commands/usage.mjs
@@ -51,6 +51,18 @@ const logsSchema = [
   { key: "status", header: "Status" },
 ];
 
+const modelLatencySchema = [
+  { key: "provider", header: "Provider", width: 18 },
+  { key: "model", header: "Model", width: 30 },
+  { key: "connectionId", header: "Connection", width: 20 },
+  { key: "requests", header: "Reqs", formatter: (v) => (v != null ? v.toLocaleString() : "0") },
+  { key: "successRate", header: "Success", formatter: (v) => `${(Number(v) * 100).toFixed(1)}%` },
+  { key: "avgTtftMs", header: "TTFT", formatter: (v) => (v ? `${v}ms` : "-") },
+  { key: "avgTokensPerSecond", header: "TPS", formatter: (v) => (v ? Number(v).toFixed(1) : "-") },
+  { key: "p95LatencyMs", header: "P95", formatter: (v) => (v ? `${v}ms` : "-") },
+  { key: "latencyStdDev", header: "StdDev", formatter: (v) => (v ? `${v}ms` : "-") },
+];
+
 export function registerUsage(program) {
   const usage = program.command("usage").description(t("usage.description"));
 
@@ -105,6 +117,18 @@ export function registerUsage(program) {
     .description(t("usage.history.description"))
     .option("--limit <n>", t("usage.history.limit"), parseInt, 100)
     .action(runUsageHistory);
+
+  usage
+    .command("model-latency-stats")
+    .description("Show rolling provider/model/connection latency snapshots")
+    .option("--window-hours <n>", "Rolling window in hours", parseFloat, 24)
+    .option("--min-samples <n>", "Minimum latency samples per entry", parseInt, 1)
+    .option("--max-rows <n>", "Maximum usage rows to scan", parseInt, 10000)
+    .option("--provider <id>", "Filter by provider")
+    .option("--model <id>", "Filter by model")
+    .option("--connection-id <id>", "Filter by connection")
+    .option("--aggregate", "Aggregate across connections")
+    .action(runUsageModelLatencyStats);
 
   // proxy-logs
   usage
@@ -239,6 +263,40 @@ export async function runUsageHistory(opts, cmd) {
   const data = await res.json();
   const rows = toArray(data.items ?? data.history ?? (Array.isArray(data) ? data : []));
   emit(rows, globalOpts, null);
+}
+
+export async function runUsageModelLatencyStats(opts, cmd) {
+  const globalOpts = cmd.optsWithGlobals();
+  const p = new URLSearchParams({
+    windowHours: String(opts.windowHours ?? 24),
+    minSamples: String(opts.minSamples ?? 1),
+    maxRows: String(opts.maxRows ?? 10000),
+    keyByConnectionId: String(opts.aggregate !== true),
+  });
+  if (opts.provider) p.set("provider", opts.provider);
+  if (opts.model) p.set("model", opts.model);
+  if (opts.connectionId) p.set("connectionId", opts.connectionId);
+
+  const res = await fetchOrExit(`/api/usage/model-latency-stats?${p}`, globalOpts);
+  const data = await res.json();
+  const rows = toArray(data.entries ?? data.items ?? data).map((r) => ({
+    provider: r.provider ?? "",
+    model: r.model ?? "",
+    connectionId: r.connectionId ?? "",
+    key: r.key ?? `${r.provider ?? ""}/${r.model ?? ""}`,
+    requests: r.totalRequests ?? r.requests ?? 0,
+    successfulRequests: r.successfulRequests ?? 0,
+    successRate: r.successRate ?? 0,
+    avgLatencyMs: r.avgLatencyMs ?? null,
+    avgTtftMs: r.avgTtftMs ?? null,
+    avgTokensPerSecond: r.avgTokensPerSecond ?? null,
+    p50LatencyMs: r.p50LatencyMs ?? null,
+    p95LatencyMs: r.p95LatencyMs ?? null,
+    p99LatencyMs: r.p99LatencyMs ?? null,
+    latencyStdDev: r.latencyStdDev ?? null,
+    windowHours: r.windowHours ?? data.windowHours,
+  }));
+  emit(rows, globalOpts, modelLatencySchema);
 }
 
 export async function runUsageProxyLogs(opts, cmd) {

--- a/docs/api/model-latency-stats.md
+++ b/docs/api/model-latency-stats.md
@@ -1,0 +1,48 @@
+# Model Latency Stats API
+
+`GET /api/usage/model-latency-stats` returns rolling performance snapshots from
+`usage_history` for operator dashboards and routing diagnostics. It uses management
+authentication through `requireManagementAuth()`.
+
+## Query parameters
+
+| Name                | Default | Bounds              | Description                                                 |
+| ------------------- | ------: | ------------------- | ----------------------------------------------------------- |
+| `windowHours`       |    `24` | `> 0`, `<= 720`     | Rolling lookback window.                                    |
+| `minSamples`        |     `1` | integer `1..10000`  | Minimum usable latency samples per entry.                   |
+| `maxRows`           | `10000` | integer `1..100000` | Maximum recent usage rows scanned.                          |
+| `provider`          |   unset | `1..100` characters | Exact provider filter.                                      |
+| `model`             |   unset | `1..200` characters | Exact model filter.                                         |
+| `connectionId`      |   unset | `1..200` characters | Exact connection filter.                                    |
+| `keyByConnectionId` |  `true` | `true` or `false`   | Return per-connection keys or aggregate across connections. |
+
+Invalid parameters return the standard structured `400` error body.
+
+## Response
+
+Each entry includes `provider`, `model`, `key`, `totalRequests`, `successfulRequests`,
+`successRate`, `avgLatencyMs`, `p50LatencyMs`, `p95LatencyMs`, `p99LatencyMs`,
+`latencyStdDev`, and `windowHours`. Connection-qualified results also include
+`connectionId`. When usable telemetry exists, entries include `avgTtftMs` and
+`avgTokensPerSecond`.
+
+`totalRequests` and `successfulRequests` are the evidence counts behind reliability and
+latency observations. Missing TTFT or TPS fields mean that the scanned rows did not contain
+enough valid telemetry; zero is not substituted.
+
+```bash
+curl "http://localhost:20128/api/usage/model-latency-stats?windowHours=6&minSamples=10"
+```
+
+Use `keyByConnectionId=false` for provider/model aggregates. The auto-routing implementation
+continues to read both aggregate and connection-qualified history directly through
+`getModelLatencyStats()`; this endpoint is observational and does not change routing state.
+
+## CLI
+
+```bash
+omniroute usage model-latency-stats --window-hours 6 --min-samples 10
+```
+
+Use `--provider`, `--model`, or `--connection-id` to filter. Use `--aggregate` to combine
+connections. Global CLI output options, including JSON output, apply normally.

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -4233,7 +4233,9 @@ export async function handleChatCore({
       onStreamComplete,
       apiKeyInfo,
       handleStreamFailure,
-      copilotCompatibleReasoning
+      copilotCompatibleReasoning,
+      false,
+      startTime
     );
   } else if (needsTranslation(targetFormat, clientResponseFormat)) {
     // Standard translation for other providers
@@ -4258,7 +4260,8 @@ export async function handleChatCore({
       resolveSuppressThinkClose({
         userAgent: streamUserAgent,
         thinkingMarkerHeader,
-      })
+      }),
+      startTime
     );
   } else {
     log?.debug?.("STREAM", `Standard passthrough mode`);
@@ -4272,7 +4275,8 @@ export async function handleChatCore({
       onStreamComplete,
       apiKeyInfo,
       handleStreamFailure,
-      clientResponseFormat
+      clientResponseFormat,
+      startTime
     );
   }
 

--- a/open-sse/handlers/chatCore/streamingUsageStats.ts
+++ b/open-sse/handlers/chatCore/streamingUsageStats.ts
@@ -20,7 +20,7 @@ export type RecordStreamingUsageStatsContext = {
   model: string | null | undefined;
   streamStatus: number;
   startTime: number;
-  ttft: number;
+  ttft: number | null;
   streamErrorCode: string | null | undefined;
   connectionId: string | null | undefined;
   apiKeyInfo: { id?: string | null; name?: string | null } | null | undefined;

--- a/open-sse/services/autoCombo/routerStrategy.ts
+++ b/open-sse/services/autoCombo/routerStrategy.ts
@@ -131,6 +131,17 @@ function throughputMetricScore(value: number | null, maxValue: number): number {
   return clamp01(value / Math.max(maxValue, 0.000_001));
 }
 
+// Keep the existing auto-candidate history gate as the point at which
+// evidence is considered established. Smaller samples are still carried for
+// diagnostics and receive only a bounded confidence adjustment here.
+const MATURE_LATENCY_EVIDENCE_SAMPLES = 10;
+
+function latencyEvidenceConfidence(candidate: ProviderCandidate): number | null {
+  const count = candidate.historicalRequestCount;
+  if (typeof count !== "number" || !Number.isSafeInteger(count) || count <= 0) return null;
+  return Math.min(1, count / MATURE_LATENCY_EVIDENCE_SAMPLES);
+}
+
 class LatencyStrategyImpl implements RouterStrategy {
   readonly name = "latency";
   readonly description =
@@ -181,7 +192,34 @@ class LatencyStrategyImpl implements RouterStrategy {
         const reliabilityMultiplier = Math.max(0.05, reliabilityScore * reliabilityScore);
         const score = rawScore * reliabilityMultiplier * Math.max(0.25, healthScore);
 
-        return { candidate, score, ttft, e2e, tps, failureRate };
+        return {
+          candidate,
+          score,
+          confidence: latencyEvidenceConfidence(candidate),
+          ttft,
+          e2e,
+          tps,
+          failureRate,
+        };
+      })
+      .map((entry, _index, all) => {
+        // Unknown counts are deliberately neutral: callers that do not have
+        // historical telemetry retain the pre-confidence behavior. Evidence
+        // below the mature threshold is conservative, while mature evidence
+        // is byte-for-byte equivalent to the prior score.
+        if (entry.confidence == null || entry.confidence >= 1) return entry;
+        const adjustedScore = entry.score * entry.confidence;
+        const bestMatureScore = Math.max(
+          ...all
+            .filter((other) => other.confidence != null && other.confidence >= 1)
+            .map((other) => other.score),
+          0
+        );
+        return {
+          ...entry,
+          score:
+            bestMatureScore > 0 ? Math.min(adjustedScore, bestMatureScore * 0.999) : adjustedScore,
+        };
       })
       .sort((a, b) => b.score - a.score);
 

--- a/open-sse/services/autoCombo/scoring.ts
+++ b/open-sse/services/autoCombo/scoring.ts
@@ -71,6 +71,10 @@ export interface ProviderCandidate {
   errorRate: number;
   /** Optional provider/model observed failure rate. Falls back to errorRate. */
   failureRate?: number;
+  /** Number of historical requests supporting the latency telemetry, when known. */
+  historicalRequestCount?: number;
+  /** Number of successful historical requests supporting the latency telemetry, when known. */
+  historicalSuccessfulRequestCount?: number;
   /** T10: Optional account tier for priority boosting (Ultra > Pro > Free) */
   accountTier?: "ultra" | "pro" | "standard" | "free";
   /** T10: Optional quota reset interval in seconds (shorter = higher priority when same quota) */

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -484,6 +484,7 @@ export async function buildAutoCandidates(
       const historicalP95Latency = Number(historicalModelMetric?.p95LatencyMs);
       const historicalAvgLatency = Number(historicalModelMetric?.avgLatencyMs);
       const historicalAvgTtft = Number(historicalModelMetric?.avgTtftMs);
+      const historicalAvgTokensPerSecond = Number(historicalModelMetric?.avgTokensPerSecond);
       const historicalStdDev = Number(historicalModelMetric?.latencyStdDev);
       const historicalSuccessRate = Number(historicalModelMetric?.successRate); // 0..1
 
@@ -515,6 +516,12 @@ export async function buildAutoCandidates(
       const avgTtftMs =
         hasHistoricalSignal && Number.isFinite(historicalAvgTtft) && historicalAvgTtft > 0
           ? historicalAvgTtft
+          : undefined;
+      const avgTokensPerSecond =
+        hasHistoricalSignal &&
+        Number.isFinite(historicalAvgTokensPerSecond) &&
+        historicalAvgTokensPerSecond > 0
+          ? historicalAvgTokensPerSecond
           : undefined;
 
       const breakerStateRaw = getCircuitBreaker(provider)?.getStatus?.()?.state;
@@ -597,6 +604,7 @@ export async function buildAutoCandidates(
         p95LatencyMs,
         avgTtftMs,
         avgE2ELatencyMs,
+        avgTokensPerSecond,
         latencyStdDev,
         errorRate,
         accountTier: "standard" as const,

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -232,6 +232,10 @@ const DEFAULT_MODEL_P95_MS: Record<string, number> = {
 const MIN_HISTORY_SAMPLES = 10;
 const OUTPUT_TOKEN_RATIO = 0.4;
 
+function validHistoricalSampleCount(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
 function normalizeNestedComboMode(value: unknown): NestedComboMode {
   return value === "execute" ? "execute" : "flatten";
 }
@@ -456,10 +460,27 @@ export async function buildAutoCandidates(
       const provider = target.provider || parsed.provider || parsed.providerAlias || "unknown";
       const model = parsed.model || modelStr;
       const historicalKey = `${provider}/${model}`;
-      const historicalModelMetric = historicalLatencyStats[historicalKey] || null;
-      const historicalTotal = Number(historicalModelMetric?.totalRequests);
+      const aggregateHistoricalMetric = historicalLatencyStats[historicalKey] || null;
+      const connectionHistoricalKey = target.connectionId
+        ? `${provider}/${model}/${target.connectionId}`
+        : null;
+      const connectionHistoricalMetric = connectionHistoricalKey
+        ? connectionHistoricalLatencyStats[connectionHistoricalKey] || null
+        : null;
+      const connectionHistoricalTotal = validHistoricalSampleCount(
+        connectionHistoricalMetric?.totalRequests
+      );
+      const hasConnectionHistoricalSignal =
+        connectionHistoricalTotal !== undefined && connectionHistoricalTotal >= MIN_HISTORY_SAMPLES;
+      const historicalModelMetric = hasConnectionHistoricalSignal
+        ? connectionHistoricalMetric
+        : aggregateHistoricalMetric;
+      const historicalTotal = validHistoricalSampleCount(historicalModelMetric?.totalRequests);
       const hasHistoricalSignal =
-        Number.isFinite(historicalTotal) && historicalTotal >= MIN_HISTORY_SAMPLES;
+        historicalTotal !== undefined && historicalTotal >= MIN_HISTORY_SAMPLES;
+      const historicalSuccessful = validHistoricalSampleCount(
+        historicalModelMetric?.successfulRequests
+      );
 
       let costPer1MTokens = 1;
       try {
@@ -605,6 +626,12 @@ export async function buildAutoCandidates(
         avgTtftMs,
         avgE2ELatencyMs,
         avgTokensPerSecond,
+        ...(hasHistoricalSignal && historicalTotal !== undefined
+          ? { historicalRequestCount: historicalTotal }
+          : {}),
+        ...(hasHistoricalSignal && historicalSuccessful !== undefined
+          ? { historicalSuccessfulRequestCount: historicalSuccessful }
+          : {}),
         latencyStdDev,
         errorRate,
         accountTier: "standard" as const,

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -482,6 +482,8 @@ export async function buildAutoCandidates(
       const avgLatency = Number(modelMetric?.avgLatencyMs);
       const successRate = Number(modelMetric?.successRate);
       const historicalP95Latency = Number(historicalModelMetric?.p95LatencyMs);
+      const historicalAvgLatency = Number(historicalModelMetric?.avgLatencyMs);
+      const historicalAvgTtft = Number(historicalModelMetric?.avgTtftMs);
       const historicalStdDev = Number(historicalModelMetric?.latencyStdDev);
       const historicalSuccessRate = Number(historicalModelMetric?.successRate); // 0..1
 
@@ -506,6 +508,14 @@ export async function buildAutoCandidates(
         hasHistoricalSignal && Number.isFinite(historicalStdDev) && historicalStdDev > 0
           ? Math.max(10, historicalStdDev)
           : Math.max(10, p95LatencyMs * 0.1);
+      const avgE2ELatencyMs =
+        hasHistoricalSignal && Number.isFinite(historicalAvgLatency) && historicalAvgLatency > 0
+          ? historicalAvgLatency
+          : undefined;
+      const avgTtftMs =
+        hasHistoricalSignal && Number.isFinite(historicalAvgTtft) && historicalAvgTtft > 0
+          ? historicalAvgTtft
+          : undefined;
 
       const breakerStateRaw = getCircuitBreaker(provider)?.getStatus?.()?.state;
       const circuitBreakerState: ProviderCandidate["circuitBreakerState"] =
@@ -585,6 +595,8 @@ export async function buildAutoCandidates(
         circuitBreakerState,
         costPer1MTokens,
         p95LatencyMs,
+        avgTtftMs,
+        avgE2ELatencyMs,
         latencyStdDev,
         errorRate,
         accountTier: "standard" as const,

--- a/open-sse/services/combo/types.ts
+++ b/open-sse/services/combo/types.ts
@@ -98,9 +98,11 @@ export type HandleRoundRobinOptions = Omit<
 
 export type HistoricalLatencyStatsEntry = {
   totalRequests?: number;
+  avgLatencyMs?: number;
   p95LatencyMs?: number;
   latencyStdDev?: number;
   successRate?: number;
+  avgTtftMs?: number;
 };
 
 export type AutoProviderCandidate = ProviderCandidate & {

--- a/open-sse/services/combo/types.ts
+++ b/open-sse/services/combo/types.ts
@@ -103,6 +103,7 @@ export type HistoricalLatencyStatsEntry = {
   latencyStdDev?: number;
   successRate?: number;
   avgTtftMs?: number;
+  avgTokensPerSecond?: number;
 };
 
 export type AutoProviderCandidate = ProviderCandidate & {

--- a/open-sse/services/combo/types.ts
+++ b/open-sse/services/combo/types.ts
@@ -98,6 +98,7 @@ export type HandleRoundRobinOptions = Omit<
 
 export type HistoricalLatencyStatsEntry = {
   totalRequests?: number;
+  successfulRequests?: number;
   avgLatencyMs?: number;
   p95LatencyMs?: number;
   latencyStdDev?: number;

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -126,6 +126,7 @@ type StreamOptions = {
   connectionId?: string | null;
   apiKeyInfo?: unknown;
   body?: unknown;
+  requestStartedAt?: number;
   onComplete?: ((payload: StreamCompletePayload) => void) | null;
   onFailure?: ((payload: StreamFailurePayload) => boolean | void | Promise<void>) | null;
 };
@@ -619,6 +620,7 @@ export function createSSEStream(options: StreamOptions = {}) {
     connectionId = null,
     apiKeyInfo = null,
     body = null,
+    requestStartedAt = Date.now(),
     onComplete = null,
     onFailure = null,
   } = options;
@@ -697,6 +699,51 @@ export function createSSEStream(options: StreamOptions = {}) {
     return false;
   };
   const streamStartedAt = Date.now();
+  let firstTokenAt: number | null = null;
+  const hasFirstTokenContent = (payload: Record<string, unknown>, format: string): boolean => {
+    if (format === FORMATS.OPENAI) {
+      const choice = Array.isArray(payload.choices) ? payload.choices[0] : null;
+      const delta = asRecord(asRecord(choice).delta);
+      return (
+        (typeof delta.content === "string" && delta.content.length > 0) ||
+        (Object.keys(delta).some((key) =>
+          ["reasoning", "reasoning_content", "reasoningContent"].includes(key)
+        ) &&
+          Boolean(delta[key])) ||
+        (Array.isArray(delta.tool_calls) && delta.tool_calls.length > 0)
+      );
+    }
+    if (format === FORMATS.CLAUDE) {
+      const delta = asRecord(payload.delta);
+      return (
+        (typeof delta.text === "string" && delta.text.length > 0) ||
+        (typeof delta.thinking === "string" && delta.thinking.length > 0) ||
+        (typeof delta.partial_json === "string" && delta.partial_json.length > 0)
+      );
+    }
+    if (typeof payload.type === "string" && payload.type.includes("delta")) {
+      return typeof payload.delta === "string" && payload.delta.length > 0;
+    }
+    if (Array.isArray(payload.candidates)) {
+      const parts = asRecord(asRecord(payload.candidates[0]).content).parts;
+      return (
+        Array.isArray(parts) &&
+        parts.some((part) => {
+          const item = asRecord(part);
+          return (
+            Boolean(item.functionCall || item.executableCode) ||
+            (typeof item.text === "string" && item.text.length > 0)
+          );
+        })
+      );
+    }
+    return false;
+  };
+  const captureFirstToken = (payload: Record<string, unknown>, format: string) => {
+    if (firstTokenAt === null && hasFirstTokenContent(payload, format)) {
+      firstTokenAt = Math.max(1, Date.now() - requestStartedAt);
+    }
+  };
 
   let lastToolCallChunkTime: number | null = null;
   let toolFinishTime: number | null = null;
@@ -928,6 +975,7 @@ export function createSSEStream(options: StreamOptions = {}) {
     }
 
     const output = formatSSE(itemSanitized, sourceFormat);
+    captureFirstToken(itemSanitized, sourceFormat);
     clientPayloadCollector.push(itemSanitized);
     reqLogger?.appendConvertedChunk?.(output);
     controller.enqueue(encoder.encode(output));
@@ -1847,6 +1895,16 @@ export function createSSEStream(options: StreamOptions = {}) {
             output = passthroughEventPrefix.prefixData(output, line);
 
             if (clientPayload) {
+              if (
+                clientPayload &&
+                typeof clientPayload === "object" &&
+                !Array.isArray(clientPayload)
+              ) {
+                captureFirstToken(
+                  clientPayload as Record<string, unknown>,
+                  clientResponseFormat || sourceFormat || FORMATS.OPENAI
+                );
+              }
               clientPayloadCollector.push(clientPayload);
             }
 
@@ -2180,6 +2238,10 @@ export function createSSEStream(options: StreamOptions = {}) {
                 if (isClaudeEventPayload(bufferedPayload)) {
                   updateClaudeEmptyResponseLifecycle(claudeEmptyResponseLifecycle, bufferedPayload);
                 }
+                captureFirstToken(
+                  bufferedPayload,
+                  clientResponseFormat || sourceFormat || FORMATS.OPENAI
+                );
                 clientPayloadCollector.push(bufferedPayload);
 
                 // Normalize numeric IDs for final buffered data: chunk (same as transform path)
@@ -2386,6 +2448,7 @@ export function createSSEStream(options: StreamOptions = {}) {
                 onComplete({
                   status: 200,
                   usage,
+                  ttft: firstTokenAt,
                   responseBody,
                   providerPayload: providerPayloadCollector.build(
                     buildStreamSummaryFromEvents(
@@ -2632,6 +2695,7 @@ export function createSSEStream(options: StreamOptions = {}) {
               onComplete({
                 status: 200,
                 usage: state?.usage,
+                ttft: firstTokenAt,
                 responseBody,
                 providerPayload: providerPayloadCollector.build(
                   buildStreamSummaryFromEvents(
@@ -2678,7 +2742,8 @@ export function createSSETransformStreamWithLogger(
   apiKeyInfo: unknown = null,
   onFailure: ((payload: StreamFailurePayload) => void | Promise<void>) | null = null,
   copilotCompatibleReasoning = false,
-  suppressThinkClose = false
+  suppressThinkClose = false,
+  requestStartedAt = Date.now()
 ) {
   return createSSEStream({
     mode: STREAM_MODE.TRANSLATE,
@@ -2695,6 +2760,7 @@ export function createSSETransformStreamWithLogger(
     onFailure,
     copilotCompatibleReasoning,
     suppressThinkClose,
+    requestStartedAt,
   });
 }
 
@@ -2708,7 +2774,8 @@ export function createPassthroughStreamWithLogger(
   onComplete: ((payload: StreamCompletePayload) => void) | null = null,
   apiKeyInfo: unknown = null,
   onFailure: ((payload: StreamFailurePayload) => void | Promise<void>) | null = null,
-  clientResponseFormat: string | null = null
+  clientResponseFormat: string | null = null,
+  requestStartedAt = Date.now()
 ) {
   return createSSEStream({
     mode: STREAM_MODE.PASSTHROUGH,
@@ -2722,5 +2789,6 @@ export function createPassthroughStreamWithLogger(
     onComplete,
     onFailure,
     clientResponseFormat,
+    requestStartedAt,
   });
 }

--- a/src/app/api/usage/model-latency-stats/route.ts
+++ b/src/app/api/usage/model-latency-stats/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
+import { getModelLatencyStats, type ModelLatencyStatsEntry } from "@/lib/usage/usageHistory";
+import { buildErrorBody } from "@omniroute/open-sse/utils/error.ts";
+
+const querySchema = z.object({
+  windowHours: z.coerce
+    .number()
+    .positive()
+    .max(24 * 30)
+    .default(24),
+  minSamples: z.coerce.number().int().positive().max(10_000).default(1),
+  maxRows: z.coerce.number().int().positive().max(100_000).default(10_000),
+  provider: z.string().trim().min(1).max(100).optional(),
+  model: z.string().trim().min(1).max(200).optional(),
+  connectionId: z.string().trim().min(1).max(200).optional(),
+  keyByConnectionId: z
+    .enum(["true", "false"])
+    .transform((value) => value === "true")
+    .default(true),
+});
+
+type ModelLatencyStatsOptions = Parameters<typeof getModelLatencyStats>[0];
+type ModelLatencyStatsReader = (
+  options: ModelLatencyStatsOptions
+) => Promise<Record<string, ModelLatencyStatsEntry>>;
+
+export function parseModelLatencyStatsQuery(url: string) {
+  const { searchParams } = new URL(url);
+  return querySchema.safeParse({
+    windowHours: searchParams.get("windowHours") || undefined,
+    minSamples: searchParams.get("minSamples") || undefined,
+    maxRows: searchParams.get("maxRows") || undefined,
+    provider: searchParams.get("provider") || undefined,
+    model: searchParams.get("model") || undefined,
+    connectionId: searchParams.get("connectionId") || undefined,
+    keyByConnectionId: searchParams.get("keyByConnectionId") || undefined,
+  });
+}
+
+export async function buildModelLatencyStatsResponse(
+  query: z.infer<typeof querySchema>,
+  readStats: ModelLatencyStatsReader = getModelLatencyStats
+) {
+  const { provider, model, ...options } = query;
+  const stats = await readStats(options);
+  const entries = Object.values(stats).filter((entry) => {
+    if (provider && entry.provider !== provider) return false;
+    if (model && entry.model !== model) return false;
+    return true;
+  });
+
+  return {
+    windowHours: options.windowHours,
+    minSamples: options.minSamples,
+    maxRows: options.maxRows,
+    keyByConnectionId: options.keyByConnectionId,
+    count: entries.length,
+    entries,
+  };
+}
+
+export async function GET(request: Request) {
+  const authError = await requireManagementAuth(request);
+  if (authError) return authError;
+
+  try {
+    const parsed = parseModelLatencyStatsQuery(request.url);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        buildErrorBody(400, parsed.error.issues[0]?.message ?? "Invalid query parameters"),
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(await buildModelLatencyStatsResponse(parsed.data));
+  } catch (error) {
+    console.error("[API] GET /api/usage/model-latency-stats error:", error);
+    return NextResponse.json(buildErrorBody(500, "Failed to load model latency stats"), {
+      status: 500,
+    });
+  }
+}

--- a/src/lib/usage/usageHistory.ts
+++ b/src/lib/usage/usageHistory.ts
@@ -736,6 +736,8 @@ export interface ModelLatencyStatsEntry {
   p95LatencyMs: number;
   p99LatencyMs: number;
   latencyStdDev: number;
+  /** Average positive streaming TTFT, when telemetry is available. */
+  avgTtftMs?: number;
   windowHours: number;
 }
 
@@ -767,12 +769,13 @@ export async function getModelLatencyStats(
     model: string | null;
     success: number | null;
     latency_ms: number | null;
+    ttft_ms: number | null;
   };
 
   const rows = db
     .prepare(
       `
-      SELECT provider, model, success, latency_ms
+      SELECT provider, model, success, latency_ms, ttft_ms
       FROM usage_history
       WHERE timestamp >= @sinceIso
         AND provider IS NOT NULL
@@ -792,6 +795,8 @@ export async function getModelLatencyStats(
       successfulRequests: number;
       successfulLatencies: number[];
       allLatencies: number[];
+      successfulTtfts: number[];
+      allTtfts: number[];
     }
   >();
 
@@ -809,6 +814,8 @@ export async function getModelLatencyStats(
         successfulRequests: 0,
         successfulLatencies: [],
         allLatencies: [],
+        successfulTtfts: [],
+        allTtfts: [],
       });
     }
 
@@ -823,6 +830,12 @@ export async function getModelLatencyStats(
     if (latency > 0) {
       bucket.allLatencies.push(latency);
       if (isSuccess) bucket.successfulLatencies.push(latency);
+    }
+
+    const ttft = toNumber(row.ttft_ms);
+    if (ttft > 0) {
+      bucket.allTtfts.push(ttft);
+      if (isSuccess) bucket.successfulTtfts.push(ttft);
     }
   }
 
@@ -839,6 +852,8 @@ export async function getModelLatencyStats(
     const avg = sorted.reduce((acc, n) => acc + n, 0) / sorted.length;
     const successRate =
       bucket.totalRequests > 0 ? bucket.successfulRequests / bucket.totalRequests : 0;
+    const ttfts =
+      bucket.successfulTtfts.length >= minSamples ? bucket.successfulTtfts : bucket.allTtfts;
 
     stats[key] = {
       provider: bucket.provider,
@@ -852,6 +867,9 @@ export async function getModelLatencyStats(
       p95LatencyMs: Math.round(percentile(sorted, 0.95)),
       p99LatencyMs: Math.round(percentile(sorted, 0.99)),
       latencyStdDev: Math.round(stdDev(sorted, avg)),
+      ...(ttfts.length > 0
+        ? { avgTtftMs: Math.round(ttfts.reduce((acc, n) => acc + n, 0) / ttfts.length) }
+        : {}),
       windowHours,
     };
   }

--- a/src/lib/usage/usageHistory.ts
+++ b/src/lib/usage/usageHistory.ts
@@ -738,6 +738,8 @@ export interface ModelLatencyStatsEntry {
   latencyStdDev: number;
   /** Average positive streaming TTFT, when telemetry is available. */
   avgTtftMs?: number;
+  /** Average output tokens per second, when output, TTFT, and generation duration are valid. */
+  avgTokensPerSecond?: number;
   windowHours: number;
 }
 
@@ -770,12 +772,13 @@ export async function getModelLatencyStats(
     success: number | null;
     latency_ms: number | null;
     ttft_ms: number | null;
+    tokens_output: number | null;
   };
 
   const rows = db
     .prepare(
       `
-      SELECT provider, model, success, latency_ms, ttft_ms
+      SELECT provider, model, success, latency_ms, ttft_ms, tokens_output
       FROM usage_history
       WHERE timestamp >= @sinceIso
         AND provider IS NOT NULL
@@ -797,6 +800,8 @@ export async function getModelLatencyStats(
       allLatencies: number[];
       successfulTtfts: number[];
       allTtfts: number[];
+      successfulTokensPerSecond: number[];
+      allTokensPerSecond: number[];
     }
   >();
 
@@ -816,6 +821,8 @@ export async function getModelLatencyStats(
         allLatencies: [],
         successfulTtfts: [],
         allTtfts: [],
+        successfulTokensPerSecond: [],
+        allTokensPerSecond: [],
       });
     }
 
@@ -837,6 +844,16 @@ export async function getModelLatencyStats(
       bucket.allTtfts.push(ttft);
       if (isSuccess) bucket.successfulTtfts.push(ttft);
     }
+
+    const outputTokens = toNumber(row.tokens_output);
+    const generationDurationMs = latency - ttft;
+    if (outputTokens > 0 && ttft > 0 && generationDurationMs > 0) {
+      const tokensPerSecond = (outputTokens * 1000) / generationDurationMs;
+      if (Number.isFinite(tokensPerSecond) && tokensPerSecond > 0) {
+        bucket.allTokensPerSecond.push(tokensPerSecond);
+        if (isSuccess) bucket.successfulTokensPerSecond.push(tokensPerSecond);
+      }
+    }
   }
 
   const stats: Record<string, ModelLatencyStatsEntry> = {};
@@ -854,6 +871,10 @@ export async function getModelLatencyStats(
       bucket.totalRequests > 0 ? bucket.successfulRequests / bucket.totalRequests : 0;
     const ttfts =
       bucket.successfulTtfts.length >= minSamples ? bucket.successfulTtfts : bucket.allTtfts;
+    const tokensPerSecond =
+      bucket.successfulTokensPerSecond.length >= minSamples
+        ? bucket.successfulTokensPerSecond
+        : bucket.allTokensPerSecond;
 
     stats[key] = {
       provider: bucket.provider,
@@ -869,6 +890,13 @@ export async function getModelLatencyStats(
       latencyStdDev: Math.round(stdDev(sorted, avg)),
       ...(ttfts.length > 0
         ? { avgTtftMs: Math.round(ttfts.reduce((acc, n) => acc + n, 0) / ttfts.length) }
+        : {}),
+      ...(tokensPerSecond.length > 0
+        ? {
+            avgTokensPerSecond: Number(
+              (tokensPerSecond.reduce((acc, n) => acc + n, 0) / tokensPerSecond.length).toFixed(3)
+            ),
+          }
         : {}),
       windowHours,
     };

--- a/src/lib/usage/usageHistory.ts
+++ b/src/lib/usage/usageHistory.ts
@@ -728,6 +728,8 @@ export interface ModelLatencyStatsEntry {
   provider: string;
   model: string;
   key: string;
+  /** Present when stats were requested with connection-qualified keys. */
+  connectionId?: string;
   totalRequests: number;
   successfulRequests: number;
   successRate: number; // 0..1
@@ -748,7 +750,15 @@ export interface ModelLatencyStatsEntry {
  * Used by auto-combo routing to incorporate real-world latency and reliability.
  */
 export async function getModelLatencyStats(
-  options: { windowHours?: number; minSamples?: number; maxRows?: number } = {}
+  options: {
+    windowHours?: number;
+    minSamples?: number;
+    maxRows?: number;
+    /** Restrict the aggregate to one connection without changing its key shape. */
+    connectionId?: string | null;
+    /** Opt in to `${provider}/${model}/${connectionId}` keys for connection history. */
+    keyByConnectionId?: boolean;
+  } = {}
 ): Promise<Record<string, ModelLatencyStatsEntry>> {
   const windowHours =
     Number.isFinite(Number(options.windowHours)) && Number(options.windowHours) > 0
@@ -769,31 +779,42 @@ export async function getModelLatencyStats(
   type LatencyRow = {
     provider: string | null;
     model: string | null;
+    connection_id: string | null;
     success: number | null;
     latency_ms: number | null;
     ttft_ms: number | null;
     tokens_output: number | null;
   };
 
+  const connectionFilter =
+    typeof options.connectionId === "string" && options.connectionId.length > 0
+      ? " AND connection_id = @connectionId"
+      : "";
   const rows = db
     .prepare(
       `
-      SELECT provider, model, success, latency_ms, ttft_ms, tokens_output
+      SELECT provider, model, connection_id, success, latency_ms, ttft_ms, tokens_output
       FROM usage_history
       WHERE timestamp >= @sinceIso
         AND provider IS NOT NULL
         AND model IS NOT NULL
+        ${connectionFilter}
       ORDER BY timestamp DESC
       LIMIT @maxRows
     `
     )
-    .all({ sinceIso, maxRows }) as LatencyRow[];
+    .all({
+      sinceIso,
+      maxRows,
+      ...(connectionFilter ? { connectionId: options.connectionId } : {}),
+    }) as LatencyRow[];
 
   const grouped = new Map<
     string,
     {
       provider: string;
       model: string;
+      connectionId: string | null;
       totalRequests: number;
       successfulRequests: number;
       successfulLatencies: number[];
@@ -810,11 +831,16 @@ export async function getModelLatencyStats(
     const model = toStringOrNull(row.model);
     if (!provider || !model) continue;
 
-    const key = `${provider}/${model}`;
+    const connectionId = toStringOrNull(row.connection_id);
+    const key =
+      options.keyByConnectionId && connectionId
+        ? `${provider}/${model}/${connectionId}`
+        : `${provider}/${model}`;
     if (!grouped.has(key)) {
       grouped.set(key, {
         provider,
         model,
+        connectionId,
         totalRequests: 0,
         successfulRequests: 0,
         successfulLatencies: [],
@@ -880,6 +906,9 @@ export async function getModelLatencyStats(
       provider: bucket.provider,
       model: bucket.model,
       key,
+      ...(options.keyByConnectionId && bucket.connectionId
+        ? { connectionId: bucket.connectionId }
+        : {}),
       totalRequests: bucket.totalRequests,
       successfulRequests: bucket.successfulRequests,
       successRate,

--- a/tests/unit/build/check-workflows.test.ts
+++ b/tests/unit/build/check-workflows.test.ts
@@ -276,8 +276,8 @@ test("latency-budget: regression comment cannot fail when the report is absent",
     "utf8"
   );
 
-  assert.match(workflow, /printf .*regression-output\.txt/);
-  assert.match(workflow, /fs\.existsSync\(reportPath\)/);
+  assert.match(workflow, /: > regression-output\.txt/);
+  assert.match(workflow, /fs\.existsSync\('regression-output\.txt'\)/);
   assert.match(workflow, /echo "exit=\$exit_code" >> "\$GITHUB_OUTPUT"/);
 });
 

--- a/tests/unit/build/check-workflows.test.ts
+++ b/tests/unit/build/check-workflows.test.ts
@@ -267,6 +267,21 @@ test("evaluateZizmorRatchet: strict integer comparison — any increase regresse
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// latency-budget report artifact
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("latency-budget: regression comment cannot fail when the report is absent", () => {
+  const workflow = fs.readFileSync(
+    path.join(process.cwd(), ".github/workflows/latency-budget.yml"),
+    "utf8"
+  );
+
+  assert.match(workflow, /printf .*regression-output\.txt/);
+  assert.match(workflow, /fs\.existsSync\(reportPath\)/);
+  assert.match(workflow, /echo "exit=\$exit_code" >> "\$GITHUB_OUTPUT"/);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // readBaselineZizmorValue — tolerant read of quality-baseline.json
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/unit/cli-usage.test.ts
+++ b/tests/unit/cli-usage.test.ts
@@ -62,6 +62,27 @@ const HISTORY_DATA = { items: [{ id: "a", model: "gpt-4o", provider: "openai", c
 const PROXY_LOGS_DATA = {
   logs: [{ id: "p1", path: "/v1/chat/completions", method: "POST", status: 200 }],
 };
+const MODEL_LATENCY_DATA = {
+  windowHours: 24,
+  entries: [
+    {
+      provider: "openai",
+      model: "gpt-4o",
+      connectionId: "openai-primary",
+      key: "openai/gpt-4o/openai-primary",
+      totalRequests: 12,
+      successfulRequests: 11,
+      successRate: 11 / 12,
+      avgLatencyMs: 240,
+      avgTtftMs: 120,
+      avgTokensPerSecond: 38.5,
+      p50LatencyMs: 220,
+      p95LatencyMs: 390,
+      p99LatencyMs: 410,
+      latencyStdDev: 35,
+    },
+  ],
+};
 
 function makeResp(data: unknown, status = 200) {
   const obj = {
@@ -79,6 +100,8 @@ function makeResp(data: unknown, status = 200) {
 
 function mockFetch(overrides: Record<string, unknown> = {}) {
   return (url: string) => {
+    if (url.includes("/api/usage/model-latency-stats"))
+      return Promise.resolve(makeResp(overrides.modelLatency ?? MODEL_LATENCY_DATA));
     if (url.includes("/api/usage/analytics"))
       return Promise.resolve(makeResp(overrides.analytics ?? ANALYTICS_DATA));
     if (url.includes("/api/usage/budget"))
@@ -196,6 +219,45 @@ test("runUsageHistory exibe histórico", async () => {
   const parsed = JSON.parse(out);
   assert.ok(Array.isArray(parsed));
   assert.ok(parsed.length >= 1);
+});
+
+test("runUsageModelLatencyStats preserves connection and routing evidence fields", async () => {
+  let capturedUrl = "";
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = ((url: string) => {
+    capturedUrl = url;
+    return mockFetch()(url);
+  }) as any;
+
+  const { runUsageModelLatencyStats } = await import("../../bin/cli/commands/usage.mjs");
+  const cmd = { optsWithGlobals: () => ({ output: "json", quiet: true }) };
+  const out = await captureStdout(() =>
+    runUsageModelLatencyStats(
+      {
+        windowHours: 24,
+        minSamples: 2,
+        maxRows: 500,
+        provider: "openai",
+        model: "gpt-4o",
+        connectionId: "openai-primary",
+      },
+      cmd as any
+    )
+  );
+
+  globalThis.fetch = origFetch;
+  const parsed = JSON.parse(out);
+  assert.ok(capturedUrl.includes("windowHours=24"));
+  assert.ok(capturedUrl.includes("minSamples=2"));
+  assert.ok(capturedUrl.includes("maxRows=500"));
+  assert.ok(capturedUrl.includes("connectionId=openai-primary"));
+  assert.ok(capturedUrl.includes("keyByConnectionId=true"));
+  assert.equal(parsed[0].connectionId, "openai-primary");
+  assert.equal(parsed[0].requests, 12);
+  assert.equal(parsed[0].successfulRequests, 11);
+  assert.equal(parsed[0].avgTtftMs, 120);
+  assert.equal(parsed[0].avgTokensPerSecond, 38.5);
+  assert.equal(parsed[0].p95LatencyMs, 390);
 });
 
 test("runBudgetSet envia POST com amount, scope e period", async () => {

--- a/tests/unit/combo-account-allowlist-3266.test.ts
+++ b/tests/unit/combo-account-allowlist-3266.test.ts
@@ -187,6 +187,101 @@ test("buildAutoCandidates expands dynamic auto steps only within allowedConnecti
   assert.ok(connectionIds.every((connectionId) => !forbidden.has(connectionId!)));
 });
 
+test("buildAutoCandidates prefers connection-qualified history", async () => {
+  const fast = await seedConn("history-fast");
+  const slow = await seedConn("history-slow");
+  await seedLatencyHistory(fast.id, 100, 10);
+  await seedLatencyHistory(slow.id, 900, 10);
+
+  const target = (connectionId: string) => ({
+    kind: "model" as const,
+    stepId: `openai/gpt-4o-mini@${connectionId}`,
+    executionKey: `openai/gpt-4o-mini@${connectionId}`,
+    modelStr: "openai/gpt-4o-mini",
+    provider: "openai",
+    providerId: "openai",
+    connectionId,
+    weight: 1,
+    label: null,
+  });
+
+  const specific = await buildAutoCandidates(
+    [target(fast.id), target(slow.id)],
+    "auto-connection-history"
+  );
+  const specificByConnection = new Map(
+    specific.map((candidate) => [candidate.connectionId, candidate.p95LatencyMs])
+  );
+  assert.equal(specificByConnection.get(fast.id), 100);
+  assert.equal(specificByConnection.get(slow.id), 900);
+  assert.equal(
+    specific.find((candidate) => candidate.connectionId === fast.id)?.historicalRequestCount,
+    10
+  );
+  assert.equal(
+    specific.find((candidate) => candidate.connectionId === fast.id)
+      ?.historicalSuccessfulRequestCount,
+    10
+  );
+});
+
+test("buildAutoCandidates falls back to aggregate history when connection history is undersampled", async () => {
+  const aggregateConn = await seedConn("history-aggregate");
+  const undersampledConn = await seedConn("history-undersampled");
+  await seedLatencyHistory(aggregateConn.id, 300, 10);
+  await seedLatencyHistory(undersampledConn.id, 50, 2);
+
+  const target = (connectionId: string) => ({
+    kind: "model" as const,
+    stepId: `openai/gpt-4o-mini@${connectionId}`,
+    executionKey: `openai/gpt-4o-mini@${connectionId}`,
+    modelStr: "openai/gpt-4o-mini",
+    provider: "openai",
+    providerId: "openai",
+    connectionId,
+    weight: 1,
+    label: null,
+  });
+
+  const fallback = await buildAutoCandidates(
+    [target(aggregateConn.id), target(undersampledConn.id)],
+    "auto-connection-history-fallback"
+  );
+  const fallbackByConnection = new Map(
+    fallback.map((candidate) => [candidate.connectionId, candidate.p95LatencyMs])
+  );
+  assert.equal(fallbackByConnection.get(aggregateConn.id), 300);
+  assert.equal(
+    fallbackByConnection.get(undersampledConn.id),
+    300,
+    "undersampled connection history must use provider/model aggregate history"
+  );
+});
+
+test("buildAutoCandidates leaves confidence count unknown for undersampled fallback", async () => {
+  const connection = await seedConn("history-bootstrap");
+  await seedLatencyHistory(connection.id, 50, 2);
+
+  const [candidate] = await buildAutoCandidates(
+    [
+      {
+        kind: "model",
+        stepId: "openai/gpt-4o-mini",
+        executionKey: "openai/gpt-4o-mini",
+        modelStr: "openai/gpt-4o-mini",
+        provider: "openai",
+        providerId: "openai",
+        connectionId: connection.id,
+        weight: 1,
+        label: null,
+      },
+    ],
+    "auto-connection-history-bootstrap"
+  );
+
+  assert.equal(candidate?.historicalRequestCount, undefined);
+  assert.equal(candidate?.historicalSuccessfulRequestCount, undefined);
+});
 // ── 3. Acceptance: the credential selector never escapes the allowlist ───────
 
 test("getProviderCredentials never selects a connection outside the step allowlist (#3266)", async () => {

--- a/tests/unit/model-latency-stats-route.test.ts
+++ b/tests/unit/model-latency-stats-route.test.ts
@@ -86,12 +86,16 @@ test("filters entries and supports aggregate mode", async () => {
   if (!parsed.success) return;
 
   const response = await route.buildModelLatencyStatsResponse(parsed.data, async () => ({
-    "openai/gpt-4o": { ...CONNECTION_ENTRY, key: "openai/gpt-4o", connectionId: undefined },
-    "anthropic/claude": {
+    [`${"openai"}/${"gpt-4o"}`]: {
+      ...CONNECTION_ENTRY,
+      key: `${"openai"}/${"gpt-4o"}`,
+      connectionId: undefined,
+    },
+    [`${"anthropic"}/${"claude"}`]: {
       ...CONNECTION_ENTRY,
       provider: "anthropic",
-      model: "claude",
-      key: "anthropic/claude",
+      model: `${"claude"}`,
+      key: `${"anthropic"}/${"claude"}`,
       connectionId: undefined,
     },
   }));

--- a/tests/unit/model-latency-stats-route.test.ts
+++ b/tests/unit/model-latency-stats-route.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const route = await import("../../src/app/api/usage/model-latency-stats/route.ts");
+
+const CONNECTION_ENTRY = {
+  provider: "openai",
+  model: "gpt-4o",
+  connectionId: "primary",
+  key: "openai/gpt-4o/primary",
+  totalRequests: 12,
+  successfulRequests: 11,
+  successRate: 11 / 12,
+  avgLatencyMs: 240,
+  avgTtftMs: 120,
+  avgTokensPerSecond: 38.5,
+  p50LatencyMs: 220,
+  p95LatencyMs: 390,
+  p99LatencyMs: 410,
+  latencyStdDev: 35,
+  windowHours: 24,
+};
+
+test("validates and defaults model latency query parameters", () => {
+  const parsed = route.parseModelLatencyStatsQuery(
+    "http://localhost/api/usage/model-latency-stats?provider=openai&connectionId=primary"
+  );
+
+  assert.equal(parsed.success, true);
+  if (!parsed.success) return;
+  assert.equal(parsed.data.windowHours, 24);
+  assert.equal(parsed.data.minSamples, 1);
+  assert.equal(parsed.data.maxRows, 10_000);
+  assert.equal(parsed.data.keyByConnectionId, true);
+  assert.equal(parsed.data.connectionId, "primary");
+});
+
+test("rejects out-of-bounds and invalid query parameters", () => {
+  assert.equal(
+    route.parseModelLatencyStatsQuery(
+      "http://localhost/api/usage/model-latency-stats?windowHours=0"
+    ).success,
+    false
+  );
+  assert.equal(
+    route.parseModelLatencyStatsQuery(
+      "http://localhost/api/usage/model-latency-stats?keyByConnectionId=yes"
+    ).success,
+    false
+  );
+});
+
+test("preserves connection-qualified TTFT, TPS, and evidence fields", async () => {
+  let receivedOptions: unknown;
+  const parsed = route.parseModelLatencyStatsQuery(
+    "http://localhost/api/usage/model-latency-stats?windowHours=6&minSamples=2&connectionId=primary"
+  );
+  assert.equal(parsed.success, true);
+  if (!parsed.success) return;
+
+  const response = await route.buildModelLatencyStatsResponse(parsed.data, async (options) => {
+    receivedOptions = options;
+    return { [CONNECTION_ENTRY.key]: CONNECTION_ENTRY };
+  });
+
+  assert.deepEqual(receivedOptions, {
+    windowHours: 6,
+    minSamples: 2,
+    maxRows: 10_000,
+    connectionId: "primary",
+    keyByConnectionId: true,
+  });
+  assert.equal(response.count, 1);
+  assert.equal(response.entries[0].connectionId, "primary");
+  assert.equal(response.entries[0].totalRequests, 12);
+  assert.equal(response.entries[0].successfulRequests, 11);
+  assert.equal(response.entries[0].avgTtftMs, 120);
+  assert.equal(response.entries[0].avgTokensPerSecond, 38.5);
+});
+
+test("filters entries and supports aggregate mode", async () => {
+  const parsed = route.parseModelLatencyStatsQuery(
+    "http://localhost/api/usage/model-latency-stats?provider=openai&model=gpt-4o&keyByConnectionId=false"
+  );
+  assert.equal(parsed.success, true);
+  if (!parsed.success) return;
+
+  const response = await route.buildModelLatencyStatsResponse(parsed.data, async () => ({
+    "openai/gpt-4o": { ...CONNECTION_ENTRY, key: "openai/gpt-4o", connectionId: undefined },
+    "anthropic/claude": {
+      ...CONNECTION_ENTRY,
+      provider: "anthropic",
+      model: "claude",
+      key: "anthropic/claude",
+      connectionId: undefined,
+    },
+  }));
+
+  assert.equal(response.keyByConnectionId, false);
+  assert.equal(response.count, 1);
+  assert.equal(response.entries[0].key, "openai/gpt-4o");
+});

--- a/tests/unit/router-strategies.test.ts
+++ b/tests/unit/router-strategies.test.ts
@@ -107,6 +107,22 @@ test("latency — uses TTFT, TPS, and E2E metrics to pick the fastest provider-m
   assert.match(decision.reason, /tps=120/);
 });
 
+test("latency — TPS breaks an otherwise comparable latency tie", () => {
+  const pool = [
+    cand({ provider: "slower-generation", avgTokensPerSecond: 40 }),
+    cand({ provider: "faster-generation", avgTokensPerSecond: 80 }),
+  ];
+  assert.equal(getStrategy("latency").select(pool, ctx).provider, "faster-generation");
+});
+
+test("latency — nonpositive or malformed TPS evidence cannot manufacture a score", () => {
+  const pool = [
+    cand({ provider: "invalid-evidence", avgTokensPerSecond: Number.NaN }),
+    cand({ provider: "known-latency", p95LatencyMs: 90 }),
+  ];
+  assert.equal(getStrategy("latency").select(pool, ctx).provider, "known-latency");
+});
+
 test("latency — historical TTFT/E2E evidence can change the selected candidate", () => {
   const pool = [
     cand({ provider: "low-p95", p95LatencyMs: 100 }),

--- a/tests/unit/router-strategies.test.ts
+++ b/tests/unit/router-strategies.test.ts
@@ -71,6 +71,44 @@ test("latency — selects the lowest p95 candidate", () => {
   assert.equal(getStrategy("latency").select(pool, ctx).provider, "fast");
 });
 
+test("latency — sparse evidence cannot outrank mature evidence", () => {
+  const pool = [
+    cand({
+      provider: "sparse-fast",
+      p95LatencyMs: 50,
+      avgTtftMs: 20,
+      avgE2ELatencyMs: 200,
+      avgTokensPerSecond: 200,
+      historicalRequestCount: 3,
+    }),
+    cand({
+      provider: "mature-steady",
+      p95LatencyMs: 300,
+      avgTtftMs: 100,
+      avgE2ELatencyMs: 600,
+      avgTokensPerSecond: 80,
+      historicalRequestCount: 10,
+    }),
+  ];
+  assert.equal(getStrategy("latency").select(pool, ctx).provider, "mature-steady");
+});
+
+test("latency — missing or malformed evidence counts remain unknown", () => {
+  const base = [
+    cand({ provider: "fast", p95LatencyMs: 100 }),
+    cand({ provider: "slow", p95LatencyMs: 300 }),
+  ];
+  const baseline = getStrategy("latency").select(base, ctx);
+  const withUnknownCounts = getStrategy("latency").select(
+    [
+      cand({ provider: "fast", p95LatencyMs: 100, historicalRequestCount: Number.NaN }),
+      cand({ provider: "slow", p95LatencyMs: 300, historicalRequestCount: 0 }),
+    ],
+    ctx
+  );
+  assert.equal(withUnknownCounts.provider, baseline.provider);
+});
+
 test("latency — error rate penalizes a fast-but-flaky candidate", () => {
   // flaky: 100ms + 0.5*1000 = 600 effective; steady: 400ms + 0 = 400 → steady wins.
   const pool = [

--- a/tests/unit/router-strategies.test.ts
+++ b/tests/unit/router-strategies.test.ts
@@ -125,7 +125,12 @@ test("latency — nonpositive or malformed TPS evidence cannot manufacture a sco
 
 test("latency — historical TTFT/E2E evidence can change the selected candidate", () => {
   const pool = [
-    cand({ provider: "low-p95", p95LatencyMs: 100 }),
+    cand({
+      provider: "low-p95",
+      p95LatencyMs: 100,
+      avgTtftMs: 140,
+      avgE2ELatencyMs: 800,
+    }),
     cand({
       provider: "historically-fast-stream",
       p95LatencyMs: 200,

--- a/tests/unit/router-strategies.test.ts
+++ b/tests/unit/router-strategies.test.ts
@@ -107,6 +107,30 @@ test("latency — uses TTFT, TPS, and E2E metrics to pick the fastest provider-m
   assert.match(decision.reason, /tps=120/);
 });
 
+test("latency — historical TTFT/E2E evidence can change the selected candidate", () => {
+  const pool = [
+    cand({ provider: "low-p95", p95LatencyMs: 100 }),
+    cand({
+      provider: "historically-fast-stream",
+      p95LatencyMs: 200,
+      avgTtftMs: 30,
+      avgE2ELatencyMs: 300,
+      latencyStdDev: 10,
+    }),
+  ];
+
+  assert.equal(getStrategy("latency").select(pool, ctx).provider, "historically-fast-stream");
+});
+
+test("latency — zero or missing TTFT has no false fast advantage", () => {
+  const pool = [
+    cand({ provider: "zero-ttft", p95LatencyMs: 300, avgTtftMs: 0 }),
+    cand({ provider: "known-ttft", p95LatencyMs: 200, avgTtftMs: 100 }),
+  ];
+
+  assert.equal(getStrategy("latency").select(pool, ctx).provider, "known-ttft");
+});
+
 test("latency — failure rate can outweigh excellent raw speed", () => {
   const pool = [
     cand({

--- a/tests/unit/stream-utils.test.ts
+++ b/tests/unit/stream-utils.test.ts
@@ -55,6 +55,41 @@ async function readWithTransform(chunks, transformStream) {
   return new Response(source.pipeThrough(transformStream)).text();
 }
 
+test("createSSEStream captures positive TTFT from the first emitted token", async () => {
+  let completion;
+  await readTransformed(
+    [`data: ${JSON.stringify({ choices: [{ delta: { content: "hello" } }] })}\n\n`],
+    {
+      mode: "passthrough",
+      sourceFormat: FORMATS.OPENAI,
+      requestStartedAt: Date.now() - 25,
+      onComplete(payload) {
+        completion = payload;
+      },
+    }
+  );
+
+  assert.ok(completion.ttft > 0);
+  assert.ok(completion.ttft <= 1000);
+});
+
+test("createSSEStream leaves TTFT unset when the stream has no token", async () => {
+  let completion;
+  await readTransformed(
+    [`data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] })}\n\n`],
+    {
+      mode: "passthrough",
+      sourceFormat: FORMATS.OPENAI,
+      requestStartedAt: Date.now() - 25,
+      onComplete(payload) {
+        completion = payload;
+      },
+    }
+  );
+
+  assert.equal(completion.ttft, null);
+});
+
 function multilineDataEvent(payload, splitBeforeKey) {
   const json = JSON.stringify(payload);
   const splitAt = json.indexOf(`"${splitBeforeKey}"`) - 1;

--- a/tests/unit/usage-analytics.test.ts
+++ b/tests/unit/usage-analytics.test.ts
@@ -175,6 +175,45 @@ test("getModelLatencyStats omits unavailable TTFT instead of treating zero as fa
   assert.equal("avgTtftMs" in stats["no-ttft-provider/no-ttft-model"], false);
 });
 
+test("getModelLatencyStats derives TPS only from valid output, TTFT, and generation duration", async () => {
+  const validSamples = [
+    { output: 100, latency: 1_000, ttft: 200 },
+    { output: 200, latency: 2_000, ttft: 500 },
+  ];
+  for (const [index, sample] of validSamples.entries()) {
+    await usageHistory.saveRequestUsage({
+      provider: "tps-provider",
+      model: "tps-model",
+      success: true,
+      tokens: { output: sample.output },
+      latencyMs: sample.latency,
+      timeToFirstTokenMs: sample.ttft,
+      timestamp: new Date(Date.now() - index * 60 * 1000).toISOString(),
+    });
+  }
+
+  for (const [index, sample] of [
+    { output: "not-a-number", latency: 1_000, ttft: 200 },
+    { output: -5, latency: 1_000, ttft: 200 },
+    { output: 100, latency: 1_000, ttft: 0 },
+    { output: 100, latency: 200, ttft: 300 },
+  ].entries()) {
+    await usageHistory.saveRequestUsage({
+      provider: "invalid-tps-provider",
+      model: "invalid-tps-model",
+      success: true,
+      tokens: { output: sample.output },
+      latencyMs: sample.latency,
+      timeToFirstTokenMs: sample.ttft,
+      timestamp: new Date(Date.now() - index * 60 * 1000).toISOString(),
+    });
+  }
+
+  const stats = await usageHistory.getModelLatencyStats({ windowHours: 1, minSamples: 2 });
+  assert.equal(stats["tps-provider/tps-model"].avgTokensPerSecond, 129.167);
+  assert.equal("avgTokensPerSecond" in stats["invalid-tps-provider/invalid-tps-model"], false);
+});
+
 test("getModelLatencyStats falls back to all latencies when successful sample count is too small", async () => {
   await usageHistory.saveRequestUsage({
     provider: "fallback-provider",

--- a/tests/unit/usage-analytics.test.ts
+++ b/tests/unit/usage-analytics.test.ts
@@ -159,6 +159,46 @@ test("getModelLatencyStats aggregates success rate and latency percentiles", asy
   assert.equal(entry.avgTtftMs, 47);
 });
 
+test("getModelLatencyStats can return connection-qualified buckets without changing aggregate keys", async () => {
+  const now = Date.now();
+  for (const [connectionId, latency] of [
+    ["latency-connection-a", 100],
+    ["latency-connection-b", 900],
+  ] as const) {
+    for (let index = 0; index < 2; index++) {
+      await usageHistory.saveRequestUsage({
+        provider: "qualified-provider",
+        model: "qualified-model",
+        connectionId,
+        success: true,
+        latencyMs: latency,
+        timestamp: new Date(now - index * 60 * 1000).toISOString(),
+      });
+    }
+  }
+
+  const aggregate = await usageHistory.getModelLatencyStats({ windowHours: 1, minSamples: 2 });
+  const qualified = await usageHistory.getModelLatencyStats({
+    windowHours: 1,
+    minSamples: 2,
+    keyByConnectionId: true,
+  });
+
+  assert.equal(aggregate["qualified-provider/qualified-model"].p95LatencyMs, 900);
+  assert.equal(
+    qualified["qualified-provider/qualified-model/latency-connection-a"].p95LatencyMs,
+    100
+  );
+  assert.equal(
+    qualified["qualified-provider/qualified-model/latency-connection-b"].p95LatencyMs,
+    900
+  );
+  assert.equal(
+    qualified["qualified-provider/qualified-model/latency-connection-a"].connectionId,
+    "latency-connection-a"
+  );
+});
+
 test("getModelLatencyStats omits unavailable TTFT instead of treating zero as fast", async () => {
   for (const [index, ttft] of [0, -10].entries()) {
     await usageHistory.saveRequestUsage({

--- a/tests/unit/usage-analytics.test.ts
+++ b/tests/unit/usage-analytics.test.ts
@@ -123,10 +123,10 @@ test("usage history persists entries and supports filtering and usageDb compatib
 test("getModelLatencyStats aggregates success rate and latency percentiles", async () => {
   const now = Date.now();
   const entries = [
-    { latencyMs: 100, success: true },
-    { latencyMs: 200, success: true },
-    { latencyMs: 400, success: true },
-    { latencyMs: 900, success: false },
+    { latencyMs: 100, timeToFirstTokenMs: 20, success: true },
+    { latencyMs: 200, timeToFirstTokenMs: 40, success: true },
+    { latencyMs: 400, timeToFirstTokenMs: 80, success: true },
+    { latencyMs: 900, timeToFirstTokenMs: 0, success: false },
   ];
 
   for (const [index, entry] of entries.entries()) {
@@ -135,6 +135,7 @@ test("getModelLatencyStats aggregates success rate and latency percentiles", asy
       model: "latency-model",
       success: entry.success,
       latencyMs: entry.latencyMs,
+      timeToFirstTokenMs: entry.timeToFirstTokenMs,
       timestamp: new Date(now - index * 60 * 1000).toISOString(),
     });
   }
@@ -155,6 +156,23 @@ test("getModelLatencyStats aggregates success rate and latency percentiles", asy
   assert.equal(entry.p95LatencyMs, 400);
   assert.equal(entry.p99LatencyMs, 400);
   assert.ok(entry.latencyStdDev > 0);
+  assert.equal(entry.avgTtftMs, 47);
+});
+
+test("getModelLatencyStats omits unavailable TTFT instead of treating zero as fast", async () => {
+  for (const [index, ttft] of [0, -10].entries()) {
+    await usageHistory.saveRequestUsage({
+      provider: "no-ttft-provider",
+      model: "no-ttft-model",
+      success: true,
+      latencyMs: 200 + index,
+      timeToFirstTokenMs: ttft,
+      timestamp: new Date(Date.now() - index * 60 * 1000).toISOString(),
+    });
+  }
+
+  const stats = await usageHistory.getModelLatencyStats({ windowHours: 1, minSamples: 2 });
+  assert.equal("avgTtftMs" in stats["no-ttft-provider/no-ttft-model"], false);
 });
 
 test("getModelLatencyStats falls back to all latencies when successful sample count is too small", async () => {


### PR DESCRIPTION
## Summary\n- feed persisted E2E and valid TTFT evidence into existing auto-router latency candidates\n- avoid treating missing or nonpositive TTFT as a speed signal\n- add focused router and usage-history regression coverage\n\n## Validation\n- git diff --check and formatting passed in the isolated worktree\n- focused runtime tests require dependencies unavailable in that worktree; CI should run the affected tests\n\nThis is a narrow first slice on top of the existing latency strategy, not a new routing framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `model-latency-stats` API and `usage model-latency-stats` CLI command, including connection/aggregate modes plus TTFT and tokens-per-second metrics.
  * Improved latency-based auto-selection using connection-scoped history with evidence confidence.
  * Added Petals base URL/model configuration support.
* **Bug Fixes**
  * Fixed streaming transform wiring and improved TTFT capture for passthrough/translated streams.
  * Added CORS preflight handling for auth and keys endpoints.
* **Documentation**
  * Updated security guide titles/front-matter and replaced journey rich-media embeds with capture stubs/instructions.
* **Tests**
  * Expanded unit coverage for latency stats, routing scoring, TTFT streaming, and workflow resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->