### PR TITLE
refactor(bff): clean replay of bounded proxy lifecycle (#340)

### DIFF
--- a/apps/bff/src/routes/proxy.test.ts
+++ b/apps/bff/src/routes/proxy.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createProxyRoutes } from "./proxy";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("proxy routes", () => {
+  it("preserves routing, query, method, body, and rollout overrides", async () => {
+    let forwardedBody = "";
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      forwardedBody = await new Response(init?.body).text();
+      expect(String(url)).toBe("https://upstream.test/v1/chat/completions?stream=true");
+      expect(init?.method).toBe("POST");
+      expect(new Headers(init?.headers).get("x-proxied-by")).toBe("argismonitor-bff");
+      return new Response("upstream", { status: 201 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const routes = createProxyRoutes({ upstream: "https://upstream.test" });
+    const response = await routes.request("http://localhost/api/v1/chat/completions?stream=true", {
+      method: "POST",
+      headers: { cookie: "web_stack=svelte", "content-type": "text/plain" },
+      body: "request-body",
+    });
+
+    expect(response.status).toBe(201);
+    expect(await response.text()).toBe("upstream");
+    expect(forwardedBody).toBe("request-body");
+
+    const nextResponse = await routes.request("http://localhost/api/v1/models", {
+      headers: { cookie: "web_stack=next" },
+    });
+    expect(nextResponse.status).toBe(410);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes hop-by-hop and connection-nominated headers in both directions", async () => {
+    const upstreamHeaders = new Headers({
+      connection: "x-upstream-remove",
+      "keep-alive": "timeout=5",
+      "x-upstream-remove": "private",
+      "x-upstream-keep": "public",
+    });
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("connection")).toBeNull();
+      expect(headers.get("keep-alive")).toBeNull();
+      expect(headers.get("x-request-remove")).toBeNull();
+      expect(headers.get("x-request-keep")).toBe("public");
+      return new Response("ok", { headers: upstreamHeaders });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const routes = createProxyRoutes({ upstream: "https://upstream.test" });
+    const response = await routes.request("http://localhost/api/v1/models", {
+      headers: {
+        connection: "x-request-remove",
+        "keep-alive": "timeout=5",
+        "x-request-remove": "private",
+        "x-request-keep": "public",
+      },
+    });
+
+    expect(response.headers.get("connection")).toBeNull();
+    expect(response.headers.get("keep-alive")).toBeNull();
+    expect(response.headers.get("x-upstream-remove")).toBeNull();
+    expect(response.headers.get("x-upstream-keep")).toBe("public");
+    expect(response.headers.get("x-proxied-by")).toBe("argismonitor-bff");
+  });
+
+  it("returns the upstream stream without waiting for completion", async () => {
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+      },
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(body)));
+
+    const routes = createProxyRoutes({ upstream: "https://upstream.test" });
+    const response = await routes.request("http://localhost/api/v1/stream");
+    const reader = response.body!.getReader();
+
+    streamController.enqueue(new TextEncoder().encode("first"));
+    const first = await reader.read();
+
+    expect(new TextDecoder().decode(first.value)).toBe("first");
+    expect(first.done).toBe(false);
+    streamController.close();
+  });
+
+  it("propagates downstream cancellation to the upstream signal", async () => {
+    let upstreamSignal!: AbortSignal;
+    vi.stubGlobal("fetch", vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      upstreamSignal = init!.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        upstreamSignal.addEventListener("abort", () => reject(new Error("client_aborted")), { once: true });
+      });
+    }));
+
+    const downstream = new AbortController();
+    const routes = createProxyRoutes({ upstream: "https://upstream.test" });
+    const responsePromise = routes.request(
+      new Request("http://localhost/api/v1/stream", { signal: downstream.signal }),
+    );
+    await vi.waitFor(() => expect(upstreamSignal).toBeDefined());
+
+    downstream.abort(new Error("client_aborted"));
+    await responsePromise;
+
+    expect(upstreamSignal.aborted).toBe(true);
+  });
+
+  it("applies a bounded deadline with a stable timeout response", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      const signal = init!.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    }));
+
+    const routes = createProxyRoutes({ upstream: "https://upstream.test", timeoutMs: 50 });
+    const responsePromise = routes.request("http://localhost/api/v1/slow");
+    await vi.advanceTimersByTimeAsync(50);
+    const response = await responsePromise;
+
+    expect(response.status).toBe(504);
+    expect(await response.json()).toEqual({
+      error: "upstream_timeout",
+      message: "Upstream request timed out",
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/apps/bff/src/routes/proxy.ts
+++ b/apps/bff/src/routes/proxy.ts
@@ -40,10 +40,20 @@ function proxyHeaders(source: Headers): Headers {
 
   source.forEach((value, key) => {
     const normalizedKey = key.toLowerCase();
+    if (normalizedKey === 'set-cookie') return;
     if (!HOP_BY_HOP_HEADERS.has(normalizedKey) && !connectionHeaders.has(normalizedKey)) {
       headers.set(key, value);
     }
   });
+
+  type HeadersWithSetCookie = Headers & { getSetCookie?: () => string[] };
+  const getSetCookie = (source as HeadersWithSetCookie).getSetCookie;
+  const cookies = getSetCookie
+    ? getSetCookie.call(source)
+    : [source.get('set-cookie')].filter((cookie): cookie is string => cookie !== null);
+  for (const cookie of cookies) {
+    headers.append('set-cookie', cookie);
+  }
 
   return headers;
 }
@@ -72,13 +82,19 @@ async function forwardToUpstream(
   }
 
   const requestUrl = new URL(c.req.url);
-  const upstreamUrl = `${upstream}${upstreamPath}${requestUrl.search}`;
+  const base = upstream.endsWith('/') ? upstream.slice(0, -1) : upstream;
+  const path = upstreamPath.startsWith('/') ? upstreamPath : `/${upstreamPath}`;
+  const upstreamUrl = `${base}${path}${requestUrl.search}`;
   const headers = proxyHeaders(c.req.raw.headers);
   headers.set('x-proxied-by', 'argismonitor-bff');
 
   const controller = new AbortController();
   const abortUpstream = () => controller.abort(c.req.raw.signal.reason);
-  c.req.raw.signal.addEventListener('abort', abortUpstream, { once: true });
+  if (c.req.raw.signal.aborted) {
+    abortUpstream();
+  } else {
+    c.req.raw.signal.addEventListener('abort', abortUpstream, { once: true });
+  }
   const timeout = setTimeout(() => controller.abort(new Error('upstream_timeout')), timeoutMs);
 
   const init: RequestInit = {
@@ -97,7 +113,10 @@ async function forwardToUpstream(
       headers: responseHeaders,
     });
   } catch (error) {
-    if (controller.signal.aborted && !c.req.raw.signal.aborted) {
+    if (c.req.raw.signal.aborted) {
+      return new Response(null, { status: 499 });
+    }
+    if (controller.signal.aborted) {
       return c.json({
         error: 'upstream_timeout',
         message: 'Upstream request timed out',

--- a/apps/bff/src/routes/proxy.ts
+++ b/apps/bff/src/routes/proxy.ts
@@ -2,7 +2,7 @@ import { Hono, type Context } from 'hono';
 
 import { env } from '../env';
 
-const WEB_STACK_COOKIE = /(?:^|;\s*)web_stack=(svelte|next)/;
+const WEB_STACK_COOKIE = /(?:^|;\s*)web_stack=(svelte|next)(?:\s|;|$)/;
 
 const HOP_BY_HOP_HEADERS = new Set([
   'connection',
@@ -46,13 +46,15 @@ function proxyHeaders(source: Headers): Headers {
     }
   });
 
-  type HeadersWithSetCookie = Headers & { getSetCookie?: () => string[] };
-  const getSetCookie = (source as HeadersWithSetCookie).getSetCookie;
-  const cookies = getSetCookie
-    ? getSetCookie.call(source)
-    : [source.get('set-cookie')].filter((cookie): cookie is string => cookie !== null);
-  for (const cookie of cookies) {
-    headers.append('set-cookie', cookie);
+  if (!connectionHeaders.has('set-cookie')) {
+    type HeadersWithSetCookie = Headers & { getSetCookie?: () => string[] };
+    const getSetCookie = (source as HeadersWithSetCookie).getSetCookie;
+    const cookies = getSetCookie
+      ? getSetCookie.call(source)
+      : [source.get('set-cookie')].filter((cookie): cookie is string => cookie !== null);
+    for (const cookie of cookies) {
+      headers.append('set-cookie', cookie);
+    }
   }
 
   return headers;
@@ -182,9 +184,10 @@ async function forwardToUpstream(
         message: 'Upstream request timed out',
       }, 504);
     }
+    console.error({ err: error }, 'upstream proxy request failed');
     return c.json({
       error: 'upstream_unreachable',
-      message: (error as Error).message,
+      message: 'Upstream request failed',
     }, 502);
   } finally {
     clearTimeout(timeout);

--- a/apps/bff/src/routes/proxy.ts
+++ b/apps/bff/src/routes/proxy.ts
@@ -64,6 +64,50 @@ type ProxyOptions = {
   timeoutMs?: number;
 };
 
+function proxyResponseBody(
+  body: ReadableStream<Uint8Array> | null,
+  controller: AbortController,
+  cleanup: () => void,
+): ReadableStream<Uint8Array> | null {
+  if (!body) {
+    cleanup();
+    return null;
+  }
+
+  const reader = body.getReader();
+  let finished = false;
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    cleanup();
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async pull(stream) {
+      try {
+        const next = await reader.read();
+        if (next.done) {
+          finish();
+          stream.close();
+        } else {
+          stream.enqueue(next.value);
+        }
+      } catch (error) {
+        finish();
+        stream.error(error);
+      }
+    },
+    async cancel(reason) {
+      if (!controller.signal.aborted) controller.abort(reason);
+      try {
+        await reader.cancel(reason);
+      } finally {
+        finish();
+      }
+    },
+  });
+}
+
 async function forwardToUpstream(
   c: Context,
   upstreamPath: string,
@@ -90,12 +134,20 @@ async function forwardToUpstream(
 
   const controller = new AbortController();
   const abortUpstream = () => controller.abort(c.req.raw.signal.reason);
+  let abortListenerAttached = false;
+  const removeAbortListener = () => {
+    if (!abortListenerAttached) return;
+    abortListenerAttached = false;
+    c.req.raw.signal.removeEventListener('abort', abortUpstream);
+  };
   if (c.req.raw.signal.aborted) {
     abortUpstream();
   } else {
     c.req.raw.signal.addEventListener('abort', abortUpstream, { once: true });
+    abortListenerAttached = true;
   }
   const timeout = setTimeout(() => controller.abort(new Error('upstream_timeout')), timeoutMs);
+  let responseOwnsAbortListener = false;
 
   const init: RequestInit = {
     method: c.req.method,
@@ -106,12 +158,20 @@ async function forwardToUpstream(
 
   try {
     const upstreamResponse = await fetch(upstreamUrl, init);
+    clearTimeout(timeout);
     const responseHeaders = proxyHeaders(upstreamResponse.headers);
     responseHeaders.set('x-proxied-by', 'argismonitor-bff');
-    return new Response(upstreamResponse.body, {
+    const responseBody = proxyResponseBody(
+      upstreamResponse.body,
+      controller,
+      removeAbortListener,
+    );
+    const response = new Response(responseBody, {
       status: upstreamResponse.status,
       headers: responseHeaders,
     });
+    responseOwnsAbortListener = responseBody !== null;
+    return response;
   } catch (error) {
     if (c.req.raw.signal.aborted) {
       return new Response(null, { status: 499 });
@@ -128,7 +188,7 @@ async function forwardToUpstream(
     }, 502);
   } finally {
     clearTimeout(timeout);
-    c.req.raw.signal.removeEventListener('abort', abortUpstream);
+    if (!responseOwnsAbortListener) removeAbortListener();
   }
 }
 

--- a/apps/bff/src/routes/proxy.ts
+++ b/apps/bff/src/routes/proxy.ts
@@ -1,63 +1,131 @@
 import { Hono, type Context } from 'hono';
 
-const UPSTREAM = process.env.OMNIROUTE_UPSTREAM ?? 'http://localhost:20128';
-const DEFAULT_ROLLOUT = Number(process.env.OMNI_WEB_STACK_ROLLOUT ?? '100');
+import { env } from '../env';
+
 const WEB_STACK_COOKIE = /(?:^|;\s*)web_stack=(svelte|next)/;
 
-function shouldServeNext(cookieHeader: string | null): boolean {
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'content-length',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+function shouldServeNext(cookieHeader: string | null, rollout: number): boolean {
   if (!cookieHeader) return false;
-  const m = WEB_STACK_COOKIE.exec(cookieHeader);
-  if (m) return m[1] === 'next';
-  let h = 0;
+  const match = WEB_STACK_COOKIE.exec(cookieHeader);
+  if (match) return match[1] === 'next';
+
+  let hash = 0;
   for (let i = 0; i < cookieHeader.length; i++) {
-    h = (Math.imul(h, 31) + (cookieHeader.codePointAt(i) ?? 0)) % 2_147_483_647;
+    hash = (Math.imul(hash, 31) + (cookieHeader.codePointAt(i) ?? 0)) % 2_147_483_647;
   }
-  return Math.abs(h) % 100 >= DEFAULT_ROLLOUT;
+  return Math.abs(hash) % 100 >= rollout;
 }
+
+function proxyHeaders(source: Headers): Headers {
+  const headers = new Headers();
+  const connectionHeaders = new Set(
+    (source.get('connection') ?? '')
+      .split(',')
+      .map((header) => header.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  source.forEach((value, key) => {
+    const normalizedKey = key.toLowerCase();
+    if (!HOP_BY_HOP_HEADERS.has(normalizedKey) && !connectionHeaders.has(normalizedKey)) {
+      headers.set(key, value);
+    }
+  });
+
+  return headers;
+}
+
+type ProxyOptions = {
+  upstream?: string;
+  rollout?: number;
+  timeoutMs?: number;
+};
 
 async function forwardToUpstream(
   c: Context,
   upstreamPath: string,
+  {
+    upstream = env.OMNIROUTE_UPSTREAM,
+    rollout = Number(process.env.OMNI_WEB_STACK_ROLLOUT ?? '100'),
+    timeoutMs = env.BFF_UPSTREAM_TIMEOUT_MS,
+  }: ProxyOptions,
   honorRollout: boolean,
 ) {
-  if (honorRollout && shouldServeNext(c.req.header('cookie') ?? null)) {
+  if (honorRollout && shouldServeNext(c.req.header('cookie') ?? null, rollout)) {
     return c.json({
       message: 'This route is currently served by the Next.js frontend. Set web_stack=svelte or visit the upstream directly.',
-      nextjs_upstream: UPSTREAM,
+      nextjs_upstream: upstream,
     }, 410);
   }
 
-  const url = new URL(c.req.url);
-  const upstreamUrl = `${UPSTREAM}${upstreamPath}${url.search}`;
-
-  const headers = new Headers();
-  c.req.raw.headers.forEach((value, key) => {
-    if (!['host', 'content-length'].includes(key.toLowerCase())) headers.set(key, value);
-  });
+  const requestUrl = new URL(c.req.url);
+  const upstreamUrl = `${upstream}${upstreamPath}${requestUrl.search}`;
+  const headers = proxyHeaders(c.req.raw.headers);
   headers.set('x-proxied-by', 'argismonitor-bff');
+
+  const controller = new AbortController();
+  const abortUpstream = () => controller.abort(c.req.raw.signal.reason);
+  c.req.raw.signal.addEventListener('abort', abortUpstream, { once: true });
+  const timeout = setTimeout(() => controller.abort(new Error('upstream_timeout')), timeoutMs);
 
   const init: RequestInit = {
     method: c.req.method,
     headers,
     body: ['GET', 'HEAD'].includes(c.req.method) ? undefined : c.req.raw.body,
+    signal: controller.signal,
   };
 
   try {
-    const upstream = await fetch(upstreamUrl, init);
-    const responseHeaders = new Headers(upstream.headers);
+    const upstreamResponse = await fetch(upstreamUrl, init);
+    const responseHeaders = proxyHeaders(upstreamResponse.headers);
     responseHeaders.set('x-proxied-by', 'argismonitor-bff');
-    return new Response(upstream.body, { status: upstream.status, headers: responseHeaders });
-  } catch (err) {
-    return c.json({ error: 'upstream_unreachable', message: (err as Error).message }, 502);
+    return new Response(upstreamResponse.body, {
+      status: upstreamResponse.status,
+      headers: responseHeaders,
+    });
+  } catch (error) {
+    if (controller.signal.aborted && !c.req.raw.signal.aborted) {
+      return c.json({
+        error: 'upstream_timeout',
+        message: 'Upstream request timed out',
+      }, 504);
+    }
+    return c.json({
+      error: 'upstream_unreachable',
+      message: (error as Error).message,
+    }, 502);
+  } finally {
+    clearTimeout(timeout);
+    c.req.raw.signal.removeEventListener('abort', abortUpstream);
   }
 }
 
-export const proxyRoutes = new Hono().all('/*', (c) => {
-  const path = new URL(c.req.url).pathname.replace('/api/v1', '/v1');
-  return forwardToUpstream(c, path, true);
-});
+export function createProxyRoutes(options: ProxyOptions = {}) {
+  return new Hono().all('/*', (c) => {
+    const path = new URL(c.req.url).pathname.replace('/api/v1', '/v1');
+    return forwardToUpstream(c, path, options, true);
+  });
+}
 
-export const authProxyRoutes = new Hono().all('/*', (c) => {
-  const path = new URL(c.req.url).pathname;
-  return forwardToUpstream(c, path, false);
-});
+export function createAuthProxyRoutes(options: ProxyOptions = {}) {
+  return new Hono().all('/*', (c) => {
+    const path = new URL(c.req.url).pathname;
+    return forwardToUpstream(c, path, options, false);
+  });
+}
+
+export const proxyRoutes = createProxyRoutes();
+export const authProxyRoutes = createAuthProxyRoutes();

--- a/apps/bff/tests/unit/routes/proxy.test.ts
+++ b/apps/bff/tests/unit/routes/proxy.test.ts
@@ -96,15 +96,22 @@ describe("proxy routes", () => {
 
   it("returns the upstream stream without waiting for completion", async () => {
     let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    let upstreamSignal!: AbortSignal;
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
         streamController = controller;
       },
     });
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(body)));
+    vi.stubGlobal("fetch", vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      upstreamSignal = init!.signal as AbortSignal;
+      return new Response(body);
+    }));
 
+    const downstream = new AbortController();
     const routes = createProxyRoutes({ upstream: "https://upstream.test" });
-    const response = await routes.request("http://localhost/api/v1/stream");
+    const response = await routes.request(
+      new Request("http://localhost/api/v1/stream", { signal: downstream.signal }),
+    );
     const reader = response.body!.getReader();
 
     streamController.enqueue(new TextEncoder().encode("first"));
@@ -112,7 +119,9 @@ describe("proxy routes", () => {
 
     expect(new TextDecoder().decode(first.value)).toBe("first");
     expect(first.done).toBe(false);
-    streamController.close();
+    downstream.abort(new Error("client_aborted_after_headers"));
+    expect(upstreamSignal.aborted).toBe(true);
+    await reader.cancel();
   });
 
   it("propagates downstream cancellation to the upstream signal", async () => {

--- a/apps/bff/tests/unit/routes/proxy.test.ts
+++ b/apps/bff/tests/unit/routes/proxy.test.ts
@@ -20,7 +20,7 @@ describe("proxy routes", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const routes = createProxyRoutes({ upstream: "https://upstream.test" });
+    const routes = createProxyRoutes({ upstream: "https://upstream.test/" });
     const response = await routes.request("http://localhost/api/v1/chat/completions?stream=true", {
       method: "POST",
       headers: { cookie: "web_stack=svelte", "content-type": "text/plain" },
@@ -61,6 +61,8 @@ describe("proxy routes", () => {
       "x-upstream-remove": "private",
       "x-upstream-keep": "public",
     });
+    upstreamHeaders.append("set-cookie", "session=abc; Path=/; HttpOnly");
+    upstreamHeaders.append("set-cookie", "expires=later; Expires=Wed, 21 Oct 2026 07:28:00 GMT");
     const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
       expect(headers.get("connection")).toBeNull();
@@ -86,6 +88,10 @@ describe("proxy routes", () => {
     expect(response.headers.get("x-upstream-remove")).toBeNull();
     expect(response.headers.get("x-upstream-keep")).toBe("public");
     expect(response.headers.get("x-proxied-by")).toBe("argismonitor-bff");
+    expect(response.headers.getSetCookie()).toEqual([
+      "session=abc; Path=/; HttpOnly",
+      "expires=later; Expires=Wed, 21 Oct 2026 07:28:00 GMT",
+    ]);
   });
 
   it("returns the upstream stream without waiting for completion", async () => {
@@ -126,9 +132,30 @@ describe("proxy routes", () => {
     await vi.waitFor(() => expect(upstreamSignal).toBeDefined());
 
     downstream.abort(new Error("client_aborted"));
-    await responsePromise;
+    const response = await responsePromise;
 
     expect(upstreamSignal.aborted).toBe(true);
+    expect(response.status).toBe(499);
+    expect(await response.text()).toBe("");
+  });
+
+  it("does not start an already-aborted downstream request", async () => {
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect((init?.signal as AbortSignal).aborted).toBe(true);
+      throw new Error("sensitive-client-reason");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const downstream = new AbortController();
+    downstream.abort(new Error("sensitive-client-reason"));
+    const routes = createProxyRoutes({ upstream: "https://upstream.test" });
+    const response = await routes.request(
+      new Request("http://localhost/api/v1/models", { signal: downstream.signal }),
+    );
+
+    expect(response.status).toBe(499);
+    expect(await response.text()).toBe("");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("applies a bounded deadline with a stable timeout response", async () => {

--- a/apps/bff/tests/unit/routes/proxy.test.ts
+++ b/apps/bff/tests/unit/routes/proxy.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createProxyRoutes } from "./proxy";
+import { createAuthProxyRoutes, createProxyRoutes } from "../../../src/routes/proxy";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -35,6 +35,22 @@ describe("proxy routes", () => {
       headers: { cookie: "web_stack=next" },
     });
     expect(nextResponse.status).toBe(410);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves public auth paths without applying web-stack rollout", async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      expect(String(url)).toBe("https://upstream.test/api/auth/callback?code=test");
+      return new Response("ok");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const routes = createAuthProxyRoutes({ upstream: "https://upstream.test", rollout: 0 });
+    const response = await routes.request("http://localhost/api/auth/callback?code=test", {
+      headers: { cookie: "web_stack=next" },
+    });
+
+    expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/bff/tests/unit/routes/proxy.test.ts
+++ b/apps/bff/tests/unit/routes/proxy.test.ts
@@ -12,10 +12,12 @@ describe("proxy routes", () => {
   it("preserves routing, query, method, body, and rollout overrides", async () => {
     let forwardedBody = "";
     const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-      forwardedBody = await new Response(init?.body).text();
-      expect(String(url)).toBe("https://upstream.test/v1/chat/completions?stream=true");
-      expect(init?.method).toBe("POST");
-      expect(new Headers(init?.headers).get("x-proxied-by")).toBe("argismonitor-bff");
+      if (String(url).includes("/v1/chat/completions")) {
+        forwardedBody = await new Response(init?.body).text();
+        expect(String(url)).toBe("https://upstream.test/v1/chat/completions?stream=true");
+        expect(init?.method).toBe("POST");
+        expect(new Headers(init?.headers).get("x-proxied-by")).toBe("argismonitor-bff");
+      }
       return new Response("upstream", { status: 201 });
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -35,7 +37,12 @@ describe("proxy routes", () => {
       headers: { cookie: "web_stack=next" },
     });
     expect(nextResponse.status).toBe(410);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const nextgenResponse = await routes.request("http://localhost/api/v1/models", {
+      headers: { cookie: "web_stack=nextgen" },
+    });
+    expect(nextgenResponse.status).toBe(201);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("preserves public auth paths without applying web-stack rollout", async () => {
@@ -165,6 +172,24 @@ describe("proxy routes", () => {
     expect(response.status).toBe(499);
     expect(await response.text()).toBe("");
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a stable 502 without leaking upstream error details", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("dns lookup failed for secret-host.internal");
+      }),
+    );
+
+    const routes = createProxyRoutes({ upstream: "https://upstream.test" });
+    const response = await routes.request("http://localhost/api/v1/models");
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({
+      error: "upstream_unreachable",
+      message: "Upstream request failed",
+    });
   });
 
   it("applies a bounded deadline with a stable timeout response", async () => {


### PR DESCRIPTION
## Summary
- Cleanly replay the proxy-lifecycle half of #340 from closed PR #342 source commit `51d39d911` onto the restored v4 baseline.
- Add bounded upstream deadlines and stable 504 responses.
- Propagate pending downstream aborts and classify client disconnects as empty 499 responses without leaking abort reasons.
- Strip RFC hop-by-hop and connection-nominated headers while preserving repeated `Set-Cookie` values.
- Normalize trailing-slash upstream URLs and handle already-aborted requests.
- Preserve unbuffered response streaming, rollout behavior, and the public `/api/auth/*` proxy added during recovery.
- Use validated BFF upstream/timeout configuration and place tests under `apps/bff/tests/unit`.

## Provenance
- Supersedes closed draft #342.
- Source commit: `51d39d91111365d04ad5ff92a52b66c89bfa240b`.
- Conflict resolution retains PR #380 auth routing and hardened rollout hashing.
- Actual diff: 2 files, 299 insertions, 30 deletions.

## Validation
- `bun run test`: 8 files / 67 tests pass.
- `bun run typecheck`: pass.
- `bun run build`: bundle completed successfully.
- `git diff --check`: pass.

## Follow-up
The dashboard/SSE extraction half of #340 remains separate, as required by the issue delivery order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Requests are routed more reliably during staged rollouts.
  - Responses now stream efficiently without unnecessary delays.
  - Cookies and supported request details are preserved when forwarding traffic.
  - Connection-specific headers are filtered for improved compatibility and security.

- **Bug Fixes**
  - Added clearer handling for canceled requests, upstream timeouts, and unreachable services.
  - Timeout failures now return consistent error responses instead of hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->