### PR TITLE
ci: harden CodeQL and DOMPurify lock checks

### DIFF
--- a/.github/workflows/cargo-lock-hash.yaml
+++ b/.github/workflows/cargo-lock-hash.yaml
@@ -40,3 +40,35 @@ jobs:
             exit 1
           fi
           echo "✅ package-lock.json is deterministic."
+      - name: Reject vulnerable nested DOMPurify versions
+        run: |
+          npm ci --ignore-scripts --no-audit --no-fund
+          npm ls dompurify --all --json > /tmp/omniroute-npm-ls.json 2>/dev/null || true
+          node <<'NODE'
+          const fs = require("node:fs");
+          const tree = JSON.parse(fs.readFileSync("/tmp/omniroute-npm-ls.json", "utf8"));
+          const vulnerable = [];
+          const minimum = [3, 4, 12];
+          const compare = (version) => {
+            const parts = String(version).replace(/^[^0-9]*/, "").split(".").map(Number);
+            for (let i = 0; i < minimum.length; i += 1) {
+              if ((parts[i] || 0) !== minimum[i]) return (parts[i] || 0) - minimum[i];
+            }
+            return 0;
+          };
+          const visit = (node, path) => {
+            if (!node || typeof node !== "object") return;
+            if (node.name === "dompurify" && node.version && compare(node.version) < 0) {
+              vulnerable.push(`${path}/dompurify@${node.version}`);
+            }
+            for (const [name, dependency] of Object.entries(node.dependencies || {})) {
+              visit(dependency, `${path}/${name}`);
+            }
+          };
+          visit(tree, "root");
+          if (vulnerable.length) {
+            console.error(`::error::Vulnerable DOMPurify versions found (<3.4.12): ${vulnerable.join(", ")}`);
+            process.exit(1);
+          }
+          console.log("DOMPurify invariant passed: every installed version is >=3.4.12.");
+          NODE

--- a/.github/workflows/qgate.yml
+++ b/.github/workflows/qgate.yml
@@ -32,6 +32,7 @@ permissions:
 jobs:
   qgate:
     continue-on-error: true   # remove once coverage ≥60%
+    timeout-minutes: 45       # bound npm/coverage/Rust stalls; preserve a terminal gate result
 
     runs-on: ubuntu-latest   # Linux standard only — no billed runners
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -62,7 +62,9 @@ jobs:
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    # CodeQL query runtime varies substantially across the TypeScript surface;
+    # allow the slowest CWE queries to finish instead of canceling mid-analysis.
+    timeout-minutes: 45
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
## Summary
- allow CodeQL deep query workloads up to 45 minutes
- fail hosted lock checks when any installed DOMPurify is below 3.4.12

## Validation
- actionlint passed
- Lock Hash Check run 29972045993 passed on commit 2aa95fe193076f448ea4561d1a432fb101ee1ba5
- DOMPurify invariant passed across full npm dependency tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated checks to prevent vulnerable versions of a transitive security dependency from being installed.
  * Increased the security scan time limit to reduce incomplete analyses caused by timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->