### PR TITLE
ci(desktop): Electrobun gate; path-filter legacy Electron smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       docs: ${{ steps.classify.outputs.docs }}
       i18n: ${{ steps.classify.outputs.i18n }}
       workflow: ${{ steps.classify.outputs.workflow }}
+      electron: ${{ steps.classify.outputs.electron }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -46,6 +47,7 @@ jobs:
               echo "docs=true"
               echo "i18n=true"
               echo "workflow=true"
+              echo "electron=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -54,6 +56,9 @@ jobs:
           docs=false
           i18n=false
           workflow=false
+          # Legacy Electron shell — only required when electron/ or its smoke path changes.
+          # Canonical desktop spike is desktop-electrobun/ (ADR-ECO-015); see desktop-electrobun.yml.
+          electron=false
 
           git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
 
@@ -70,7 +75,11 @@ jobs:
                 i18n=true
                 code=true
                 ;;
-              src/*|open-sse/*|bin/*|electron/*|tests/*|scripts/*|package.json|package-lock.json|tsconfig*.json|next.config.*|vitest*.config.*|playwright.config.*)
+              electron/*|scripts/dev/smoke-electron*|electron-package-smoke*)
+                electron=true
+                code=true
+                ;;
+              src/*|open-sse/*|bin/*|tests/*|scripts/*|package.json|package-lock.json|tsconfig*.json|next.config.*|vitest*.config.*|playwright.config.*)
                 code=true
                 ;;
               db/*|config/*)
@@ -87,6 +96,7 @@ jobs:
             echo "docs=$docs"
             echo "i18n=$i18n"
             echo "workflow=$workflow"
+            echo "electron=$electron"
           } >> "$GITHUB_OUTPUT"
 
   lint:
@@ -575,7 +585,10 @@ jobs:
     name: Electron Package Smoke
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: build
+    # Legacy Electron path only. Canonical desktop gate is Electrobun
+    # (.github/workflows/desktop-electrobun.yml). Skip on PRs that do not touch electron/.
+    needs: [changes, build]
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.electron == 'true' }}
     env:
       JWT_SECRET: ci-build-secret-with-sufficient-length-for-validation
       CSC_IDENTITY_AUTO_DISCOVERY: "false"

--- a/.github/workflows/desktop-electrobun.yml
+++ b/.github/workflows/desktop-electrobun.yml
@@ -4,7 +4,15 @@ on:
   pull_request:
     paths:
       - "desktop-electrobun/**"
+      - "apps/desktop/**"
       - "apps/web/**"
+      - "scripts/build/prepare-electrobun-web.mjs"
+      - ".github/workflows/desktop-electrobun.yml"
+  push:
+    branches: [main]
+    paths:
+      - "desktop-electrobun/**"
+      - "apps/desktop/**"
       - "scripts/build/prepare-electrobun-web.mjs"
       - ".github/workflows/desktop-electrobun.yml"
   workflow_dispatch:

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -7,3 +7,5 @@ Implementation lives at the repo root until promotion is complete:
 **→ [`../../desktop-electrobun/`](../../desktop-electrobun/)**
 
 Work there; this directory is a redirect only (no duplicated source).
+
+**Not Electron.** The legacy `electron/` tree remains for release packaging until the Electrobun selection gate passes; CI Electron Package Smoke is path-filtered to `electron/**` only. Prefer ElectroBun (or a Tauri spike branch) for new desktop work.

--- a/desktop-electrobun/README.md
+++ b/desktop-electrobun/README.md
@@ -3,7 +3,7 @@
 > **Status:** Selection-gate spike (ADR-ECO-015 hybrid gateway app layer)  
 > **Registry choice:** FFI + Electrobun → canonical path `apps/desktop/` (this tree promoted from repo root)
 
-Electrobun + Bun shell that wraps the OmniRoute web UI (`RENDERER_URL`, default `http://localhost:3000`) with optional one-click `process-compose` service boot. Existing Electron shell remains in [`../electron/`](../electron/) until this spike passes the gate below.
+Electrobun + Bun shell that wraps the OmniRoute web UI (`RENDERER_URL`, default `http://localhost:3000`) with optional one-click `process-compose` service boot. This is the **canonical desktop spike** (not Electron, not Tauri-on-main). Legacy Electron remains in [`../electron/`](../electron/) for packaging until this spike passes the gate below; CI Electron smoke is path-filtered and is not the required desktop gate.
 
 ## Selection gate
 


### PR DESCRIPTION
## Summary
- Path-filter **Electron Package Smoke** so it runs on PRs only when `electron/**` (or Electron smoke scripts) change.
- Keep **Electrobun** as the ADR-ECO-015 canonical desktop spike; extend `desktop-electrobun.yml` to watch `apps/desktop/**` and `main` pushes.
- Clarify READMEs: new desktop work is Electrobun (or a Tauri spike), not Electron.

## Test plan
- [ ] Change Classification emits `electron=false` on this PR (no Electron smoke job).
- [ ] Electrobun desktop workflow runs because `desktop-electrobun/**` / workflow paths changed.
- [ ] Confirm Electron smoke still runs on `main` pushes and on electron-only PRs.
