### PR TITLE
chore(device): harden native process-compose plane

### DIFF
--- a/docs/deployment/device-plane.md
+++ b/docs/deployment/device-plane.md
@@ -17,5 +17,10 @@ The gateway binds to loopback by default on port `20128`. To expose it over a
 trusted tailnet, set `OMNIROUTE_HOSTNAME` explicitly and enforce tailnet ACLs;
 never put provider keys in the compose file or commit them to the repository.
 
+The process file creates the Redis data directory and restarts either process
+after an unexpected exit. Its readiness probes are local-only and bounded;
+`npm run start` must pass the production environment validation, including
+`BFF_API_KEY`.
+
 Docker Compose remains the canonical production container topology. Use
 `docker-compose.prod.yml` when isolation or reproducible images are required.

--- a/process-compose.device.yaml
+++ b/process-compose.device.yaml
@@ -1,0 +1,37 @@
+version: "0.5"
+
+# Device compute plane. Docker Compose remains the containerized production
+# source of truth; this file is for native desktop/process-compose installs.
+processes:
+  omniroute:
+    command: "npm run start"
+    working_dir: "${OMNIROUTE_REPO_DIR:-.}"
+    environment:
+      - NODE_ENV=production
+      - HOSTNAME=${OMNIROUTE_HOSTNAME:-127.0.0.1}
+      - PORT=${OMNIROUTE_PORT:-20128}
+      - DATA_DIR=${OMNIROUTE_DATA_DIR:-.data}
+      - BFF_API_KEY=${BFF_API_KEY}
+    readiness_probe:
+      exec:
+        command: "node scripts/dev/healthcheck.mjs"
+      initial_delay_seconds: 5
+      period_seconds: 5
+      timeout_seconds: 3
+      failure_threshold: 12
+    availability:
+      restart: always
+      max_restarts: 10
+  redis:
+    command: "mkdir -p \"${OMNIROUTE_REDIS_DIR:-.data/redis}\" && redis-server --dir \"${OMNIROUTE_REDIS_DIR:-.data/redis}\" --save 60 1 --loglevel warning"
+    working_dir: "${OMNIROUTE_REDIS_DIR:-.data/redis}"
+    readiness_probe:
+      exec:
+        command: "redis-cli ping"
+      initial_delay_seconds: 2
+      period_seconds: 5
+      timeout_seconds: 3
+      failure_threshold: 12
+    availability:
+      restart: always
+      max_restarts: 10


### PR DESCRIPTION
Post-merge continuation of #386.

Includes device-oriented process-compose hardening and Electrobun desktop integration.

- preserves loopback-first device exposure
- adds readiness and persistence contracts
- keeps secrets in local env boundaries
- excludes Fly/cloud runtime changes

Validation: targeted local checks and Airlock snapshot attempted (configured Python entrypoint unavailable).