### PR TITLE
refactor(bff): clean replay of time-series clock helper (#339)

### DIFF
--- a/apps/bff/src/routes/timeSeries.test.ts
+++ b/apps/bff/src/routes/timeSeries.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildKeyUsageSeries,
+  buildObservabilityLatencySeries,
+  buildTimeSeries,
+} from "./timeSeries";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildTimeSeries", () => {
+  it("captures the clock once and preserves count, order, spacing, and mapped values", () => {
+    const now = vi.fn(() => Date.UTC(2026, 6, 14, 12));
+
+    const points = buildTimeSeries({
+      count: 3,
+      stepMs: 60_000,
+      now,
+      mapPoint: (index, timestampMs) => ({ index, timestampMs, value: index * 10 }),
+    });
+
+    expect(now).toHaveBeenCalledTimes(1);
+    expect(points).toEqual([
+      { index: 0, timestampMs: Date.UTC(2026, 6, 14, 11, 58), value: 0 },
+      { index: 1, timestampMs: Date.UTC(2026, 6, 14, 11, 59), value: 10 },
+      { index: 2, timestampMs: Date.UTC(2026, 6, 14, 12), value: 20 },
+    ]);
+  });
+
+  it("supports a trailing offset while retaining uniform spacing", () => {
+    const points = buildTimeSeries({
+      count: 2,
+      stepMs: 1_000,
+      now: () => 10_000,
+      endOffsetSteps: 1,
+      mapPoint: (_, timestampMs) => timestampMs,
+    });
+
+    expect(points).toEqual([8_000, 9_000]);
+  });
+});
+
+describe("dashboard time-series builders", () => {
+  it("preserves the observability response shape and captures its clock once", () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 6, 14, 12));
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const points = buildObservabilityLatencySeries();
+
+    expect(now).toHaveBeenCalledTimes(1);
+    expect(random).toHaveBeenCalledTimes(60);
+    expect(points).toHaveLength(60);
+    expect(points[0]).toEqual({
+      ts: new Date(Date.UTC(2026, 6, 14, 11)).toISOString(),
+      latency: 500,
+    });
+    expect(points[59]).toEqual({
+      ts: new Date(Date.UTC(2026, 6, 14, 11, 59)).toISOString(),
+      latency: 500,
+    });
+  });
+
+  it("preserves the key-usage response shape and captures its clock once", () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 6, 14, 12));
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const usage = buildKeyUsageSeries();
+
+    expect(now).toHaveBeenCalledTimes(1);
+    expect(random).toHaveBeenCalledTimes(30);
+    expect(usage).toHaveLength(30);
+    expect(usage[0]).toEqual({ date: "2026-06-15", requests: 500 });
+    expect(usage[29]).toEqual({ date: "2026-07-14", requests: 500 });
+  });
+});

--- a/apps/bff/src/routes/timeSeries.ts
+++ b/apps/bff/src/routes/timeSeries.ts
@@ -32,8 +32,15 @@ export type KeyUsagePoint = {
   requests: number;
 };
 
+function secureRandomUnit(): number {
+  return crypto.getRandomValues(new Uint32Array(1))[0] / 4_294_967_296;
+}
+
 /** 60 one-minute latency points; trailing offset matches legacy dashboard semantics. */
-export function buildObservabilityLatencySeries(now: () => number = Date.now): ObservabilityTimeseriesPoint[] {
+export function buildObservabilityLatencySeries(
+  now: () => number = Date.now,
+  random: () => number = secureRandomUnit,
+): ObservabilityTimeseriesPoint[] {
   return buildTimeSeries({
     count: 60,
     stepMs: 60_000,
@@ -41,20 +48,23 @@ export function buildObservabilityLatencySeries(now: () => number = Date.now): O
     endOffsetSteps: 1,
     mapPoint: (_, timestampMs) => ({
       ts: new Date(timestampMs).toISOString(),
-      latency: 100 + Math.random() * 800,
+      latency: 100 + random() * 800,
     }),
   });
 }
 
 /** 30 one-day usage points. */
-export function buildKeyUsageSeries(now: () => number = Date.now): KeyUsagePoint[] {
+export function buildKeyUsageSeries(
+  now: () => number = Date.now,
+  random: () => number = secureRandomUnit,
+): KeyUsagePoint[] {
   return buildTimeSeries({
     count: 30,
     stepMs: 86_400_000,
     now,
     mapPoint: (_, timestampMs) => ({
       date: new Date(timestampMs).toISOString().slice(0, 10),
-      requests: Math.floor(Math.random() * 1000),
+      requests: Math.floor(random() * 1000),
     }),
   });
 }

--- a/apps/bff/src/routes/timeSeries.ts
+++ b/apps/bff/src/routes/timeSeries.ts
@@ -1,3 +1,5 @@
+import { randomInt } from "node:crypto";
+
 export type TimeSeriesOptions<T> = {
   count: number;
   stepMs: number;
@@ -36,6 +38,10 @@ function secureRandomUnit(): number {
   return crypto.getRandomValues(new Uint32Array(1))[0] / 4_294_967_296;
 }
 
+function secureRandomRequestCount(): number {
+  return randomInt(1_000);
+}
+
 /** 60 one-minute latency points; trailing offset matches legacy dashboard semantics. */
 export function buildObservabilityLatencySeries(
   now: () => number = Date.now,
@@ -56,7 +62,7 @@ export function buildObservabilityLatencySeries(
 /** 30 one-day usage points. */
 export function buildKeyUsageSeries(
   now: () => number = Date.now,
-  random: () => number = secureRandomUnit,
+  randomRequestCount: () => number = secureRandomRequestCount,
 ): KeyUsagePoint[] {
   return buildTimeSeries({
     count: 30,
@@ -64,7 +70,7 @@ export function buildKeyUsageSeries(
     now,
     mapPoint: (_, timestampMs) => ({
       date: new Date(timestampMs).toISOString().slice(0, 10),
-      requests: Math.floor(random() * 1000),
+      requests: randomRequestCount(),
     }),
   });
 }

--- a/apps/bff/src/routes/timeSeries.ts
+++ b/apps/bff/src/routes/timeSeries.ts
@@ -1,0 +1,60 @@
+export type TimeSeriesOptions<T> = {
+  count: number;
+  stepMs: number;
+  now: () => number;
+  mapPoint: (index: number, timestampMs: number) => T;
+  endOffsetSteps?: number;
+};
+
+/** Build ascending time-series points from a single captured clock reading. */
+export function buildTimeSeries<T>({
+  count,
+  stepMs,
+  now,
+  mapPoint,
+  endOffsetSteps = 0,
+}: TimeSeriesOptions<T>): T[] {
+  const nowMs = now();
+
+  return Array.from({ length: count }, (_, index) => {
+    const stepsFromNow = count - 1 - index + endOffsetSteps;
+    return mapPoint(index, nowMs - stepsFromNow * stepMs);
+  });
+}
+
+export type ObservabilityTimeseriesPoint = {
+  ts: string;
+  latency: number;
+};
+
+export type KeyUsagePoint = {
+  date: string;
+  requests: number;
+};
+
+/** 60 one-minute latency points; trailing offset matches legacy dashboard semantics. */
+export function buildObservabilityLatencySeries(now: () => number = Date.now): ObservabilityTimeseriesPoint[] {
+  return buildTimeSeries({
+    count: 60,
+    stepMs: 60_000,
+    now,
+    endOffsetSteps: 1,
+    mapPoint: (_, timestampMs) => ({
+      ts: new Date(timestampMs).toISOString(),
+      latency: 100 + Math.random() * 800,
+    }),
+  });
+}
+
+/** 30 one-day usage points. */
+export function buildKeyUsageSeries(now: () => number = Date.now): KeyUsagePoint[] {
+  return buildTimeSeries({
+    count: 30,
+    stepMs: 86_400_000,
+    now,
+    mapPoint: (_, timestampMs) => ({
+      date: new Date(timestampMs).toISOString().slice(0, 10),
+      requests: Math.floor(Math.random() * 1000),
+    }),
+  });
+}

--- a/apps/bff/tests/unit/routes/timeSeries.test.ts
+++ b/apps/bff/tests/unit/routes/timeSeries.test.ts
@@ -4,7 +4,7 @@ import {
   buildKeyUsageSeries,
   buildObservabilityLatencySeries,
   buildTimeSeries,
-} from "./timeSeries";
+} from "../../../src/routes/timeSeries";
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/apps/bff/tests/unit/routes/timeSeries.test.ts
+++ b/apps/bff/tests/unit/routes/timeSeries.test.ts
@@ -44,10 +44,10 @@ describe("buildTimeSeries", () => {
 
 describe("dashboard time-series builders", () => {
   it("preserves the observability response shape and captures its clock once", () => {
-    const now = vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 6, 14, 12));
-    const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const now = vi.fn(() => Date.UTC(2026, 6, 14, 12));
+    const random = vi.fn(() => 0.5);
 
-    const points = buildObservabilityLatencySeries();
+    const points = buildObservabilityLatencySeries(now, random);
 
     expect(now).toHaveBeenCalledTimes(1);
     expect(random).toHaveBeenCalledTimes(60);
@@ -63,10 +63,10 @@ describe("dashboard time-series builders", () => {
   });
 
   it("preserves the key-usage response shape and captures its clock once", () => {
-    const now = vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 6, 14, 12));
-    const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const now = vi.fn(() => Date.UTC(2026, 6, 14, 12));
+    const random = vi.fn(() => 0.5);
 
-    const usage = buildKeyUsageSeries();
+    const usage = buildKeyUsageSeries(now, random);
 
     expect(now).toHaveBeenCalledTimes(1);
     expect(random).toHaveBeenCalledTimes(30);

--- a/apps/bff/tests/unit/routes/timeSeries.test.ts
+++ b/apps/bff/tests/unit/routes/timeSeries.test.ts
@@ -64,12 +64,12 @@ describe("dashboard time-series builders", () => {
 
   it("preserves the key-usage response shape and captures its clock once", () => {
     const now = vi.fn(() => Date.UTC(2026, 6, 14, 12));
-    const random = vi.fn(() => 0.5);
+    const randomRequestCount = vi.fn(() => 500);
 
-    const usage = buildKeyUsageSeries(now, random);
+    const usage = buildKeyUsageSeries(now, randomRequestCount);
 
     expect(now).toHaveBeenCalledTimes(1);
-    expect(random).toHaveBeenCalledTimes(30);
+    expect(randomRequestCount).toHaveBeenCalledTimes(30);
     expect(usage).toHaveLength(30);
     expect(usage[0]).toEqual({ date: "2026-06-15", requests: 500 });
     expect(usage[29]).toEqual({ date: "2026-07-14", requests: 500 });

--- a/apps/bff/vitest.config.ts
+++ b/apps/bff/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- Replay the single intended #375 feature commit onto the restored v4 baseline merged by #380.
- Add a pure `buildTimeSeries` helper with one injected clock capture and optional trailing offset.
- Add observability-latency and key-usage builders preserving legacy count, order, spacing, and value shapes.
- Use Web Crypto for unit samples and unbiased `randomInt` for bounded request counts, with injectable deterministic test seams.
- Place the unit test under `apps/bff/tests/unit` and extend Vitest discovery per repository policy.
- Keep dashboard routes honesty-first (`unavailable`) until #368 has a runtime aggregation source.

## Provenance
- Supersedes orphaned draft #375, whose 1,442-file diff was branch-lineage noise.
- Replayed source commit: `1ee5df63cddce0bdbcff981b691ce2c0a6affc7a`.
- Actual diff: 3 files, 154 insertions, 1 deletion (helper, tests, and one-line test-discovery update).

## Validation
- Existing BFF suite: 56 tests pass.
- Relocated time-series suite: 4 tests pass.
- `bun run typecheck`: pass.
- `bun run build`: pass.

Closes #339.