### PR TITLE
ci: publish macOS Electrobun app artifact

### DIFF
--- a/.github/workflows/cargo-lock-hash.yaml
+++ b/.github/workflows/cargo-lock-hash.yaml
@@ -40,3 +40,35 @@ jobs:
             exit 1
           fi
           echo "✅ package-lock.json is deterministic."
+      - name: Reject vulnerable nested DOMPurify versions
+        run: |
+          npm ci --ignore-scripts --no-audit --no-fund
+          npm ls dompurify --all --json > /tmp/omniroute-npm-ls.json 2>/dev/null || true
+          node <<'NODE'
+          const fs = require("node:fs");
+          const tree = JSON.parse(fs.readFileSync("/tmp/omniroute-npm-ls.json", "utf8"));
+          const vulnerable = [];
+          const minimum = [3, 4, 12];
+          const compare = (version) => {
+            const parts = String(version).replace(/^[^0-9]*/, "").split(".").map(Number);
+            for (let i = 0; i < minimum.length; i += 1) {
+              if ((parts[i] || 0) !== minimum[i]) return (parts[i] || 0) - minimum[i];
+            }
+            return 0;
+          };
+          const visit = (node, path) => {
+            if (!node || typeof node !== "object") return;
+            if (node.name === "dompurify" && node.version && compare(node.version) < 0) {
+              vulnerable.push(`${path}/dompurify@${node.version}`);
+            }
+            for (const [name, dependency] of Object.entries(node.dependencies || {})) {
+              visit(dependency, `${path}/${name}`);
+            }
+          };
+          visit(tree, "root");
+          if (vulnerable.length) {
+            console.error(`::error::Vulnerable DOMPurify versions found (<3.4.12): ${vulnerable.join(", ")}`);
+            process.exit(1);
+          }
+          console.log("DOMPurify invariant passed: every installed version is >=3.4.12.");
+          NODE

--- a/.github/workflows/desktop-electrobun.yml
+++ b/.github/workflows/desktop-electrobun.yml
@@ -50,3 +50,48 @@ jobs:
           path: desktop-electrobun/build/
           if-no-files-found: error
           retention-days: 7
+
+  macos-app:
+    name: macOS .app bundle
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+      - name: Install web dependencies
+        working-directory: apps/web
+        run: bun install --frozen-lockfile
+      - name: Build web client handoff
+        working-directory: apps/web
+        run: bun run build
+      - name: Install desktop dependencies
+        working-directory: desktop-electrobun
+        run: bun install --ignore-scripts
+      - name: Build macOS release bundle
+        working-directory: desktop-electrobun
+        run: bun run build:release
+      - name: Stage macOS app artifact
+        working-directory: desktop-electrobun
+        shell: bash
+        run: |
+          set -euo pipefail
+          app_path="$(find build -type d -name '*.app' -print -quit)"
+          if [[ -z "$app_path" ]]; then
+            echo "::error::Electrobun did not produce a macOS .app bundle"
+            find build -maxdepth 3 -print 2>/dev/null || true
+            exit 1
+          fi
+          rm -rf artifacts
+          mkdir -p artifacts
+          cp -R "$app_path" artifacts/OmniRoute.app
+          ditto -c -k --sequesterRsrc --keepParent artifacts/OmniRoute.app artifacts/OmniRoute-macos.zip
+      - name: Upload macOS app artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: omniroute-electrobun-macos-${{ github.sha }}
+          path: desktop-electrobun/artifacts/
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/qgate.yml
+++ b/.github/workflows/qgate.yml
@@ -32,6 +32,7 @@ permissions:
 jobs:
   qgate:
     continue-on-error: true   # remove once coverage ≥60%
+    timeout-minutes: 45       # bound npm/coverage/Rust stalls; preserve a terminal gate result
 
     runs-on: ubuntu-latest   # Linux standard only — no billed runners
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -62,7 +62,9 @@ jobs:
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    # CodeQL query runtime varies substantially across the TypeScript surface;
+    # allow the slowest CWE queries to finish instead of canceling mid-analysis.
+    timeout-minutes: 45
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
Adds a macOS runner that builds and uploads OmniRoute.app plus a zip artifact.

Validation: workflow run 29989740663 succeeded; artifact ID 8556553252.