### PR TITLE
ci(perf): recover hosted v4 latency evidence

### DIFF
--- a/.github/workflows/v4-latency-baseline.yml
+++ b/.github/workflows/v4-latency-baseline.yml
@@ -3,6 +3,7 @@ name: v4 latency baseline evidence
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - ".github/workflows/v4-latency-baseline.yml"
       - "apps/bff/**"

--- a/.github/workflows/v4-latency-baseline.yml
+++ b/.github/workflows/v4-latency-baseline.yml
@@ -45,7 +45,7 @@ jobs:
             src/observability/benchmark-egress-guard.test.ts \
             src/observability/benchmark-output-path.test.ts \
             src/observability/latency.test.ts \
-            src/observability/route-inventory.test.ts)
+            tests/unit/observability/route-inventory.test.ts)
           bun run --cwd apps/bff typecheck
           bun run --cwd apps/bff typecheck:ts7
           bun run --cwd apps/bff build

--- a/.github/workflows/v4-latency-baseline.yml
+++ b/.github/workflows/v4-latency-baseline.yml
@@ -43,7 +43,8 @@ jobs:
             src/observability/compare-benchmark-reports.test.ts \
             src/observability/benchmark-egress-guard.test.ts \
             src/observability/benchmark-output-path.test.ts \
-            src/observability/latency.test.ts)
+            src/observability/latency.test.ts \
+            src/observability/route-inventory.test.ts)
           bun run --cwd apps/bff typecheck
           bun run --cwd apps/bff typecheck:ts7
           bun run --cwd apps/bff build

--- a/.github/workflows/v4-latency-baseline.yml
+++ b/.github/workflows/v4-latency-baseline.yml
@@ -1,0 +1,63 @@
+name: v4 latency baseline evidence
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/v4-latency-baseline.yml"
+      - "apps/bff/**"
+      - "budgets/rest-endpoints.yaml"
+      - "config/performance/v4-latency-inventory.json"
+      - "docs/performance/V4_LATENCY_BASELINE.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  baseline:
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-billing-exception') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 8
+    env:
+      SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+      RUNNER_IMAGE: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact source provenance
+        run: |
+          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
+          echo "SOURCE_TREE=$(git rev-parse HEAD^{tree})" >> "$GITHUB_ENV"
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+      - name: Install locked BFF dependencies
+        run: |
+          bun install --frozen-lockfile --cwd packages/api-contracts --ignore-scripts
+          bun install --frozen-lockfile --cwd apps/bff --ignore-scripts
+      - name: Verify bounded benchmark contract
+        run: |
+          (cd apps/bff && bunx vitest run \
+            src/observability/compare-benchmark-reports.test.ts \
+            src/observability/benchmark-egress-guard.test.ts \
+            src/observability/benchmark-output-path.test.ts \
+            src/observability/latency.test.ts)
+          bun run --cwd apps/bff typecheck
+          bun run --cwd apps/bff typecheck:ts7
+          bun run --cwd apps/bff build
+      - name: Capture two local-only runs
+        run: |
+          bun run --cwd apps/bff benchmark:latency -- run-1.json
+          bun run --cwd apps/bff benchmark:latency -- run-2.json
+          bun run --cwd apps/bff benchmark:compare -- ../../latency-evidence/run-1.json ../../latency-evidence/run-2.json
+          sha256sum latency-evidence/*.json > latency-evidence/manifest.sha256
+      - name: Upload non-deployable evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v4-latency-baseline-${{ github.event.pull_request.head.sha || github.sha }}
+          path: latency-evidence/
+          if-no-files-found: error
+          retention-days: 14
+          include-hidden-files: false

--- a/apps/bff/src/observability/route-inventory.test.ts
+++ b/apps/bff/src/observability/route-inventory.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import inventory from "../../../../config/performance/v4-latency-inventory.json";
+import app from "../index";
+import { assertUnique, inventorySha256 } from "./benchmark-contract";
+
+describe("v4 registered route inventory", () => {
+  it("matches the normalized count and hash committed for benchmark evidence", () => {
+    const registeredRoutes = [...new Set<string>(
+      app.routes.map((entry: { method: string; path: string }) => `${entry.method} ${entry.path}`),
+    )].sort((left, right) => left.localeCompare(right, "en"));
+
+    expect(() => assertUnique(registeredRoutes, "route inventory")).not.toThrow();
+    expect(registeredRoutes).toHaveLength(inventory.registeredRouteCount);
+    expect(inventorySha256(registeredRoutes)).toBe(inventory.registeredRouteSha256);
+  });
+});

--- a/apps/bff/tests/unit/observability/route-inventory.test.ts
+++ b/apps/bff/tests/unit/observability/route-inventory.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import inventory from "../../../../config/performance/v4-latency-inventory.json";
-import app from "../index";
-import { assertUnique, inventorySha256 } from "./benchmark-contract";
+import inventory from "../../../../../config/performance/v4-latency-inventory.json";
+import app from "../../../src/index";
+import {
+  assertUnique,
+  inventorySha256,
+} from "../../../src/observability/benchmark-contract";
 
 describe("v4 registered route inventory", () => {
   it("matches the normalized count and hash committed for benchmark evidence", () => {

--- a/config/performance/v4-latency-inventory.json
+++ b/config/performance/v4-latency-inventory.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "owner": "apps/bff",
-  "registeredRouteCount": 65,
-  "registeredRouteSha256": "5fa728cf935f6620380544d0d4803b073cec073efc354428b73c393d341b7e13",
+  "registeredRouteCount": 68,
+  "registeredRouteSha256": "ef29b19de19768f639e063595ab2560c95dc1af7951eec650890edf8aed98261",
   "producers": [
     {
       "path": "/api/v1/telemetry/web-vitals",

--- a/docs/performance/V4_LATENCY_BASELINE.md
+++ b/docs/performance/V4_LATENCY_BASELINE.md
@@ -1,0 +1,49 @@
+---
+title: v4 latency baseline contract
+audience: developer
+owner: apps/bff
+status: reviewed
+lastReviewed: 2026-07-18
+sourceOfTruth:
+  - apps/bff/src/observability/latency.ts
+  - apps/bff/src/observability/benchmark-contract.ts
+  - apps/bff/src/observability/benchmark-egress-guard.ts
+  - apps/bff/scripts/benchmark-latency.ts
+  - config/performance/v4-latency-inventory.json
+---
+
+# v4 latency baseline contract
+
+This contract inventories reproducible evidence; it does not claim production performance.
+
+The local benchmark loads the built BFF and measures `/healthz` and
+`/api/dashboard/health` over a TCP listener bound to `127.0.0.1`. Each route receives 30
+warmups and 250 recorded samples. Reports retain every bounded raw duration and status,
+plus nearest-rank p50, p95, and p99; HTTP 5xx responses count as errors. Each report records
+the exact source commit and tree, runtime and pinned runner environment, complete normalized
+route inventory, sample contract, and resident memory.
+
+The benchmark process installs deny-by-default guards before importing the built BFF. It
+permits `global.fetch` only to the benchmark's exact loopback port and blocks non-loopback
+`Bun.connect`, Node socket creation, and Node DNS lookup/resolve calls. No providers or
+credentials are used. A zero blocked-attempt count is required; the workflow also publishes
+SHA-256 checksums with the raw reports.
+
+Run twice from an installed checkout:
+
+```sh
+SOURCE_COMMIT=$(git rev-parse HEAD) SOURCE_TREE=$(git rev-parse HEAD^{tree}) bun run --cwd apps/bff benchmark:latency -- run-1.json
+SOURCE_COMMIT=$(git rev-parse HEAD) SOURCE_TREE=$(git rev-parse HEAD^{tree}) bun run --cwd apps/bff benchmark:latency -- run-2.json
+bun run --cwd apps/bff benchmark:compare -- ../../latency-evidence/run-1.json ../../latency-evidence/run-2.json
+```
+
+The comparison strictly revalidates schemas, raw-sample sequences and derived summaries,
+then requires identical source/tree, benchmark and environment contracts, complete
+bidirectional route sets, inventory hash, sample count, error count/rate, and network-policy
+invariants. Each percentile may vary by at most the greater of 0.75 ms or 35% of the larger
+value; RSS may vary by at most the greater of 32 MiB or 20% of the larger value. These are
+repeatability tolerances for consecutive runs, not production SLOs.
+
+All provider/model latency, throughput, cost, cache-benefit, and production-scale claims are
+unverified for v4. They remain excluded from Phenodocs until backed by a versioned runtime
+producer, deterministic aggregation tests, and exact-source evidence.


### PR DESCRIPTION
Closes #397.

## Recovery scope

Fresh from exact main `63842030c11d1d2fdb9a7ad7fab595bf597c4d87`:

- restores the non-deploying hosted v4 latency evidence workflow
- restores the developer evidence contract
- updates only the mechanical registered-route count/hash from 65 to the exact-main 68-route set
- adds a focused regression that derives the normalized route enumeration from the BFF and locks its count/hash

No runtime endpoint, provider, cache, stream, telemetry, Pages, Wiki, package, release, OIDC, or deployment behavior changes.

## Local exact-head evidence

Head: `0fadb84850ca7e52dcb041d3057dd26b0f2d5c7c`
Tree: `b8f10219eecfcd02c222eeba35cbd0ed24684f86`

- frozen installs: API contracts + BFF
- focused benchmark suite: 5 files / 36 tests passed
- BFF TypeScript 5: passed
- BFF TypeScript 7: passed
- BFF build: passed (234 modules)
- two exact-head local captures: strict comparison passed
- inventory: 68 routes, SHA-256 `ef29b19de19768f639e063595ab2560c95dc1af7951eec650890edf8aed98261`
- both runs: 560 allowed loopback attempts, 0 blocked non-loopback attempts, 0 HTTP 5xx samples
- Gitleaks: 2 commits / 6.26 KB, no leaks

Workflow authority is `contents: read`, Ubuntu 24.04, Bun 1.3.14, SHA-pinned checkout/setup/upload actions, 8-minute timeout, and 14-day artifact-only output.

Keep draft pending exact-head hosted artifact inspection, security/Sonar terminal results, and independent review.