### PR TITLE
fix: correct codeql-action/upload-sarif SHA for sha_pinning_required repo policy

### DIFF
--- a/.github/workflows/reusable/quality-gate.yml
+++ b/.github/workflows/reusable/quality-gate.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload SAST results
         if: ${{ steps.parse-na.outputs.skip_sast != 'true' && always() }}
-        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357
         with:
           sarif_file: semgrep-results.sarif
           category: 'semgrep'


### PR DESCRIPTION
Repo has `sha_pinning_required: true` — all action references must use commit SHAs.

**Root cause**: The  SHA in  was an annotated tag object, not a commit. GH Actions rejects non-commit SHAs at parse time, causing `startup_failure` on **all** workflows that reference this reusable.

**Fix**: Replaced the non-resolving SHA `b7351df...` with the peeled commit SHA `dd903d2...` (v3.28.14 tag → real commit).

**Verified**: This correctly SHA-pinned auto-release ran successfully on the feature branch with all 6 jobs green ([ref](https://github.com/KooshaPari/OmniRoute/actions/runs/29666168578)).