### PR TITLE
ci: make coverage and protected aggregates fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,8 +146,8 @@ jobs:
     # the coverage artifact and MUST still run so cycle drift is measured on the
     # release PR — otherwise a flake silently skips the whole gate (incident: v3.8.36
     # release PR #4854, where the drift cascade only surfaced post-merge in #5029).
-    # The coverage.* metrics degrade gracefully: the download is continue-on-error and
-    # the ratchet runs with --allow-missing, so absent coverage is skipped, not failed.
+    # Coverage.* metrics are blocking: the download and ratchet fail when coverage is
+    # absent, preventing a skipped coverage shard from silently bypassing quality gates.
     if: ${{ !cancelled() }}
     # security-events: read lets the CodeQL ratchet read open code-scanning alerts
     # via `gh api .../code-scanning/alerts`. contents: read keeps checkout working.
@@ -163,13 +163,9 @@ jobs:
           node-version: ${{ env.CI_NODE_VERSION }}
           cache: npm
       - uses: ./.github/actions/npm-ci-retry
-      # Coverage mergeada (coverage-summary.json) p/ o ratchet de cobertura.
-      # continue-on-error: o artifact pode não existir se a job test-coverage foi
-      # SKIPPED (shard flaky). Nesse caso collect-metrics pula coverage.* (ausente sem
-      # erro) e o ratchet roda com --allow-missing — as métricas determinísticas
-      # (eslint/complexity/cognitive) seguem BLOQUEANTES.
+      # Coverage mergeada (coverage-summary.json) para o ratchet de cobertura.
+      # A ausência do artefato é uma falha: cobertura é uma condição de qualidade.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        continue-on-error: true
         with:
           name: coverage-report
           path: coverage/
@@ -177,10 +173,8 @@ jobs:
       # Catraca: falha se qualquer métrica regredir vs quality-baseline.json (commitado).
       # Hoje: contagem de warnings do ESLint. Fase 4 estende com cobertura (lida do
       # coverage mergeado). Tamanho de arquivo e duplicação têm gates dedicados.
-      # --allow-missing: pula métricas do baseline ausentes do collect (coverage.* quando
-      # o artifact não veio) em vez de falhar — mantém os gates determinísticos ativos.
       - name: Ratchet check
-        run: node scripts/quality/check-quality-ratchet.mjs --allow-missing --summary .artifacts/quality-ratchet.md
+        run: node scripts/quality/check-quality-ratchet.mjs --summary .artifacts/quality-ratchet.md
       # Fase 6A.5: require-tighten — BLOQUEANTE (promovido de advisory no fim do ciclo
       # v3.8.27). Falha quando uma métrica MELHOROU sem o baseline ter sido apertado no
       # mesmo PR (força capturar ganhos permanentes). As métricas coverage.* carregam
@@ -189,7 +183,7 @@ jobs:
       # mergeada == baseline (ver a nota _require_tighten_flip_blocking em
       # config/quality/quality-baseline.json).
       - name: Require-tighten (blocking)
-        run: node scripts/quality/check-quality-ratchet.mjs --allow-missing --require-tighten
+        run: node scripts/quality/check-quality-ratchet.mjs --require-tighten
       # Catraca de duplicação (jscpd@4 sobre src+open-sse). Roda neste job (paralelo)
       # para não pesar no caminho crítico do lint.
       - name: Duplication ratchet
@@ -1128,7 +1122,6 @@ jobs:
       - run: node scripts/check/check-job-results.mjs
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
-          ALLOW_SKIPPED: pr-test-policy,build,package-artifact,electron-package-smoke,test-unit,test-vitest,node-24-compat,node-26-compat-build,node-26-compat,test-coverage,sonarqube
 
   protected-e2e:
     name: ci/e2e
@@ -1142,7 +1135,6 @@ jobs:
       - run: node scripts/check/check-job-results.mjs
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
-          ALLOW_SKIPPED: build,test-e2e,test-integration
 
   release-green:
     name: release-green

--- a/.github/workflows/qgate.yml
+++ b/.github/workflows/qgate.yml
@@ -31,7 +31,6 @@ permissions:
 
 jobs:
   qgate:
-    continue-on-error: true   # remove once coverage ≥60%
     timeout-minutes: 45       # bound npm/coverage/Rust stalls; preserve a terminal gate result
 
     runs-on: ubuntu-latest   # Linux standard only — no billed runners
@@ -56,7 +55,6 @@ jobs:
       # Generate coverage report (lcov) from existing test suite.
       - name: Generate coverage (lcov)
         id: coverage
-        continue-on-error: true
         run: npm run test:coverage
         env:
           NODE_ENV: test


### PR DESCRIPTION
## Summary

Make the coverage/protected aggregate workflow behavior fail closed on the exact-main candidate.

- Base: \\