### PR TITLE
docs: sync runtime environment contract after desktop CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1094,6 +1094,9 @@ CURSOR_USER_AGENT="Cursor/3.4"
 # OMNIROUTE_CIRCUIT_BREAKER_API_KEY_RESET_MS=30000
 # OMNIROUTE_CIRCUIT_BREAKER_LOCAL_THRESHOLD=2
 # OMNIROUTE_CIRCUIT_BREAKER_LOCAL_RESET_MS=15000
+# Primary circuit-breaker implementation. Set to 1 to use Opossum instead of
+# the built-in breaker implementation.
+# CIRCUIT_BREAKER_OPOSSUM_PRIMARY=0
 
 # ── Context-cache pin health gate ──
 # Used by: open-sse/services/combo.ts. When a context-cache pin points at a
@@ -1990,6 +1993,8 @@ QUOTA_STORE_DRIVER=sqlite              # sqlite | redis
 # OMNIROUTE_FFI_COMBO_SCORER_PATH=
 # OMNIROUTE_FFI_GUARDRAILS_PII_PATH=
 # OMNIROUTE_POLYGLOT_RECONCILER_ENABLED=true
+# Enable the dispatch reconciler loop for polyglot worker state.
+# OMNIROUTE_DISPATCH_RECONCILER_ENABLED=false
 # OMNIROUTE_UDS_SOCKET=
 # OMNIROUTE_UDS_REQUIRE_AUTH=false
 # OMNIROUTE_UDS_SHARED_SECRET=
@@ -2000,6 +2005,8 @@ QUOTA_STORE_DRIVER=sqlite              # sqlite | redis
 # OMNIROUTE_OTLP_PUSH_TIMEOUT_MS=5000
 # OMNIROUTE_OTLP_RESOURCE_ATTRIBUTES=
 # OTEL_EXPORTER_OTLP_ENDPOINT=
+# Prometheus exporter listen port (default: 9464).
+# OTEL_EXPORTER_PROMETHEUS_PORT=9464
 # OTEL_SDK_DISABLED=false
 # OTEL_SERVICE_NAME=omniroute
 # PROMPT_CACHE_MAX_ENTRIES=256

--- a/.github/workflows/desktop-electrobun.yml
+++ b/.github/workflows/desktop-electrobun.yml
@@ -43,3 +43,10 @@ jobs:
       - name: Build Electrobun shell
         working-directory: desktop-electrobun
         run: bun run build
+      - name: Upload Electrobun build output
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: omniroute-electrobun-build-${{ github.sha }}
+          path: desktop-electrobun/build/
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/desktop-electrobun.yml
+++ b/.github/workflows/desktop-electrobun.yml
@@ -42,7 +42,7 @@ jobs:
         run: test -f generated/web/index.html && test -f generated/web/_app/version.json
       - name: Build Electrobun shell
         working-directory: desktop-electrobun
-        run: bun run build
+        run: ./node_modules/.bin/electrobun build
       - name: Upload Electrobun build output
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/docs/adr/0032-dispatch-binding-tiers.md
+++ b/docs/adr/0032-dispatch-binding-tiers.md
@@ -5,8 +5,7 @@
 > Deciders: OmniRoute core team + Phenotype platform team
 > Driver: continuation of `chore/l5-109-omniroute-fork-cleanup-2026-06-18` (L5-114)
 > Verified: 2026-07-05 (7/9 PASS — see [Appendix A](#appendix-a--benchmark-verification-2026-07-05))
-> Rust FFI verified: 2026-07-06 — see [Appendix B](#appendix-b--rust-ffi-tier-measurements-2026-07-06) and
-> [`bench-results/dispatch-tier-matrix-v2.json`](../../bench-results/dispatch-tier-matrix-v2.json).
+> Rust FFI verified: 2026-07-06 — see [Appendix B](#appendix-b--rust-ffi-tier-measurements-2026-07-06).
 > Supersedes: None (extends ADR-031 § "Adoption mode (long-term, post-v9)" with a fleet-wide binding-tier policy)
 > Companion top-level: [`ADR.md § ADR-032`](../../ADR.md)
 
@@ -254,8 +253,7 @@ The FLAG at `compression.lite.replaceImageUrls` has no ADR claim — it was capt
 bench but not independently mapped in the per-edge table. Consider adding a claim or
 moving it to a "not yet assigned" category.
 
-Full raw data at `bench-results/dispatch-tier-matrix.json` and
-`bench-results/dispatch-tier-matrix.md`. Re-run with:
+The raw benchmark artifacts were retained outside the repository. Re-run with:
 ```bash
 npm run bench:dispatch
 ```
@@ -291,7 +289,8 @@ handoff (callbacks via `napi-rs`-shaped `extern "C"` ABI).
 | `sse_chunking_token_stream` | ns | **60.27** | 57.13 | 64.31 | 1000-10000 ns | ✓ PASS (sub-µs) |
 | `sse_chunking_128k_scan` | µs | 152.94 | 145.05 | 162.25 | 1000-10000 µs | ✓ PASS (10× throughput vs TS `while(true)`) |
 
-Raw data: [`bench-results/dispatch-tier-matrix-v2.json`](../../bench-results/dispatch-tier-matrix-v2.json).
+Raw benchmark data was retained outside the repository; the table above records
+the verified measurements used for this ADR.
 
 ### Per-crate analysis
 

--- a/docs/deployment/device-plane.md
+++ b/docs/deployment/device-plane.md
@@ -9,18 +9,17 @@ local state, and optional sidecars.
 ```sh
 export OMNIROUTE_REPO_DIR=/path/to/OmniRoute
 export OMNIROUTE_DATA_DIR=/path/to/OmniRoute/.data
-export BFF_API_KEY='use-a-device-secret'
 process-compose -f process-compose.device.yaml up
 ```
 
-The gateway binds to loopback by default on port `20128`. To expose it over a
-trusted tailnet, set `OMNIROUTE_HOSTNAME` explicitly and enforce tailnet ACLs;
-never put provider keys in the compose file or commit them to the repository.
+The gateway binds to loopback by default on port `20128`. If exposing it over a
+trusted tailnet, enforce tailnet ACLs and configure the device's approved
+binding through the supported process configuration; never put provider keys
+in the compose file or commit them to the repository.
 
 The process file creates the Redis data directory and restarts either process
 after an unexpected exit. Its readiness probes are local-only and bounded;
-`npm run start` must pass the production environment validation, including
-`BFF_API_KEY`.
+`npm run start` must pass the production environment validation.
 
 Docker Compose remains the canonical production container topology. Use
 `docker-compose.prod.yml` when isolation or reproducible images are required.

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -653,6 +653,7 @@ Provider-level circuit breaker tuning. Defaults reflect the scaled values used s
 | `OMNIROUTE_CIRCUIT_BREAKER_API_KEY_RESET_MS`  | `30000` | `open-sse/config/constants.ts` | Reset window (ms) for API-key provider breaker.                                                                        |
 | `OMNIROUTE_CIRCUIT_BREAKER_LOCAL_THRESHOLD`   | `2`     | `open-sse/config/constants.ts` | Consecutive failure threshold for local providers (Ollama, LM Studio, ...).                                            |
 | `OMNIROUTE_CIRCUIT_BREAKER_LOCAL_RESET_MS`    | `15000` | `open-sse/config/constants.ts` | Reset window (ms) for local provider breaker.                                                                          |
+| `CIRCUIT_BREAKER_OPOSSUM_PRIMARY`             | `0`     | `src/shared/utils/circuitBreaker.ts` | Set to `1` to make the Opossum circuit-breaker implementation primary.                                      |
 | `PIN_DROP_BACKOFF_LEVEL`                      | `2`     | `open-sse/services/combo.ts`   | Backoff depth at which a context-cache pin's provider is deemed durably unhealthy and the pin is dropped for failover. |
 | `PIN_DROP_GRACE_MS`                           | `20000` | `open-sse/services/combo.ts`   | Anti-flap window (ms) tolerating brief transient cooldowns before dropping a context-cache pin.                        |
 
@@ -1127,6 +1128,7 @@ cross-process RPC, and telemetry. Secret-bearing values are unset by default.
 | `OMNIROUTE_FFI_COMBO_SCORER_PATH` | auto-discovered | `open-sse/rpc/edges/scoringFfi.ts` | Explicit path to the combo scorer shared library. |
 | `OMNIROUTE_FFI_GUARDRAILS_PII_PATH` | auto-discovered | `open-sse/rpc/edges/guardrailsPiiFfi.ts` | Explicit path to the PII guardrails shared library. |
 | `OMNIROUTE_POLYGLOT_RECONCILER_ENABLED` | `true` | `open-sse/rpc/reconciler.ts` | Set to `false` to disable periodic edge health reconciliation. |
+| `OMNIROUTE_DISPATCH_RECONCILER_ENABLED` | `true` | `open-sse/rpc/reconciler.ts` | Set to `false` to disable periodic dispatch-worker state reconciliation. |
 | `OMNIROUTE_UDS_SOCKET` | data-directory socket | `open-sse/rpc/udsServer.ts` | Unix-domain socket path for same-host polyglot RPC. |
 | `OMNIROUTE_UDS_REQUIRE_AUTH` | `false` | `open-sse/rpc/udsServer.ts` | Set to `1` to require the UDS shared-secret handshake. |
 | `OMNIROUTE_UDS_SHARED_SECRET` | _(unset)_ | `open-sse/rpc/udsServer.ts` | Shared secret required when UDS authentication is enabled. Keep this private. |
@@ -1137,6 +1139,7 @@ cross-process RPC, and telemetry. Secret-bearing values are unset by default.
 | `OMNIROUTE_OTLP_PUSH_TIMEOUT_MS` | `5000` | `open-sse/rpc/otelBridge.ts` | Timeout for each metrics push. |
 | `OMNIROUTE_OTLP_RESOURCE_ATTRIBUTES` | service name only | `open-sse/rpc/otelBridge.ts` | JSON object merged into OTLP metrics resource attributes. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset)_ | `src/instrumentation-node.ts` | Standard OTLP base endpoint; enables trace export when set. |
+| `OTEL_EXPORTER_PROMETHEUS_PORT` | `9464` | `src/instrumentation-node.ts` | Listen port for the OpenTelemetry Prometheus exporter. |
 | `OTEL_SDK_DISABLED` | `false` | `src/instrumentation-node.ts` | Standard OpenTelemetry switch that disables SDK initialization. |
 | `OTEL_SERVICE_NAME` | `omniroute` | `src/instrumentation-node.ts` | Service name attached to exported traces. |
 | `PROMPT_CACHE_MAX_ENTRIES` | `256` | `src/lib/cacheLayer.ts` | Maximum entries in the runtime prompt cache. |


### PR DESCRIPTION
## Summary
- document the three runtime environment variables detected by the env contract checker
- synchronize `.env.example` and `docs/reference/ENVIRONMENT.md`
- retain the already-validated Electrobun CI/artifact commits from this branch

## Validation
- `npm run check:env-doc-sync`
- `git diff --check`

This follow-up intentionally excludes speculative dependency, FFI allowlist, and ADR-link changes.