### PR TITLE
fix(rust): restore test and migration baseline (#390)

### DIFF
--- a/crates/omniroute-rs/crates/omniroute-core/src/stream.rs
+++ b/crates/omniroute-rs/crates/omniroute-core/src/stream.rs
@@ -161,7 +161,7 @@ mod tests {
                 logprobs: None,
             }],
             system_fingerprint: None,
-            usage: Some(Usage { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 }),
+            usage: Some(Usage::new(1, 2)),
             request_id: None,
         };
         let v = serde_json::to_value(&c).unwrap();

--- a/crates/omniroute-rs/crates/omniroute-storage/migrations/0001_initial.sql
+++ b/crates/omniroute-rs/crates/omniroute-storage/migrations/0001_initial.sql
@@ -1,8 +1,8 @@
 -- 0001_initial.sql
--- Initial schema for the OmniRoute Rust rewrite.
--- The CREATE TABLE statements below mirror the schema bootstrap in src/schema.rs
--- so the migration runner and the bootstrap stay in sync. Any divergence
--- should be resolved by editing both places.
+-- Migration marker for schema version 1.
+-- Full DDL lives in src/schema.rs (`SCHEMA_STATEMENTS`); keep both in sync
+-- when adding tables. Historical TypeScript `call_logs` is not recreated here;
+-- Rust uses `request_logs` as the canonical table name.
 
 CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER PRIMARY KEY,

--- a/crates/omniroute-rs/crates/omniroute-storage/src/migrations.rs
+++ b/crates/omniroute-rs/crates/omniroute-storage/src/migrations.rs
@@ -1,12 +1,13 @@
 //! Migration runner.
 //!
-//! Maintains a `schema_version` table. Each migration is a function that
-//! takes a connection and runs its SQL. Migrations are append-only; never
-//! edit a migration that has already been applied.
+//! Maintains a `schema_version` table. Version 1 delegates to
+//! [`crate::schema::ensure_schema`] so Rust-side DDL stays canonical.
+//! Historical quota tables from the removed `backend-rust` tree are deferred;
+//! they are provenance-only and not restored here.
 
 use crate::error::StorageError;
-use crate::schema::ensure_schema;
-use sqlx::{Connection, SqliteConnection, SqlitePool};
+use crate::schema::{ensure_schema, SCHEMA_VERSION};
+use sqlx::{SqliteConnection, SqlitePool};
 
 /// A single migration.
 pub struct Migration {
@@ -29,7 +30,6 @@ pub const MIGRATIONS: &[Migration] = &[
 
 /// Apply all pending migrations.
 pub async fn run_migrations(pool: &SqlitePool) -> Result<(), StorageError> {
-    // Ensure schema_version table exists
     ensure_schema(pool).await?;
 
     let mut conn = pool.acquire().await?;
@@ -69,4 +69,41 @@ async fn run_migration(
         .await?;
     tx.commit().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pool::{open, PoolOptions};
+
+    #[tokio::test]
+    async fn migrations_are_idempotent() {
+        let pool = open(PoolOptions::in_memory()).await.unwrap();
+        run_migrations(&pool).await.unwrap();
+        run_migrations(&pool).await.unwrap();
+        let version: i64 = sqlx::query_scalar("SELECT MAX(version) FROM schema_version")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION);
+    }
+
+    #[tokio::test]
+    async fn request_logs_is_canonical_log_table() {
+        let pool = open(PoolOptions::in_memory()).await.unwrap();
+        let n: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='request_logs'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 1);
+        let legacy: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='call_logs'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(legacy, 0);
+    }
 }

--- a/crates/omniroute-rs/crates/omniroute-storage/src/migrations.rs
+++ b/crates/omniroute-rs/crates/omniroute-storage/src/migrations.rs
@@ -7,7 +7,7 @@
 
 use crate::error::StorageError;
 use crate::schema::{ensure_schema, SCHEMA_VERSION};
-use sqlx::{SqliteConnection, SqlitePool};
+use sqlx::{Connection, SqliteConnection, SqlitePool};
 
 /// A single migration.
 pub struct Migration {

--- a/crates/omniroute-rs/crates/omniroute-storage/src/pool.rs
+++ b/crates/omniroute-rs/crates/omniroute-storage/src/pool.rs
@@ -81,6 +81,14 @@ impl PoolOptions {
 
 /// Open a SQLite pool with the given options and run migrations.
 pub async fn open(opts: PoolOptions) -> Result<SqlitePool, StorageError> {
+    if opts.path != Path::new(":memory:") {
+        if let Some(parent) = opts.path.parent() {
+            if !parent.as_os_str().is_empty() {
+                tokio::fs::create_dir_all(parent).await.map_err(StorageError::Io)?;
+            }
+        }
+    }
+
     let url = if opts.path == Path::new(":memory:") {
         "sqlite::memory:".to_string()
     } else {
@@ -103,13 +111,6 @@ pub async fn open(opts: PoolOptions) -> Result<SqlitePool, StorageError> {
         .await
         .map_err(|e| StorageError::Connection(e.to_string()))?;
 
-    // Ensure parent directory exists
-    if let Some(parent) = opts.path.parent() {
-        if !parent.as_os_str().is_empty() && parent != Path::new(":memory:") {
-            tokio::fs::create_dir_all(parent).await.map_err(StorageError::Io)?;
-        }
-    }
-
     ensure_schema(&pool).await?;
     Ok(pool)
 }
@@ -117,11 +118,28 @@ pub async fn open(opts: PoolOptions) -> Result<SqlitePool, StorageError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schema::SCHEMA_VERSION;
 
     #[tokio::test]
     async fn in_memory_pool_works() {
         let pool = open(PoolOptions::in_memory()).await.unwrap();
         let v: i64 = sqlx::query_scalar("SELECT 1").fetch_one(&pool).await.unwrap();
         assert_eq!(v, 1);
+    }
+
+    #[tokio::test]
+    async fn nested_path_creates_parent_directory() {
+        let base = std::env::temp_dir().join(format!("omniroute-test-{}", uuid::Uuid::new_v4()));
+        let db_path = base.join("nested").join("omniroute.sqlite");
+        let pool = open(PoolOptions::default().with_path(&db_path)).await.unwrap();
+        let v: i64 = sqlx::query_scalar("SELECT 1").fetch_one(&pool).await.unwrap();
+        assert_eq!(v, 1);
+        let version: i64 = sqlx::query_scalar("SELECT version FROM schema_version")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION);
+        drop(pool);
+        let _ = tokio::fs::remove_dir_all(&base).await;
     }
 }

--- a/crates/omniroute-rs/crates/omniroute-storage/src/schema.rs
+++ b/crates/omniroute-rs/crates/omniroute-storage/src/schema.rs
@@ -7,6 +7,9 @@
 use crate::error::StorageError;
 use sqlx::SqlitePool;
 
+/// Current schema version (monotonic integer; not the crate semver).
+pub const SCHEMA_VERSION: i64 = 1;
+
 /// All schema statements, in dependency order.
 pub const SCHEMA_STATEMENTS: &[&str] = &[
     // Schema version (for upgrade tracking)
@@ -79,7 +82,7 @@ pub const SCHEMA_STATEMENTS: &[&str] = &[
     r#"CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys(key_hash)"#,
     r#"CREATE INDEX IF NOT EXISTS idx_api_keys_status ON api_keys(status)"#,
 
-    // Request log
+    // Request log (canonical name; historical TS `call_logs` rows are not auto-imported)
     r#"CREATE TABLE IF NOT EXISTS request_logs (
         id TEXT PRIMARY KEY,
         request_id TEXT NOT NULL,
@@ -203,7 +206,7 @@ pub async fn ensure_schema(pool: &SqlitePool) -> Result<(), StorageError> {
     }
     // Record schema version if not present
     sqlx::query("INSERT OR IGNORE INTO schema_version (version, description) VALUES (?, ?)")
-        .bind(env!("CARGO_PKG_VERSION"))
+        .bind(SCHEMA_VERSION)
         .bind("OmniRoute Rust rewrite initial schema")
         .execute(pool)
         .await?;
@@ -225,6 +228,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count, 1);
+        let version: i64 = sqlx::query_scalar("SELECT version FROM schema_version")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Repair drifted Usage test initializer in omniroute-core.
- Use integer SCHEMA_VERSION instead of crate semver for schema_version.
- Create nested DB parent directories before SQLite connect.
- Document equest_logs as canonical over historical call_logs.
- Add migration idempotency and nested-path coverage.

## Test plan
- [ ] cargo test --workspace passes on CI
- [ ] Nested path pool open creates parent directory
- [ ] Schema bootstrap remains idempotent

Closes #390

Made with [Cursor](https://cursor.com)