### PR TITLE
recover(journeys): restore immutable current-main provenance

### DIFF
--- a/.github/workflows/journey-evidence.yml
+++ b/.github/workflows/journey-evidence.yml
@@ -1,0 +1,41 @@
+name: Journey evidence
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/journey-evidence.yml"
+      - "docs/journeys/**"
+      - "scripts/docs/validate-journey-manifests.mjs"
+      - "tests/e2e/journey-evidence-landing.spec.ts"
+      - "tests/unit/journey-manifest-provenance.test.ts"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: journey-evidence-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      JOURNEY_EVIDENCE_DIR: journey-evidence
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npx playwright install --with-deps chromium
+      - run: node scripts/docs/validate-journey-manifests.mjs
+      - run: node --import tsx --test tests/unit/journey-manifest-provenance.test.ts
+      - run: npx playwright test tests/e2e/journey-evidence-landing.spec.ts --project=chromium --workers=1 --retries=0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: anonymous-landing-smoke-${{ github.event.pull_request.head.sha }}
+          path: journey-evidence/anonymous-landing-smoke/
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/journey-evidence.yml
+++ b/.github/workflows/journey-evidence.yml
@@ -22,6 +22,9 @@ jobs:
     timeout-minutes: 30
     env:
       JOURNEY_EVIDENCE_DIR: journey-evidence
+      # Current main's full production build has independently tracked missing-module/media
+      # failures. Dev mode compiles the exercised public route without masking those release gates.
+      OMNIROUTE_PLAYWRIGHT_SERVER_MODE: dev
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/docs/journeys/README.md
+++ b/docs/journeys/README.md
@@ -1,0 +1,29 @@
+# Deterministic journey evidence
+
+Journey manifests bind reproducible product journeys to immutable GitHub Actions artifacts.
+They do not treat a local or hand-made screenshot as evidence.
+
+## Layout and validation
+
+- `schema/journey.schema.json` defines the portable authoring contract.
+- `manifests/*.json` records one deterministic journey per file.
+- `scripts/docs/validate-journey-manifests.mjs` verifies repository and capture provenance.
+- `tests/e2e/journey-evidence-landing.spec.ts` creates the current-main capture.
+
+Run the repository validator and focused regression suite:
+
+```sh
+node scripts/docs/validate-journey-manifests.mjs
+node --import tsx --test tests/unit/journey-manifest-provenance.test.ts
+```
+
+`blocked` manifests describe a precise blocker and have no capture linkage. `captured`
+manifests identify an exact source commit, workflow run, hosted artifact, retention interval,
+and SHA-256 digest for every declared file. The declared artifact inventory must match the
+captured-file inventory exactly.
+
+The capture runner uses a fixed viewport, reduced motion, local-only networking, no secrets,
+axe analysis, keyboard-focus verification, and explicit redaction scanning. Hosted artifacts
+may expire; immutable identifiers and digests remain the historical provenance record.
+
+Related: #394.

--- a/docs/journeys/README.md
+++ b/docs/journeys/README.md
@@ -26,4 +26,9 @@ The capture runner uses a fixed viewport, reduced motion, local-only networking,
 axe analysis, keyboard-focus verification, and explicit redaction scanning. Hosted artifacts
 may expire; immutable identifiers and digests remain the historical provenance record.
 
-Related: #394.
+The first recovery capture runs the exercised `/landing` route with the repository-supported
+development server. This is capture-only: it neither claims nor substitutes for a production
+build. Current-main production-build defects remain independently blocking under #400, and the
+accessibility report records the server mode used.
+
+Related: #394, #400.

--- a/docs/journeys/manifests/anonymous-landing-smoke.json
+++ b/docs/journeys/manifests/anonymous-landing-smoke.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 2,
+  "slug": "anonymous-landing-smoke",
+  "title": "Anonymous visitor opens the OmniRoute landing surface",
+  "persona": "A first-time visitor evaluating OmniRoute without credentials",
+  "purpose": "Prove that the public landing route renders locally and satisfies the declared accessibility contract.",
+  "preconditions": [
+    "Dependencies are installed from package-lock.json.",
+    "The Playwright web server starts the current Next.js application on localhost.",
+    "No provider credentials are configured."
+  ],
+  "fixture": { "kind": "repository", "network": "local-only", "secrets": false },
+  "viewport": { "width": 1280, "height": 800, "deviceScaleFactor": 1 },
+  "steps": [
+    {
+      "id": "open-landing",
+      "action": "goto",
+      "target": "/landing",
+      "assertions": [
+        "The document title contains OmniRoute.",
+        "The first heading is visible.",
+        "The document has no horizontal overflow at the declared viewport."
+      ]
+    }
+  ],
+  "accessibility": {
+    "keyboardOnly": true,
+    "reducedMotion": true,
+    "checks": [
+      "document-title",
+      "heading-order",
+      "landmarks",
+      "focus-visible",
+      "accessible-names",
+      "contrast",
+      "no-horizontal-overflow",
+      "reduced-motion"
+    ]
+  },
+  "redaction": {
+    "denyPatterns": [
+      "(?i)(api[-_ ]?key|authorization|token|secret|cookie)\\s*[:=]\\s*\\S+",
+      "(?i)bearer\\s+\\S+"
+    ],
+    "maskSelectors": ["input[type='password']", "[data-sensitive='true']"],
+    "reviewRequired": true
+  },
+  "evidence": {
+    "captureStatus": "blocked",
+    "artifacts": [
+      { "kind": "screenshot", "path": "journey-evidence/anonymous-landing-smoke/landing.png" },
+      { "kind": "trace", "path": "journey-evidence/anonymous-landing-smoke/trace.zip" },
+      {
+        "kind": "accessibility-report",
+        "path": "journey-evidence/anonymous-landing-smoke/accessibility.json"
+      }
+    ],
+    "retentionDays": 14,
+    "blocker": "A fresh exact-source-commit GitHub Actions capture is required before captured status can be asserted.",
+    "capture": null
+  },
+  "provenance": {
+    "baseBranch": "main",
+    "testFile": "tests/e2e/journey-evidence-landing.spec.ts",
+    "testTitle": "captures anonymous current-main landing journey evidence",
+    "command": "npx playwright test tests/e2e/journey-evidence-landing.spec.ts --project=chromium --workers=1 --retries=0"
+  }
+}

--- a/docs/journeys/manifests/anonymous-landing-smoke.json
+++ b/docs/journeys/manifests/anonymous-landing-smoke.json
@@ -6,7 +6,7 @@
   "purpose": "Prove that the public landing route renders locally and satisfies the declared accessibility contract.",
   "preconditions": [
     "Dependencies are installed from package-lock.json.",
-    "The Playwright web server starts the current Next.js application on localhost.",
+    "The capture-only Playwright web server starts the current Next.js application in development mode on localhost; this does not assert a production build.",
     "No provider credentials are configured."
   ],
   "fixture": { "kind": "repository", "network": "local-only", "secrets": false },
@@ -56,7 +56,7 @@
       }
     ],
     "retentionDays": 14,
-    "blocker": "A fresh exact-source-commit GitHub Actions capture is required before captured status can be asserted.",
+    "blocker": "A fresh exact-source-commit GitHub Actions development-mode capture is required before captured status can be asserted; production-build defects remain tracked separately in issue 400.",
     "capture": null
   },
   "provenance": {

--- a/docs/journeys/schema/journey.schema.json
+++ b/docs/journeys/schema/journey.schema.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KooshaPari/OmniRoute/blob/main/docs/journeys/schema/journey.schema.json",
+  "title": "OmniRoute deterministic journey evidence manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "slug",
+    "title",
+    "persona",
+    "purpose",
+    "preconditions",
+    "fixture",
+    "viewport",
+    "steps",
+    "accessibility",
+    "redaction",
+    "evidence",
+    "provenance"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 2 },
+    "slug": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "title": { "type": "string", "minLength": 1 },
+    "persona": { "type": "string", "minLength": 1 },
+    "purpose": { "type": "string", "minLength": 1 },
+    "preconditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "network", "secrets"],
+      "properties": {
+        "kind": { "enum": ["none", "repository"] },
+        "network": { "enum": ["blocked", "mocked", "local-only"] },
+        "secrets": { "const": false }
+      }
+    },
+    "viewport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["width", "height", "deviceScaleFactor"],
+      "properties": {
+        "width": { "type": "integer", "minimum": 320 },
+        "height": { "type": "integer", "minimum": 480 },
+        "deviceScaleFactor": { "type": "number", "minimum": 1, "maximum": 3 }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "action", "target", "assertions"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+          "action": { "enum": ["goto", "click", "fill", "press", "observe"] },
+          "target": { "type": "string", "minLength": 1 },
+          "value": { "type": "string" },
+          "assertions": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "accessibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["keyboardOnly", "reducedMotion", "checks"],
+      "properties": {
+        "keyboardOnly": { "type": "boolean" },
+        "reducedMotion": { "const": true },
+        "checks": {
+          "type": "array",
+          "minItems": 8,
+          "maxItems": 8,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "document-title",
+              "heading-order",
+              "landmarks",
+              "focus-visible",
+              "accessible-names",
+              "contrast",
+              "no-horizontal-overflow",
+              "reduced-motion"
+            ]
+          }
+        }
+      }
+    },
+    "redaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["denyPatterns", "maskSelectors", "reviewRequired"],
+      "properties": {
+        "denyPatterns": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "maskSelectors": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "reviewRequired": { "const": true }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["captureStatus", "artifacts", "retentionDays", "blocker", "capture"],
+      "properties": {
+        "captureStatus": { "enum": ["blocked", "captured"] },
+        "artifacts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind", "path"],
+            "properties": {
+              "kind": { "enum": ["screenshot", "trace", "video", "accessibility-report"] },
+              "path": { "type": "string", "pattern": "^journey-evidence/" }
+            }
+          }
+        },
+        "retentionDays": { "type": "integer", "minimum": 1 },
+        "blocker": { "type": ["string", "null"] },
+        "capture": { "anyOf": [{ "type": "null" }, { "$ref": "#/$defs/capture" }] }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "captureStatus": { "const": "blocked" } } },
+          "then": {
+            "properties": {
+              "blocker": { "type": "string", "minLength": 1 },
+              "capture": { "type": "null" }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "captureStatus": { "const": "captured" } } },
+          "then": {
+            "properties": {
+              "blocker": { "type": "null" },
+              "capture": { "$ref": "#/$defs/capture" }
+            }
+          }
+        }
+      ]
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseBranch", "testFile", "testTitle", "command"],
+      "properties": {
+        "baseBranch": { "const": "main" },
+        "testFile": { "type": "string", "pattern": "^tests/" },
+        "testTitle": { "type": "string", "minLength": 1 },
+        "command": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "$defs": {
+    "capture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceCommit", "workflowRunId", "artifact", "files"],
+      "properties": {
+        "sourceCommit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "workflowRunId": { "type": "string", "pattern": "^[1-9][0-9]*$" },
+        "artifact": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "name", "createdAt", "expiresAt"],
+          "properties": {
+            "id": { "type": "string", "pattern": "^[1-9][0-9]*$" },
+            "name": { "type": "string", "minLength": 1 },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$"
+            },
+            "expiresAt": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$"
+            }
+          }
+        },
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "sha256"],
+            "properties": {
+              "path": { "type": "string", "pattern": "^journey-evidence/" },
+              "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/docs/validate-journey-manifests.mjs
+++ b/scripts/docs/validate-journey-manifests.mjs
@@ -1,0 +1,230 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const COMMIT = /^[0-9a-f]{40}$/;
+const ID = /^[1-9]\d*$/;
+const UTC = /^\d{4}-(0[1-9]|1[0-2])-([0-2]\d|3[01])T([01]\d|2[0-3]):[0-5]\d:[0-5]\dZ$/;
+const ACTIONS = new Set(["goto", "click", "fill", "press", "observe"]);
+const CHECKS = new Set([
+  "document-title",
+  "heading-order",
+  "landmarks",
+  "focus-visible",
+  "accessible-names",
+  "contrast",
+  "no-horizontal-overflow",
+  "reduced-motion",
+]);
+
+const canonicalTime = (value) => {
+  if (typeof value !== "string" || !UTC.test(value)) return Number.NaN;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value.replace("Z", ".000Z")
+    ? parsed
+    : Number.NaN;
+};
+
+export function validateAccessibility(manifest, relative = "<manifest>") {
+  const errors = [];
+  const assert = (condition, message) => {
+    if (!condition) errors.push(`${relative}: ${message}`);
+  };
+  const checks = Array.isArray(manifest.accessibility?.checks) ? manifest.accessibility.checks : [];
+  assert(manifest.accessibility?.keyboardOnly === true, "keyboardOnly must be true");
+  assert(manifest.accessibility?.reducedMotion === true, "reducedMotion must be true");
+  assert(
+    checks.length === CHECKS.size &&
+      new Set(checks).size === CHECKS.size &&
+      [...CHECKS].every((check) => checks.includes(check)),
+    "accessibility checks must exactly match the substantiated eight-check contract"
+  );
+  return errors;
+}
+
+export function validateEvidence(manifest, relative = "<manifest>") {
+  const errors = [];
+  const assert = (condition, message) => {
+    if (!condition) errors.push(`${relative}: ${message}`);
+  };
+  const evidence = manifest.evidence ?? {};
+  const artifacts = Array.isArray(evidence.artifacts) ? evidence.artifacts : [];
+  const artifactPaths = artifacts.map((artifact) => artifact?.path);
+  assert(["blocked", "captured"].includes(evidence.captureStatus), "invalid evidence status");
+  assert(artifacts.length > 0, "at least one evidence artifact is required");
+  assert(
+    artifactPaths.every(
+      (value) => typeof value === "string" && value.startsWith("journey-evidence/")
+    ),
+    "every evidence artifact path must start with journey-evidence/"
+  );
+  assert(
+    new Set(artifactPaths).size === artifactPaths.length,
+    "evidence artifact paths must be unique"
+  );
+
+  if (evidence.captureStatus === "blocked") {
+    assert(
+      typeof evidence.blocker === "string" && evidence.blocker.trim().length > 0,
+      "blocked evidence needs a blocker"
+    );
+    assert(evidence.capture === null, "blocked evidence must have capture set to null");
+    return errors;
+  }
+  if (evidence.captureStatus !== "captured") return errors;
+
+  assert(evidence.blocker === null, "captured evidence must have blocker set to null");
+  const capture = evidence.capture;
+  assert(
+    capture && typeof capture === "object" && !Array.isArray(capture),
+    "captured evidence needs capture linkage"
+  );
+  if (!capture || typeof capture !== "object" || Array.isArray(capture)) return errors;
+  assert(
+    COMMIT.test(capture.sourceCommit ?? ""),
+    "capture.sourceCommit must be a lowercase 40-character SHA"
+  );
+  assert(
+    ID.test(capture.workflowRunId ?? ""),
+    "capture.workflowRunId must be a positive decimal ID string"
+  );
+  assert(
+    ID.test(capture.artifact?.id ?? ""),
+    "capture.artifact.id must be a positive decimal ID string"
+  );
+  assert(
+    capture.artifact?.name === `${manifest.slug}-${capture.sourceCommit}`,
+    "capture.artifact.name must equal <slug>-<sourceCommit>"
+  );
+  const created = canonicalTime(capture.artifact?.createdAt);
+  const expires = canonicalTime(capture.artifact?.expiresAt);
+  const days = evidence.retentionDays;
+  assert(Number.isFinite(created), "capture.artifact.createdAt must be canonical RFC 3339 UTC");
+  assert(Number.isFinite(expires), "capture.artifact.expiresAt must be canonical RFC 3339 UTC");
+  assert(Number.isInteger(days) && days > 0, "retentionDays must be a positive integer");
+  if (Number.isFinite(created) && Number.isFinite(expires) && Number.isInteger(days) && days > 0) {
+    assert(expires > created, "capture artifact expiry must follow creation");
+    assert(
+      Math.abs(expires - created - days * 86_400_000) <= 1000,
+      "capture artifact dates must match retentionDays within one second"
+    );
+  }
+  const files = Array.isArray(capture.files) ? capture.files : [];
+  const capturedPaths = files.map((file) => file?.path);
+  assert(files.length > 0, "capture.files must not be empty");
+  assert(
+    capturedPaths.every(
+      (value) => typeof value === "string" && value.startsWith("journey-evidence/")
+    ),
+    "every capture file path must start with journey-evidence/"
+  );
+  assert(
+    files.every((file) => SHA256.test(file?.sha256 ?? "")),
+    "every capture file needs a lowercase SHA-256 digest"
+  );
+  assert(new Set(capturedPaths).size === capturedPaths.length, "capture file paths must be unique");
+  assert(
+    artifactPaths.length === capturedPaths.length &&
+      artifactPaths.every((artifactPath) => capturedPaths.includes(artifactPath)),
+    "capture file inventory must exactly match evidence.artifacts"
+  );
+  return errors;
+}
+
+export async function validateProvenance(root, manifest, relative, errors, assert) {
+  assert(
+    manifest.provenance?.baseBranch === "main",
+    relative,
+    "provenance.baseBranch must be main"
+  );
+  const testFile = manifest.provenance?.testFile;
+  assert(
+    typeof testFile === "string" && testFile.startsWith("tests/"),
+    relative,
+    "provenance.testFile must reference tests/"
+  );
+  if (typeof testFile !== "string" || !testFile.startsWith("tests/")) return;
+  try {
+    const testSource = await readFile(path.join(root, testFile), "utf8");
+    assert(
+      typeof manifest.provenance.testTitle === "string" &&
+        testSource.includes(manifest.provenance.testTitle),
+      relative,
+      "referenced test title was not found"
+    );
+    for (const step of manifest.steps ?? []) {
+      if (step.action !== "goto") continue;
+      if (typeof step.target !== "string") {
+        assert(false, relative, "goto step target must be a string before provenance matching");
+        continue;
+      }
+      const escaped = step.target.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+      assert(
+        new RegExp(String.raw`goto\(\s*["']${escaped}["']\s*[,)]`).test(testSource),
+        relative,
+        `route ${step.target} is not present in the referenced test`
+      );
+    }
+  } catch (error) {
+    errors.push(`${relative}: cannot verify test provenance: ${error.message}`);
+  }
+}
+
+export async function validateRepository(root = process.cwd()) {
+  const errors = [];
+  const assert = (condition, file, message) => {
+    if (!condition) errors.push(`${file}: ${message}`);
+  };
+  const manifestDir = path.join(root, "docs", "journeys", "manifests");
+  const files = (await readdir(manifestDir)).filter((name) => name.endsWith(".json")).sort();
+  assert(files.length > 0, manifestDir, "at least one manifest is required");
+  for (const file of files) {
+    const relative = path.posix.join("docs/journeys/manifests", file);
+    let manifest;
+    try {
+      manifest = JSON.parse(await readFile(path.join(manifestDir, file), "utf8"));
+    } catch (error) {
+      errors.push(`${relative}: invalid JSON: ${error.message}`);
+      continue;
+    }
+    assert(manifest.schemaVersion === 2, relative, "schemaVersion must be 2");
+    assert(SLUG.test(manifest.slug ?? ""), relative, "slug must be kebab-case");
+    assert(file === `${manifest.slug}.json`, relative, "filename must equal <slug>.json");
+    assert(
+      Array.isArray(manifest.steps) && manifest.steps.length > 0,
+      relative,
+      "steps are required"
+    );
+    for (const step of manifest.steps ?? []) {
+      assert(SLUG.test(step.id ?? ""), relative, "step id must be kebab-case");
+      assert(ACTIONS.has(step.action), relative, `unsupported action ${step.action}`);
+      assert(
+        typeof step.target === "string" && step.target.length > 0,
+        relative,
+        "step target is required"
+      );
+    }
+    errors.push(...validateAccessibility(manifest, relative));
+    assert(manifest.fixture?.secrets === false, relative, "fixture.secrets must be false");
+    assert(
+      manifest.redaction?.reviewRequired === true,
+      relative,
+      "human redaction review is required"
+    );
+    errors.push(...validateEvidence(manifest, relative));
+    await validateProvenance(root, manifest, relative, errors, assert);
+  }
+  return { errors, count: files.length };
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const { errors, count } = await validateRepository();
+  if (errors.length) {
+    console.error(errors.join("\n"));
+    process.exit(1);
+  }
+  console.log(`Validated ${count} deterministic journey manifest(s).`);
+}

--- a/tests/e2e/journey-evidence-landing.spec.ts
+++ b/tests/e2e/journey-evidence-landing.spec.ts
@@ -1,0 +1,107 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const slug = "anonymous-landing-smoke";
+const evidenceDir = path.resolve(process.env.JOURNEY_EVIDENCE_DIR ?? "journey-evidence", slug);
+
+test("captures anonymous current-main landing journey evidence", async ({ context, page }) => {
+  await mkdir(evidenceDir, { recursive: true });
+  await context.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    if (["localhost", "127.0.0.1", "::1"].includes(url.hostname)) await route.continue();
+    else await route.abort("blockedbyclient");
+  });
+  await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/landing", { waitUntil: "networkidle" });
+
+  await expect(page).toHaveTitle(/OmniRoute/i);
+  await expect(page.locator("h1").first()).toBeVisible();
+
+  const structure = await page.evaluate(() => {
+    const headings = [...document.querySelectorAll("h1,h2,h3,h4,h5,h6")].map((node) =>
+      Number(node.tagName.slice(1))
+    );
+    const headingOrder = headings.every(
+      (level, index) => index === 0 || level <= headings[index - 1] + 1
+    );
+    return {
+      title: document.title,
+      headingOrder,
+      landmarks: document.querySelectorAll(
+        "main,nav,header,footer,[role='main'],[role='navigation'],[role='banner'],[role='contentinfo']"
+      ).length,
+      horizontalOverflow:
+        document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      reducedMotion: matchMedia("(prefers-reduced-motion: reduce)").matches,
+    };
+  });
+
+  let focusVisible = false;
+  let focusTarget = "";
+  for (let attempt = 0; attempt < 20 && !focusVisible; attempt += 1) {
+    await page.keyboard.press("Tab");
+    const focus = await page.evaluate(() => {
+      const element = document.activeElement;
+      if (!(element instanceof HTMLElement) || element === document.body)
+        return { visible: false, target: "" };
+      const style = getComputedStyle(element);
+      const visible =
+        (style.outlineStyle !== "none" && Number.parseFloat(style.outlineWidth) > 0) ||
+        style.boxShadow !== "none";
+      return {
+        visible,
+        target: `${element.tagName.toLowerCase()}${element.id ? `#${element.id}` : ""}`,
+      };
+    });
+    focusVisible = focus.visible;
+    focusTarget = focus.target;
+  }
+
+  const axe = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+  const contrastViolations = axe.violations.filter(
+    (violation) => violation.id === "color-contrast"
+  );
+  const nameViolations = axe.violations.filter((violation) =>
+    /name|label|title/.test(violation.id)
+  );
+  const checks = {
+    "document-title": { passed: structure.title.trim().length > 0 },
+    "heading-order": { passed: structure.headingOrder },
+    landmarks: { passed: structure.landmarks > 0, count: structure.landmarks },
+    "focus-visible": { passed: focusVisible, target: focusTarget },
+    "accessible-names": { passed: nameViolations.length === 0, violations: nameViolations },
+    contrast: { passed: contrastViolations.length === 0, violations: contrastViolations },
+    "no-horizontal-overflow": { passed: !structure.horizontalOverflow },
+    "reduced-motion": { passed: structure.reducedMotion },
+  };
+  expect(Object.values(checks).every((result) => result.passed)).toBe(true);
+
+  const report = JSON.stringify(
+    {
+      schemaVersion: 1,
+      slug,
+      url: "/landing",
+      viewport: { width: 1280, height: 800 },
+      checks,
+      axe: { violations: axe.violations, incomplete: axe.incomplete },
+    },
+    null,
+    2
+  );
+  expect(report).not.toMatch(/(api[-_ ]?key|authorization|token|secret|cookie)\s*[:=]\s*\S+/i);
+  expect(report).not.toMatch(/bearer\s+\S+/i);
+  await writeFile(path.join(evidenceDir, "accessibility.json"), `${report}\n`);
+  await page.screenshot({
+    path: path.join(evidenceDir, "landing.png"),
+    fullPage: true,
+    animations: "disabled",
+    mask: [page.locator("input[type='password']"), page.locator("[data-sensitive='true']")],
+  });
+  await context.tracing.stop({ path: path.join(evidenceDir, "trace.zip") });
+});

--- a/tests/e2e/journey-evidence-landing.spec.ts
+++ b/tests/e2e/journey-evidence-landing.spec.ts
@@ -87,6 +87,7 @@ test("captures anonymous current-main landing journey evidence", async ({ contex
       schemaVersion: 1,
       slug,
       url: "/landing",
+      serverMode: process.env.OMNIROUTE_PLAYWRIGHT_SERVER_MODE ?? "start",
       viewport: { width: 1280, height: 800 },
       checks,
       axe: { violations: axe.violations, incomplete: axe.incomplete },

--- a/tests/unit/journey-manifest-provenance.test.ts
+++ b/tests/unit/journey-manifest-provenance.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  validateAccessibility,
+  validateEvidence,
+  validateProvenance,
+  validateRepository,
+} from "../../scripts/docs/validate-journey-manifests.mjs";
+
+const manifest = JSON.parse(
+  await readFile(
+    new URL("../../docs/journeys/manifests/anonymous-landing-smoke.json", import.meta.url)
+  )
+);
+const copy = () => structuredClone(manifest);
+const errorsFor = (mutate: (candidate: any) => void) => {
+  const candidate = copy();
+  mutate(candidate);
+  return validateEvidence(candidate);
+};
+
+test("accepts the truthful blocked current-main manifest", async () => {
+  assert.deepEqual(validateEvidence(manifest), []);
+  assert.deepEqual(validateAccessibility(manifest), []);
+  assert.deepEqual(await validateRepository(), { errors: [], count: 1 });
+});
+
+test("rejects captured status without immutable linkage", () => {
+  assert.match(
+    errorsFor((value) => {
+      value.evidence.captureStatus = "captured";
+    }).join("\n"),
+    /needs capture linkage/
+  );
+});
+
+test("rejects unsupported publication claims", () => {
+  assert.match(
+    errorsFor((value) => {
+      value.evidence.captureStatus = "published";
+    }).join("\n"),
+    /invalid evidence status/
+  );
+});
+
+test("requires an exact unique artifact inventory", () => {
+  const candidate = copy();
+  candidate.evidence.captureStatus = "captured";
+  candidate.evidence.blocker = null;
+  candidate.evidence.capture = {
+    sourceCommit: "a".repeat(40),
+    workflowRunId: "1",
+    artifact: {
+      id: "2",
+      name: `anonymous-landing-smoke-${"a".repeat(40)}`,
+      createdAt: "2026-07-18T00:00:00Z",
+      expiresAt: "2026-08-01T00:00:00Z",
+    },
+    files: candidate.evidence.artifacts.map((artifact: any) => ({
+      path: artifact.path,
+      sha256: "b".repeat(64),
+    })),
+  };
+  assert.deepEqual(validateEvidence(candidate), []);
+  candidate.evidence.capture.files.pop();
+  assert.match(validateEvidence(candidate).join("\n"), /exactly match/);
+});
+
+test("rejects noncanonical timestamps and malformed identifiers", () => {
+  const base = copy();
+  base.evidence.captureStatus = "captured";
+  base.evidence.blocker = null;
+  base.evidence.capture = {
+    sourceCommit: "bad",
+    workflowRunId: "0",
+    artifact: { id: "x", name: "bad", createdAt: "July 18", expiresAt: "2026-08-01T00:00:00Z" },
+    files: [],
+  };
+  const errors = validateEvidence(base).join("\n");
+  assert.match(errors, /sourceCommit/);
+  assert.match(errors, /workflowRunId/);
+  assert.match(errors, /canonical RFC 3339 UTC/);
+});
+
+test("guards malformed provenance before path and string operations", async () => {
+  const root = path.join(os.tmpdir(), `journey-provenance-${crypto.randomUUID()}`);
+  await mkdir(path.join(root, "tests"), { recursive: true });
+  await writeFile(
+    path.join(root, "tests", "journey.spec.ts"),
+    "test('capture', () => page.goto('/landing'));\n"
+  );
+  const errors: string[] = [];
+  const record = (condition: unknown, file: string, message: string) => {
+    if (!condition) errors.push(`${file}: ${message}`);
+  };
+  await validateProvenance(
+    root,
+    { provenance: { baseBranch: "main", testFile: undefined }, steps: [] },
+    "manifest.json",
+    errors,
+    record
+  );
+  assert.ok(errors.some((error) => error.includes("must reference tests/")));
+});
+
+test("requires the exact eight-check accessibility contract", () => {
+  const candidate = copy();
+  candidate.accessibility.checks.pop();
+  assert.match(validateAccessibility(candidate).join("\n"), /eight-check contract/);
+});


### PR DESCRIPTION
## Summary

- reconstructs the journey provenance contract directly from authoritative main `63842030c11d1d2fdb9a7ad7fab595bf597c4d87`
- adds a current Next.js `/landing` capture runner and artifact-only PR workflow
- keeps the manifest truthfully blocked until this PR produces a fresh exact-source-commit artifact
- uses `String#startsWith` validation to avoid the historical S6557 finding
- adds seven focused canonical Node tests

## Root cause

Merged PR #363 is not in current main ancestry after divergent-history integration. Its old v4 runner and artifact do not describe the current Next.js surface, so they are intentionally not reused.

## Validation

- `node scripts/docs/validate-journey-manifests.mjs`
- `node --test tests/unit/journey-manifest-provenance.test.ts` (7/7)
- Prettier check across all changed files
- `git diff --check`
- Gitleaks on exact commit range (no leaks)

## Next gate

The PR remains draft. The new workflow must capture and upload a fresh exact-head artifact. A follow-up commit will record its immutable run/artifact metadata and file hashes, followed by exact-head CI, security, Sonar zero-issue verification, and independent review.

Closes neither #394 nor any prior issue.