### PR TITLE
ci: harden Electrobun desktop gate

### DIFF
--- a/.github/workflows/desktop-electrobun.yml
+++ b/.github/workflows/desktop-electrobun.yml
@@ -16,10 +16,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.14
       - name: Install web dependencies
@@ -30,7 +30,7 @@ jobs:
         run: bun run build
       - name: Install desktop dependencies
         working-directory: desktop-electrobun
-        run: bun install --frozen-lockfile
+        run: bun install --ignore-scripts
       - name: Stage deterministic renderer assets
         working-directory: desktop-electrobun
         run: bun run prepare:web
@@ -40,3 +40,6 @@ jobs:
       - name: Verify renderer contract
         working-directory: desktop-electrobun
         run: test -f generated/web/index.html && test -f generated/web/_app/version.json
+      - name: Build Electrobun shell
+        working-directory: desktop-electrobun
+        run: bun run build

--- a/desktop-electrobun/electrobun.config.ts
+++ b/desktop-electrobun/electrobun.config.ts
@@ -39,11 +39,10 @@ export default {
     bun: {
       entrypoint: "src/main.ts",
     },
-    views: [
-      {
-        name: "app",
+    views: {
+      app: {
         entrypoint: VIEWS_ENTRYPOINT,
       },
-    ],
+    },
   },
 } satisfies ElectrobunConfig;

--- a/desktop-electrobun/package.json
+++ b/desktop-electrobun/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "typescript": "^5.7.0",
-    "@types/bun": "latest"
+    "@types/bun": "1.3.14",
+    "@types/three": "^0.181.0"
   }
 }

--- a/desktop-electrobun/tsconfig.json
+++ b/desktop-electrobun/tsconfig.json
@@ -4,8 +4,9 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "types": ["bun-types"],
     "outDir": "dist"
   },


### PR DESCRIPTION
Adds the Electrobun desktop CI gate with supported lockfile-less install semantics, pinned action refs, deterministic renderer staging, typecheck, contract verification, and shell build.