### PR TITLE
ci(ts7): restore strict baseline from current main

### DIFF
--- a/.github/workflows/v4-strict-types.yml
+++ b/.github/workflows/v4-strict-types.yml
@@ -1,0 +1,70 @@
+name: v4 strict type gates
+
+on:
+  pull_request:
+    paths:
+      - "apps/web/**"
+      - "apps/bff/**"
+      - "packages/api-contracts/**"
+      - ".github/workflows/v4-strict-types.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  SOURCE_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+
+concurrency:
+  group: v4-strict-types-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 1
+      - name: Assert immutable source provenance
+        run: |
+          test "$SOURCE_SHA" != "$GITHUB_SHA" || test "$GITHUB_EVENT_NAME" != "pull_request"
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          git diff --exit-code
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+      - name: Frozen installs
+        run: |
+          for directory in packages/api-contracts apps/bff apps/web; do
+            bun install --frozen-lockfile --ignore-scripts --cwd "$directory"
+          done
+      - name: Generate SvelteKit types
+        run: bun run --cwd apps/web svelte-kit sync
+      - name: Typecheck with maintained TypeScript
+        run: |
+          bun run --cwd packages/api-contracts typecheck
+          bun run --cwd apps/bff typecheck
+          bun run --cwd apps/web typecheck
+      - name: Typecheck with TypeScript 7
+        run: |
+          bun run --cwd packages/api-contracts typecheck:ts7
+          bun run --cwd apps/bff typecheck:ts7
+          bun run --cwd apps/web typecheck:ts7
+      - name: Test proxy handlers
+        run: bun run --cwd apps/web test -- tests/unit/routes/proxy-handlers.test.ts
+      - name: Test web
+        run: bun run --cwd apps/web test
+      - name: Build web
+        run: bun run --cwd apps/web build
+      - name: Record exact-head evidence
+        run: |
+          mkdir -p v4-strict-type-evidence
+          node -e 'const fs=require("fs"),cp=require("child_process"); const checkoutSha=cp.execFileSync("git",["rev-parse","HEAD"],{encoding:"utf8"}).trim(); if(checkoutSha!==process.env.SOURCE_SHA) throw new Error(`provenance drift: ${checkoutSha} != ${process.env.SOURCE_SHA}`); fs.writeFileSync("v4-strict-type-evidence/report.json", JSON.stringify({sourceSha:process.env.SOURCE_SHA,sourceRef:process.env.SOURCE_REF,checkoutSha,triggerSha:process.env.GITHUB_SHA,bun:process.argv[1],surfaces:["packages/api-contracts","apps/bff","apps/web"],ts5:"pass",ts7:"pass",proxyTests:"pass",webTests:"pass",build:"pass"},null,2)+"\n")' "$(bun --version)"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v4-strict-types-head-${{ env.SOURCE_SHA }}
+          path: v4-strict-type-evidence/report.json
+          retention-days: 14


### PR DESCRIPTION
Closes #395.

## What changed

- restores the exact-head v4 strict-type workflow on authoritative current main
- gates the three TypeScript surfaces that still exist: `packages/api-contracts`, `apps/bff`, and `apps/web`
- runs frozen installs, maintained-TypeScript checks, TypeScript 7 checks, focused proxy tests, the full web suite, and the production web build
- records source, checkout, and synthetic trigger SHAs separately in a retained evidence artifact

## Why

Current `main` diverged from the historical #372/#370 lineage. It preserves #372's six source/test fixes byte-for-byte but dropped its workflow. Copying that workflow unchanged would be invalid because current main removed `packages/design-tokens` and the root `ci:v4:typecheck*` scripts.

This PR reconstructs the strict TS7 prerequisite directly from exact current main, without cherry-picking or merging divergent history. It deliberately does not perform the later Bun migration.

## Provenance and scope

- base at branch creation: `63842030c11d1d2fdb9a7ad7fab595bf597c4d87`
- branch head: `67d2e51c06455933a5dd91fa86782c5cbb8a9df1`
- the head has one parent, exactly the base above
- one new workflow file; no application source, dependency, lockfile, runtime-version, publication, or deployment change

## Local validation on exact base + this commit

- frozen installs: API contracts, BFF, web — pass
- maintained TypeScript: API contracts, BFF, web — pass; Svelte reports 0 errors and 0 warnings
- TypeScript 7: API contracts, BFF, web — pass
- focused proxy handlers: 3/3 pass
- full web suite: 11/11 pass across 4 files
- web production build: pass
- staged-diff Gitleaks: no findings

The PR remains draft until immutable exact-head CI artifact, Sonar, security, and review evidence are terminal.