### PR TITLE
fix(build): remove duplicate merged declarations

### DIFF
--- a/open-sse/services/autoCombo/scoring.ts
+++ b/open-sse/services/autoCombo/scoring.ts
@@ -246,26 +246,3 @@ export function validateWeights(weights: ScoringWeights): boolean {
   const sum = Object.values(weights).reduce((a, b) => a + b, 0);
   return Math.abs(sum - 1.0) < 0.01;
 }
-
-export function scorePool(
-  pool: ProviderCandidate[],
-  taskType: string,
-  weights?: ScoringWeights | undefined,
-  getTaskFitness: (model: string, taskType: string) => number = () => 0.5
-): ScoredProvider[] {
-  const effectiveWeights = weights ?? DEFAULT_WEIGHTS;
-
-  return pool
-    .map((candidate) => {
-      const factors = calculateFactors(candidate, pool, taskType, getTaskFitness);
-      const score = calculateScore(factors, effectiveWeights);
-      return {
-        provider: candidate.provider,
-        model: candidate.model,
-        score,
-        factors,
-        connectionId: candidate.connectionId,
-      };
-    })
-    .sort((a, b) => b.score - a.score);
-}

--- a/src/shared/utils/circuitBreaker.ts
+++ b/src/shared/utils/circuitBreaker.ts
@@ -710,7 +710,6 @@ export class OpossumCircuitBreaker {
 
 // ─── Opossum primary dispatch ──────────────────────────────────────────────
 
-const _opossumPrimaryEnabled = process.env.CIRCUIT_BREAKER_OPOSSUM_PRIMARY === "1";
 const _opossumRegistry = new Map<string, OpossumCircuitBreaker>();
 
 function getOrCreateOpossumBreaker(
@@ -749,14 +748,3 @@ export function __getOpossumShadowStats() {
 export function __resetOpossumShadowStats() {
   _opossumShadowStats = { enabled: false, fires: 0, divergences: 0, opossumOpens: 0, primaryOpens: 0 };
 }
-
-// ─── Wire primary dispatch into getCircuitBreaker ─────────────────────────
-// @ts-ignore — dynamic assignment into function body is intentional for env-gated dispatch
-const _getCircuitBreakerOrig = getCircuitBreaker;
-// @ts-ignore
-getCircuitBreaker = function(name: string, options?: CircuitBreakerOptions) {
-  if (_opossumPrimaryEnabled) {
-    return getOrCreateOpossumBreaker(name, options) as unknown as CircuitBreaker;
-  }
-  return _getCircuitBreakerOrig(name, options);
-};


### PR DESCRIPTION
Follow-up to #422. The merged import fix exposed duplicate declarations introduced by the dispatch/opossum merge: two `scorePool` exports and duplicate Opossum primary symbols. Remove the duplicate legacy implementations while retaining the enhanced routing and primary adapter paths.

Validation: Vitest auto-combo suite 11/11; circuit-breaker registry + dispatch tests pass; diff check clean.