### PR TITLE
docs(plan): publish v4-to-Rust parity baseline

### DIFF
--- a/plans/2026-07-17-proc2-wbs-pert-dag.md
+++ b/plans/2026-07-17-proc2-wbs-pert-dag.md
@@ -38,9 +38,9 @@ P0-L1 → P0-L2 → P1-L1 → P1-L2 → P1-L5 → P4-R1
 | P1-L2 | Accept ADR-107 staged v4-to-Rust convergence | P1-L1 | `[x]` |
 | P1-L3 | Refresh omni-evolve snapshot and add convergence stream | P1-L2 | `[ ]` |
 | P1-L4 | Inventory and verify the last coherent v4 commit range | P1-L2 | `[x]` |
-| P1-L5 | Restore BFF/web without reverting Rust or Argis absorbs | P1-L4 | `[/]` PR #380 merge-ready under RC-A9 waiver |
-| P1-L6 | Rebase or supersede #339, #340, and PR #375 | P1-L5 | `[ ]` |
-| P1-L7 | Publish v4-to-Rust feature-parity matrix and owners | P1-L4 | `[ ]` |
+| P1-L5 | Restore BFF/web without reverting Rust or Argis absorbs | P1-L4 | `[x]` merged via PR #380 |
+| P1-L6 | Rebase or supersede #339, #340, and PR #375 | P1-L5 | `[/]` #339/#375 complete via PR #382; closed #342 source commit verified for #340 replay |
+| P1-L7 | Publish v4-to-Rust feature-parity matrix and owners | P1-L4 | `[/]` drafted in `2026-07-18-v4-rust-feature-parity-matrix.md` |
 
 ## P2 — Hygiene (parallel)
 
@@ -104,7 +104,7 @@ flowchart TD
 
 ## Next-two queue
 
-1. **P1-L5:** land the bounded v4 compatibility recovery PR.
+1. **P1-L6:** cleanly replay #340 source commit `51d39d911` from closed PR #342.
 2. **P1-L7:** publish the first v4-to-Rust capability-parity matrix.
 
 ## Update rule

--- a/plans/2026-07-17-proc2-wbs-pert-dag.md
+++ b/plans/2026-07-17-proc2-wbs-pert-dag.md
@@ -40,7 +40,7 @@ P0-L1 → P0-L2 → P1-L1 → P1-L2 → P1-L5 → P4-R1
 | P1-L4 | Inventory and verify the last coherent v4 commit range | P1-L2 | `[x]` |
 | P1-L5 | Restore BFF/web without reverting Rust or Argis absorbs | P1-L4 | `[x]` merged via PR #380 |
 | P1-L6 | Rebase or supersede #339, #340, and PR #375 | P1-L5 | `[/]` #339/#375 complete via PR #382; closed #342 source commit verified for #340 replay |
-| P1-L7 | Publish v4-to-Rust feature-parity matrix and owners | P1-L4 | `[/]` drafted in `2026-07-18-v4-rust-feature-parity-matrix.md` |
+| P1-L7 | Publish v4-to-Rust feature-parity matrix and owners | P1-L4 | `[/]` in review via PR #389 |
 
 ## P2 — Hygiene (parallel)
 

--- a/plans/2026-07-17-proc2-wbs-pert-dag.md
+++ b/plans/2026-07-17-proc2-wbs-pert-dag.md
@@ -40,7 +40,7 @@ P0-L1 → P0-L2 → P1-L1 → P1-L2 → P1-L5 → P4-R1
 | P1-L4 | Inventory and verify the last coherent v4 commit range | P1-L2 | `[x]` |
 | P1-L5 | Restore BFF/web without reverting Rust or Argis absorbs | P1-L4 | `[x]` merged via PR #380 |
 | P1-L6 | Rebase or supersede #339, #340, and PR #375 | P1-L5 | `[/]` #339/#375 complete via PR #382; closed #342 source commit verified for #340 replay |
-| P1-L7 | Publish v4-to-Rust feature-parity matrix and owners | P1-L4 | `[/]` in review via PR #389 |
+| P1-L7 | Publish v4-to-Rust feature-parity matrix and owners | P1-L4 | `[x]` published in `2026-07-18-v4-rust-feature-parity-matrix.md` |
 
 ## P2 — Hygiene (parallel)
 
@@ -72,6 +72,9 @@ P0-L1 → P0-L2 → P1-L1 → P1-L2 → P1-L5 → P4-R1
 | P4-R3 | Delegate router to core registry | 2 d | P4-R2 |
 | P4-R4 | Implement CLI `serve` and `migrate` commands | 2 d | P4-R2 |
 | P4-R5 | Add Linux Rust CI matrix | 0.5 d | P0-L2 |
+| P4-R6 | Implement keys/auth API | 2 d | P4-R2 |
+| P4-R7 | Implement measured observability | 3 d | P4-R3 |
+| P4-R8 | Implement audit and webhook persistence/API | 2 d | P4-R2 |
 
 ## DAG
 
@@ -97,6 +100,10 @@ flowchart TD
   CRUD --> API
   API --> ROUTER[P4-R3 router]
   API --> CLI[P4-R4 CLI]
+  M376 --> RUSTCI[P4-R5 Linux Rust CI]
+  API --> AUTH[P4-R6 keys/auth]
+  ROUTER --> OBS[P4-R7 observability]
+  API --> AUDIT[P4-R8 audit/webhooks]
 
   CLOSE320[P2-L1 close #320]
   BFF --> NOTE375[P2-L2 update #375]
@@ -105,7 +112,7 @@ flowchart TD
 ## Next-two queue
 
 1. **P1-L6:** cleanly replay #340 source commit `51d39d911` from closed PR #342.
-2. **P1-L7:** publish the first v4-to-Rust capability-parity matrix.
+2. **P4-R1:** implement provider repository CRUD.
 
 ## Update rule
 

--- a/plans/2026-07-17-v4-recovery-spec.md
+++ b/plans/2026-07-17-v4-recovery-spec.md
@@ -2,7 +2,7 @@
 
 **ADR:** ADR-107 staged convergence  
 **WBS:** P1-L4 → P1-L5 → P1-L6  
-**Status:** Recovery verified and merge-ready in PR #380 under RC-A9 waiver
+**Status:** Recovery merged via PR #380; clean #375 replay merged via PR #382
 
 ## Source of truth
 
@@ -82,8 +82,9 @@ Do not restore:
 - [x] Sonar security findings use cryptographic IDs and canonical allowlisted
   benchmark egress targets; residual scanner false positives are narrowly
   documented and the final quality gate passes.
-- [ ] PR #375 has a conflict-free replay plan.
-- [ ] #339 and #340 point to canonical restored paths.
+- [x] PR #375 is superseded by conflict-free replay PR #382.
+- [x] #339 points to the canonical restored path through merged PR #382.
+- [ ] #340 points to canonical restored paths; closed draft #342 requires a clean replay.
 - [x] Recovery can be reverted with one PR without affecting later Rust work.
 
 ## Rollback

--- a/plans/2026-07-18-v4-rust-feature-parity-matrix.md
+++ b/plans/2026-07-18-v4-rust-feature-parity-matrix.md
@@ -1,0 +1,88 @@
+# v4-to-Rust Feature-Parity Matrix
+
+**ADR:** ADR-107 staged convergence  
+**WBS:** P1-L7 → P4-R1…P4-R5  
+**Evidence cutoff:** `main` at `4c19697ad` (PR #382)  
+**Status:** Initial owner and dependency baseline
+
+## Decision boundary
+
+The restored Svelte/Hono stack remains the compatibility shell while Rust
+capabilities become real behind stable contracts. A page, schema, empty array,
+echo response, or `unavailable` response is not runtime parity. Rust parity
+requires an exercised API path backed by a real adapter or repository.
+
+Status legend:
+
+- **Live** — exercised implementation exists.
+- **Partial** — useful implementation exists but is not wired end to end.
+- **Contract** — types, UI, schema, or honesty-first placeholder only.
+- **Scaffold** — crate/module compiles but contains no production behavior.
+- **Absent** — no canonical implementation found.
+
+## Capability matrix
+
+| ID | Capability | Restored v4 state and evidence | Rust state and evidence | Target owner | Next acceptance gate |
+|---|---|---|---|---|---|
+| CAP-01 | OpenAI-compatible request and streaming gateway | **Live/partial.** `apps/bff/src/routes/proxy.ts` streams to `OMNIROUTE_UPSTREAM`; canonical provider execution still lives outside the restored BFF. | **Contract/scaffold.** Wire types exist in `omniroute-core`; `omniroute-api`, `omniroute-providers`, `omniroute-router`, and `omniroute-bifrost` are scaffolds. | `omniroute-api` + `omniroute-providers` + `omniroute-router` | One OpenAI-compatible chat request streams through Axum, router, and a provider adapter with cancellation and error mapping tests. |
+| CAP-02 | Provider configuration and CRUD | **Contract.** `/api/dashboard/providers` returns an empty list and POST echoes validated input in `apps/bff/src/routes/dashboard.ts`; web UI exists. | **Partial.** Provider schema exists, but `omniroute-storage/src/provider.rs` is a constructor-only scaffold. | `omniroute-storage` (P4-R1), then `omniroute-api` | Repository create/get/list/update/delete tests pass against in-memory SQLite; API contract tests expose them without fabricated success. |
+| CAP-03 | Combos, fallback, and routing policy | **Contract.** Combo UI and schema exist; combo POST fails honestly with `no-combo-store`. | **Partial.** Core combo/routing types and `ComboRepo` CRUD exist; `omniroute-router` is a scaffold. | `omniroute-router` + `omniroute-storage` | Router resolves an enabled combo from `ComboRepo`, executes ordered fallback, and records the selected provider. |
+| CAP-04 | API keys and request authentication | **Partial.** BFF production middleware protects bounded routes, while dashboard key create/revoke/read remains `no-key-store`. | **Partial.** Core key/auth types and `ApiKeyRepo` get/list/insert/revoke operations exist; no API wiring exists. | `omniroute-api` + `omniroute-storage` | Hashed-key authentication and create/list/revoke endpoints pass scope, expiry, and revocation tests. |
+| CAP-05 | Login, sessions, profile, and SSO | **Contract/proxy.** `/api/auth` is forwarded upstream; session and SSO dashboard surfaces are placeholders. | **Contract.** Users/sessions tables and auth domain types exist; repositories and handlers are absent. | `omniroute-api` + `omniroute-storage` | Login/session lifecycle is explicitly delegated or implemented; no local endpoint reports success without durable state. |
+| CAP-06 | Request logs, usage, cost, and observability | **Contract.** Overview and time-series routes return `no-runtime-aggregation`; usage/cost lists are empty. | **Partial.** `RequestLogRepo` inserts and queries logs; usage repository is ping-only and no aggregation API exists. | `omniroute-storage` + `omniroute-api` | Request execution writes one log; p50/p95/p99, usage, model, and provider rollups derive from stored data with fixed-clock tests. |
+| CAP-07 | Audit, config history, and webhooks | **Contract.** Audit/webhook lists are empty and export returns `no-audit-export-store`. | **Partial/contract.** Tables exist; audit and webhook repositories are ping-only. | `omniroute-storage` + `omniroute-api` | CRUD/audit repositories and bounded export stream pass persistence, authorization, and redaction tests. |
+| CAP-08 | Compression | **Contract.** Dashboard stats are unavailable and A/B output is synthetic. | **Contract/scaffold.** Core compression types exist; `omniroute-compression` has placeholder tests only. | `omniroute-compression` + `omniroute-api` | A deterministic compressor implementation publishes measured bytes/quality and is callable through the API. |
+| CAP-09 | MCP, A2A, skills, and memory | **Contract.** Restored dashboard routes return empty collections. | **Contract/scaffold.** MCP domain types exist; `omniroute-mcp` is a scaffold; no canonical Rust A2A/skills/memory runtime was found. | `omniroute-mcp` + `omniroute-api` | MCP health and one audited tool call work end to end; A2A/skills/memory receive separate keep/defer/remove decisions. |
+| CAP-10 | BFF proxy lifecycle and rollout | **Live but bounded debt.** Proxy streaming and rollout work; issue #340 tracks abort, timeout, header, and SSE characterization. | **Absent.** Axum API is not implemented, so no Rust ingress lifecycle exists. | v4 BFF for #340; `omniroute-api` for convergence | Cleanly replay `51d39d911`, then prove cancellation, timeout, hop-by-hop filtering, streaming, and stable 502 behavior. |
+| CAP-11 | Health, diagnostics, and operations API | **Partial.** BFF `/health` is live; diagnostics and runtime metrics are honest placeholders. | **Scaffold.** `omniroute-api` has no router or health endpoint. | `omniroute-api` (P4-R2) | `/healthz` reports process and storage readiness without requiring providers; diagnostics expose only measured fields. |
+| CAP-12 | CLI lifecycle and migrations | **Partial.** Existing JavaScript CLI/release surface remains the operational baseline, but root bundle preconditions still break cross-platform and DAST jobs. | **Scaffold.** Rust CLI only initializes tracing and logs a scaffold message. | `omniroute-cli` (P4-R4) | `serve` and `migrate` commands have help, exit-code, temp-database, and graceful-shutdown tests on Linux. |
+| CAP-13 | Persistence, schema, and encryption | **Delegated.** Restored BFF intentionally owns no durable store. | **Partial/live foundation.** Pool, schema bootstrap, migrations, crypto, combo/key/request-log repositories exist; provider/usage/audit/webhook coverage is incomplete. | `omniroute-storage` | Every declared repository has CRUD/aggregation tests; migration from an empty and previous-version database is idempotent. |
+| CAP-14 | Svelte dashboard and desktop shell | **Live UI/contract shell.** `apps/web` contains 37 dashboard pages but many consume placeholder BFF responses. | **Not a Rust migration target.** Rust should provide stable APIs, not replace the Svelte presentation layer. | `apps/web` + `apps/bff` compatibility owners | Each page is classified live, unavailable, or hidden based on API capability; no fabricated success remains. |
+
+## Ownership and sequencing
+
+| Work package | Primary owner | Depends on | PERT estimate (O/M/P) |
+|---|---|---|---:|
+| P4-R1 provider repository CRUD | `omniroute-storage` | schema foundation | 0.5 / 1 / 2 d |
+| P4-R2 Axum skeleton and health | `omniroute-api` | P4-R1 interface | 0.5 / 1 / 2 d |
+| P4-R3 router delegates to registry | `omniroute-router`, `omniroute-providers` | P4-R1, P4-R2 | 1 / 2 / 4 d |
+| P4-R4 CLI `serve` and `migrate` | `omniroute-cli` | P4-R2, storage migrations | 0.5 / 1 / 2 d |
+| P4-R5 Linux Rust CI matrix | repository CI owner | P4-R2 through P4-R4 | 0.25 / 0.5 / 1 d |
+| P4-R6 keys/auth API | `omniroute-api`, `omniroute-storage` | P4-R2 | 1 / 2 / 4 d |
+| P4-R7 measured observability | `omniroute-storage`, `omniroute-api` | P4-R3 | 1 / 3 / 5 d |
+| P4-R8 audit/webhook persistence | `omniroute-storage`, `omniroute-api` | P4-R2 | 1 / 2 / 4 d |
+
+Expected duration uses `(O + 4M + P) / 6`; the critical initial path is
+approximately 6.0 engineering days before CI stabilization:
+
+```mermaid
+flowchart LR
+  MATRIX[P1-L7 parity baseline] --> PROVIDERS[P4-R1 provider CRUD]
+  PROVIDERS --> API[P4-R2 Axum health/API]
+  API --> ROUTER[P4-R3 registry routing]
+  ROUTER --> CLI[P4-R4 serve/migrate]
+  CLI --> CI[P4-R5 Linux Rust CI]
+
+  API --> AUTH[P4-R6 keys/auth]
+  ROUTER --> OBS[P4-R7 measured observability]
+  API --> AUDIT[P4-R8 audit/webhooks]
+
+  PROXY[#340 v4 proxy hardening] --> SHELL[v4 compatibility shell]
+  API --> SHELL
+  AUTH --> SHELL
+  OBS --> SHELL
+  AUDIT --> SHELL
+```
+
+## Release-control rules
+
+1. Do not mark a capability parity-complete from types, tables, UI, or
+   placeholder responses alone.
+2. Keep the restored BFF route honest until its Rust dependency is measured and
+   contract-tested.
+3. Cut over one capability at a time behind the compatibility shell; retain a
+   one-PR rollback path.
+4. Treat `backend-rust` or other historical Rust trees as provenance only until
+   an ADR names them canonical; current ownership is under
+   `crates/omniroute-rs`.
+5. Update this matrix and RC-A7 in the same PR that changes a capability state.

--- a/plans/2026-07-18-v4-rust-feature-parity-matrix.md
+++ b/plans/2026-07-18-v4-rust-feature-parity-matrix.md
@@ -1,7 +1,7 @@
 # v4-to-Rust Feature-Parity Matrix
 
 **ADR:** ADR-107 staged convergence  
-**WBS:** P1-L7 → P4-R1…P4-R5  
+**WBS:** P1-L7 → P4-R1…P4-R8  
 **Evidence cutoff:** `main` at `4c19697ad` (PR #382)  
 **Status:** Initial owner and dependency baseline
 
@@ -46,14 +46,14 @@ Status legend:
 | P4-R1 provider repository CRUD | `omniroute-storage` | schema foundation | 0.5 / 1 / 2 d |
 | P4-R2 Axum skeleton and health | `omniroute-api` | P4-R1 interface | 0.5 / 1 / 2 d |
 | P4-R3 router delegates to registry | `omniroute-router`, `omniroute-providers` | P4-R1, P4-R2 | 1 / 2 / 4 d |
-| P4-R4 CLI `serve` and `migrate` | `omniroute-cli` | P4-R2, storage migrations | 0.5 / 1 / 2 d |
-| P4-R5 Linux Rust CI matrix | repository CI owner | P4-R2 through P4-R4 | 0.25 / 0.5 / 1 d |
+| P4-R4 CLI `serve` and `migrate` | `omniroute-cli` | P4-R2, storage migrations | 1 / 2 / 3 d |
+| P4-R5 Linux Rust CI matrix | repository CI owner | P0-L2 compile baseline | 0.25 / 0.5 / 1 d |
 | P4-R6 keys/auth API | `omniroute-api`, `omniroute-storage` | P4-R2 | 1 / 2 / 4 d |
 | P4-R7 measured observability | `omniroute-storage`, `omniroute-api` | P4-R3 | 1 / 3 / 5 d |
 | P4-R8 audit/webhook persistence | `omniroute-storage`, `omniroute-api` | P4-R2 | 1 / 2 / 4 d |
 
-Expected duration uses `(O + 4M + P) / 6`; the critical initial path is
-approximately 6.0 engineering days before CI stabilization:
+Expected duration uses `(O + 4M + P) / 6`; the critical initial path through
+the first operational CLI is approximately 6.3 engineering days:
 
 ```mermaid
 flowchart LR
@@ -61,7 +61,7 @@ flowchart LR
   PROVIDERS --> API[P4-R2 Axum health/API]
   API --> ROUTER[P4-R3 registry routing]
   ROUTER --> CLI[P4-R4 serve/migrate]
-  CLI --> CI[P4-R5 Linux Rust CI]
+  BASELINE[P0-L2 compile baseline] --> CI[P4-R5 Linux Rust CI]
 
   API --> AUTH[P4-R6 keys/auth]
   ROUTER --> OBS[P4-R7 measured observability]

--- a/plans/2026-07-18-v4-rust-feature-parity-matrix.md
+++ b/plans/2026-07-18-v4-rust-feature-parity-matrix.md
@@ -1,9 +1,9 @@
 # v4-to-Rust Feature-Parity Matrix
 
-**ADR:** ADR-107 staged convergence  
-**WBS:** P1-L7 → P4-R1…P4-R8  
-**Evidence cutoff:** `main` at `4c19697ad` (PR #382)  
-**Status:** Initial owner and dependency baseline
+- **ADR:** ADR-107 staged convergence
+- **WBS:** P1-L7 → P4-R1…P4-R8
+- **Evidence cutoff:** `main` at `4c19697ad` (PR #382)
+- **Status:** Initial owner and dependency baseline
 
 ## Decision boundary
 

--- a/plans/RC-2026-07-17-A.md
+++ b/plans/RC-2026-07-17-A.md
@@ -11,9 +11,9 @@
 | RC-A2 | Rust crates contain no missing declared modules or binaries | Pass via #376 |
 | RC-A3 | `extensions/argis` has a verified build or explicit opt-in boundary | Partial: targeted infra smoke passes; full suite has baseline API drift |
 | RC-A4 | ADR-107 defines the staged v4-to-Rust convergence topology | Pass |
-| RC-A5 | v4 BFF/web is restored with provenance and no absorb regression | Pass on PR #380 branch; merge pending |
-| RC-A6 | #339, #340, and #375 reflect the restoration/migration state | Pending |
-| RC-A7 | A feature-parity matrix maps v4 capabilities to Rust owners | Pending |
+| RC-A5 | v4 BFF/web is restored with provenance and no absorb regression | Pass via PR #380 |
+| RC-A6 | #339, #340, and #375 reflect the restoration/migration state | Partial: #339/#375 complete via merged #382; #340 source verified for clean replay |
+| RC-A7 | A feature-parity matrix maps v4 capabilities to Rust owners | Drafted; publication pending |
 | RC-A8 | Security scans pass on the absorb repair | Pass: SonarCloud, Socket, Semgrep, and Kilo green on #380 |
 | RC-A9 | DAST and latency failures are fixed or carry evidence-backed waivers | Pass for #380 via evidence-backed baseline waiver below |
 
@@ -73,9 +73,10 @@ and approval checks pass with no unresolved review threads.
 - [x] ADR-107 accepted: staged convergence
 - [x] v4 recovery source verified: `06886ea531`
 - [x] v4 surface restored on bounded recovery branch without absorb diffs
+- [x] PR #380 merged with current `main`
 - [x] Recovery review defects and blocking Vitest CVE remediated and scanned
 - [ ] v4-to-Rust feature-parity matrix published
-- [ ] BFF issue/PR disposition recorded
+- [x] BFF issue/PR disposition recorded: #375 superseded by merged #382; closed #342 mapped to #340 replay
 - [x] Root npm lock drift no longer blocks DAST dependency installation
 - [ ] Root Next.js bundle preconditions fixed for DAST startup
 - [ ] REST latency baseline fixed or formally rebaselined

--- a/plans/RC-2026-07-17-A.md
+++ b/plans/RC-2026-07-17-A.md
@@ -13,7 +13,7 @@
 | RC-A4 | ADR-107 defines the staged v4-to-Rust convergence topology | Pass |
 | RC-A5 | v4 BFF/web is restored with provenance and no absorb regression | Pass via PR #380 |
 | RC-A6 | #339, #340, and #375 reflect the restoration/migration state | Partial: #339/#375 complete via merged #382; #340 source verified for clean replay |
-| RC-A7 | A feature-parity matrix maps v4 capabilities to Rust owners | Drafted; publication pending |
+| RC-A7 | A feature-parity matrix maps v4 capabilities to Rust owners | In review via PR #389 |
 | RC-A8 | Security scans pass on the absorb repair | Pass: SonarCloud, Socket, Semgrep, and Kilo green on #380 |
 | RC-A9 | DAST and latency failures are fixed or carry evidence-backed waivers | Pass for #380 via evidence-backed baseline waiver below |
 

--- a/plans/RC-2026-07-17-A.md
+++ b/plans/RC-2026-07-17-A.md
@@ -13,7 +13,7 @@
 | RC-A4 | ADR-107 defines the staged v4-to-Rust convergence topology | Pass |
 | RC-A5 | v4 BFF/web is restored with provenance and no absorb regression | Pass via PR #380 |
 | RC-A6 | #339, #340, and #375 reflect the restoration/migration state | Partial: #339/#375 complete via merged #382; #340 source verified for clean replay |
-| RC-A7 | A feature-parity matrix maps v4 capabilities to Rust owners | In review via PR #389 |
+| RC-A7 | A feature-parity matrix maps v4 capabilities to Rust owners | Pass via `plans/2026-07-18-v4-rust-feature-parity-matrix.md` |
 | RC-A8 | Security scans pass on the absorb repair | Pass: SonarCloud, Socket, Semgrep, and Kilo green on #380 |
 | RC-A9 | DAST and latency failures are fixed or carry evidence-backed waivers | Pass for #380 via evidence-backed baseline waiver below |
 
@@ -75,7 +75,7 @@ and approval checks pass with no unresolved review threads.
 - [x] v4 surface restored on bounded recovery branch without absorb diffs
 - [x] PR #380 merged with current `main`
 - [x] Recovery review defects and blocking Vitest CVE remediated and scanned
-- [ ] v4-to-Rust feature-parity matrix published
+- [x] v4-to-Rust feature-parity matrix published
 - [x] BFF issue/PR disposition recorded: #375 superseded by merged #382; closed #342 mapped to #340 replay
 - [x] Root npm lock drift no longer blocks DAST dependency installation
 - [ ] Root Next.js bundle preconditions fixed for DAST startup


### PR DESCRIPTION
## Summary
- Publish the initial ADR-107 v4-to-Rust feature-parity matrix across 14 capability domains.
- Distinguish live behavior from contracts, honesty-first placeholders, partial repositories, and Rust scaffolds.
- Assign canonical crate owners, acceptance gates, PERT estimates, and the P4 dependency DAG.
- Record PR #382 as merged and map closed PR #342 commit `51d39d911` as the clean replay source for #340.
- Refresh RC-A6/RC-A7 and the Proc-2 next-two queue.

## Key finding
The canonical Rust foundation under `crates/omniroute-rs` has meaningful domain types, schema, crypto, combo/key/request-log persistence, but provider CRUD, Axum API, provider adapters, router, CLI commands, usage aggregation, audit/webhooks, compression, MCP, and Bifrost remain partial or scaffolded. UI/contracts are not counted as runtime parity.

## Validation
- Evidence checked against `main` at merge commit `4c19697ad`.
- Matrix statements trace to concrete BFF and Rust files.
- `git diff --check`: pass.

## Follow-up
1. Clean replay #340 source commit `51d39d911`.
2. Start P4-R1 provider repository CRUD.