### PR TITLE
fix(v4/#392): KBridge inflight-before-write, deadlines, Win pipes

### DIFF
--- a/apps/bff/src/cors-origins.test.ts
+++ b/apps/bff/src/cors-origins.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCorsOrigins } from "./cors-origins";
+
+describe("parseCorsOrigins", () => {
+  it("parses a bounded http(s) allowlist and drops credentials / junk", () => {
+    expect(
+      parseCorsOrigins(
+        "http://localhost:4321, https://app.example.com, ftp://bad, http://user:pass@evil, not-a-url",
+      ),
+    ).toEqual(["http://localhost:4321", "https://app.example.com"]);
+  });
+
+  it("dedupes origins", () => {
+    expect(parseCorsOrigins("http://localhost:4321,http://localhost:4321/")).toEqual([
+      "http://localhost:4321",
+    ]);
+  });
+});

--- a/apps/bff/src/cors-origins.ts
+++ b/apps/bff/src/cors-origins.ts
@@ -1,0 +1,20 @@
+/** Parse BFF_CORS_ORIGINS into a bounded allowlist of absolute http(s) origins. */
+export function parseCorsOrigins(raw: string): string[] {
+  const origins = raw
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      try {
+        const url = new URL(part);
+        if (!["http:", "https:"].includes(url.protocol)) return null;
+        if (url.username || url.password) return null;
+        return url.origin;
+      } catch {
+        return null;
+      }
+    })
+    .filter((origin): origin is string => origin !== null);
+
+  return [...new Set(origins)];
+}

--- a/apps/bff/src/index.test.ts
+++ b/apps/bff/src/index.test.ts
@@ -135,3 +135,50 @@ describe("BFF observability placeholders", () => {
     });
   });
 });
+
+describe("BFF tRPC honesty", () => {
+  it("does not fabricate provider persistence", async () => {
+    const response = await app.request("http://localhost/api/trpc/providers.create", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "p1",
+        name: "Test",
+        type: "openai",
+        config: {},
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      result: {
+        data: {
+          ok: false,
+          status: "unavailable",
+          source: "no-provider-store",
+          provider: null,
+        },
+      },
+    });
+  });
+
+  it("does not fabricate key creation", async () => {
+    const response = await app.request("http://localhost/api/trpc/keys.create", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "k1" }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      result: {
+        data: {
+          ok: false,
+          status: "unavailable",
+          source: "no-key-store",
+          key: null,
+        },
+      },
+    });
+  });
+});

--- a/apps/bff/src/index.ts
+++ b/apps/bff/src/index.ts
@@ -5,18 +5,31 @@ import { dashboardRoutes } from './routes/dashboard';
 import { authProxyRoutes, proxyRoutes } from './routes/proxy';
 import { gatewayRoutes } from './routes/gateway/proxy';
 import { trpcRoutes } from './trpc/hono';
-import { requireAuth } from './middleware/auth';
+import { requireAuthOrSession } from './middleware/auth';
+import { parseCorsOrigins } from './cors-origins';
 import { env } from './env';
 import { z } from 'zod';
 
 const app = new Hono();
+const corsOrigins = parseCorsOrigins(env.BFF_CORS_ORIGINS);
 
 app.use('*', logger());
-app.use('*', cors({ origin: ['http://localhost:4321'], credentials: true }));
+app.use(
+  '*',
+  cors({
+    origin: corsOrigins.length > 0 ? corsOrigins : ['http://localhost:4321'],
+    credentials: true,
+  }),
+);
 
 app.get('/healthz', (c) => c.json({ status: 'ok', service: 'argismonitor-bff' }));
 
-const authenticate = requireAuth();
+/**
+ * Production trust boundary (#392):
+ * - Machine clients: Bearer / x-api-key == BFF_API_KEY
+ * - Browser clients: session cookie from /api/auth/* (never BFF_API_KEY in the browser)
+ */
+const authenticate = requireAuthOrSession();
 const protectInProduction = async (
   c: Parameters<typeof authenticate>[0],
   next: Parameters<typeof authenticate>[1],

--- a/apps/bff/src/kbridge/client.test.ts
+++ b/apps/bff/src/kbridge/client.test.ts
@@ -1,0 +1,99 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it } from 'vitest';
+
+import { decodeMessage, encodeMessage, type KbridgeResponse } from './protocol';
+import { createKbridgeClient, resolveGatewaySocketPath } from './client';
+
+class FakeSocket extends EventEmitter {
+  destroyed = false;
+  written: Buffer[] = [];
+
+  write(frame: Buffer, cb?: (err?: Error | null) => void): boolean {
+    this.written.push(frame);
+    queueMicrotask(() => cb?.(null));
+    return true;
+  }
+
+  reply(response: KbridgeResponse) {
+    const payload = encodeMessage(response);
+    const frame = Buffer.alloc(4 + payload.length);
+    frame.writeUInt32BE(payload.length, 0);
+    payload.copy(frame, 4);
+    this.emit('data', frame);
+  }
+}
+
+describe('resolveGatewaySocketPath', () => {
+  it('prefers configured OMNIROUTE_GATEWAY_SOCKET', () => {
+    expect(
+      resolveGatewaySocketPath({ OMNIROUTE_GATEWAY_SOCKET: '\\\\.\\pipe\\custom' }, 'win32'),
+    ).toBe('\\\\.\\pipe\\custom');
+  });
+
+  it('defaults to named pipe on Windows and unix socket elsewhere', () => {
+    expect(resolveGatewaySocketPath({}, 'win32')).toBe('\\\\.\\pipe\\omniroute-gateway');
+    expect(resolveGatewaySocketPath({}, 'linux')).toBe('/var/run/argismonitor/gateway.sock');
+  });
+});
+
+describe('kbridge call lifecycle', () => {
+  it('registers inflight before write completes so a fast reply cannot race', async () => {
+    const fake = new FakeSocket();
+    const client = createKbridgeClient({
+      socketPath: '\\\\.\\pipe\\test',
+      timeoutMs: 1000,
+      connect: () => fake as unknown as import('node:net').Socket,
+    });
+
+    const originalWrite = fake.write.bind(fake);
+    fake.write = ((frame: Buffer, cb?: (err?: Error | null) => void) => {
+      const idLen = frame.readUInt32BE(0);
+      const msg = frame.subarray(4, 4 + idLen);
+      const decoded = decodeMessage(msg) as { id: string };
+      expect(client.inflightSize()).toBe(1);
+      fake.reply({ id: decoded.id, ok: true, data: { pong: true } });
+      return originalWrite(frame, cb);
+    }) as typeof fake.write;
+
+    const reply = await client.ping();
+    expect(reply).toEqual({ id: expect.any(String), ok: true, data: { pong: true } });
+    expect(client.inflightSize()).toBe(0);
+  });
+
+  it('rejects on deadline when no response arrives', async () => {
+    const fake = new FakeSocket();
+    fake.write = ((_frame: Buffer, cb?: (err?: Error | null) => void) => {
+      queueMicrotask(() => cb?.(null));
+      return true;
+    }) as typeof fake.write;
+
+    const client = createKbridgeClient({
+      socketPath: '/tmp/test.sock',
+      timeoutMs: 30,
+      connect: () => fake as unknown as import('node:net').Socket,
+    });
+
+    await expect(client.ping()).rejects.toThrow(/timed out/i);
+    expect(client.inflightSize()).toBe(0);
+  });
+
+  it('honors AbortSignal cancellation', async () => {
+    const fake = new FakeSocket();
+    fake.write = ((_frame: Buffer, cb?: (err?: Error | null) => void) => {
+      queueMicrotask(() => cb?.(null));
+      return true;
+    }) as typeof fake.write;
+
+    const client = createKbridgeClient({
+      socketPath: '/tmp/test.sock',
+      timeoutMs: 5_000,
+      connect: () => fake as unknown as import('node:net').Socket,
+    });
+
+    const controller = new AbortController();
+    const pending = client.ping(controller.signal);
+    controller.abort();
+    await expect(pending).rejects.toThrow(/aborted/i);
+    expect(client.inflightSize()).toBe(0);
+  });
+});

--- a/apps/bff/src/kbridge/client.ts
+++ b/apps/bff/src/kbridge/client.ts
@@ -2,78 +2,184 @@ import { connect, type Socket } from 'node:net';
 import { decodeMessage, encodeMessage, type KbridgeRequest, type KbridgeResponse } from './protocol';
 import { buildKbridgeRequest, type KbridgeOpParams } from './call';
 
-const SOCKET_PATH = process.env.OMNIRoute_GATEWAY_SOCKET ?? '/var/run/argismonitor/gateway.sock';
+/**
+ * Transport decision (#392):
+ * - *nix: Unix domain socket path (default `/var/run/argismonitor/gateway.sock`)
+ * - Windows: named pipe via the same `net.connect(path)` API, e.g.
+ *   `\\.\pipe\omniroute-gateway` (set `OMNIROUTE_GATEWAY_SOCKET`)
+ * TCP loopback is not the production transport.
+ */
+const DEFAULT_UNIX_SOCKET = '/var/run/argismonitor/gateway.sock';
+const DEFAULT_WIN_PIPE = '\\\\.\\pipe\\omniroute-gateway';
+const DEFAULT_TIMEOUT_MS = 5_000;
 
-let socket: Socket | null = null;
-let inflight = new Map<string, { resolve: (r: KbridgeResponse) => void; reject: (e: Error) => void }>();
+export type KbridgeClientOptions = {
+  socketPath?: string;
+  timeoutMs?: number;
+  connect?: (path: string) => Socket;
+};
 
-function connectSocket(): Socket {
-  if (socket && !socket.destroyed) return socket;
-  const s = connect(SOCKET_PATH);
-  socket = s;
-  let buf = Buffer.alloc(0);
-  s.on('data', (chunk) => {
-    buf = Buffer.concat([buf, chunk]);
-    while (buf.length >= 4) {
-      const len = buf.readUInt32BE(0);
-      if (buf.length < 4 + len) break;
-      const msgBuf = buf.subarray(4, 4 + len);
-      buf = buf.subarray(4 + len);
-      try {
-        const reply = decodeMessage(msgBuf);
-        if ('ok' in reply) {
-          const p = inflight.get(reply.id);
-          if (p) { inflight.delete(reply.id); p.resolve(reply); }
-        }
-      } catch (e) {
-        console.error('[kbridge] decode error', e);
-      }
+type InflightEntry = {
+  resolve: (r: KbridgeResponse) => void;
+  reject: (e: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export function resolveGatewaySocketPath(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const configured =
+    env.OMNIROUTE_GATEWAY_SOCKET ??
+    env.OMNIRoute_GATEWAY_SOCKET ?? // legacy casing
+    '';
+  if (configured.trim()) return configured.trim();
+  return platform === 'win32' ? DEFAULT_WIN_PIPE : DEFAULT_UNIX_SOCKET;
+}
+
+export function createKbridgeClient(options: KbridgeClientOptions = {}) {
+  const socketPath = options.socketPath ?? resolveGatewaySocketPath();
+  const timeoutMs = options.timeoutMs ?? Number(process.env.KBRIDGE_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS);
+  const connectFn = options.connect ?? ((path: string) => connect(path));
+
+  let socket: Socket | null = null;
+  const inflight = new Map<string, InflightEntry>();
+
+  function failAll(err: Error) {
+    for (const [, entry] of inflight) {
+      clearTimeout(entry.timer);
+      entry.reject(err);
     }
-  });
-  s.on('error', (err) => {
-    console.error('[kbridge] socket error', err);
-    for (const [, p] of inflight) p.reject(err);
     inflight.clear();
-    socket = null;
-  });
-  s.on('close', () => {
-    socket = null;
-  });
-  return s;
+  }
+
+  function connectSocket(): Socket {
+    if (socket && !socket.destroyed) return socket;
+    const s = connectFn(socketPath);
+    socket = s;
+    let buf = Buffer.alloc(0);
+    s.on('data', (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      while (buf.length >= 4) {
+        const len = buf.readUInt32BE(0);
+        if (buf.length < 4 + len) break;
+        const msgBuf = buf.subarray(4, 4 + len);
+        buf = buf.subarray(4 + len);
+        try {
+          const reply = decodeMessage(msgBuf);
+          if ('ok' in reply) {
+            const entry = inflight.get(reply.id);
+            if (entry) {
+              clearTimeout(entry.timer);
+              inflight.delete(reply.id);
+              entry.resolve(reply);
+            }
+          }
+        } catch (e) {
+          console.error('[kbridge] decode error', e);
+        }
+      }
+    });
+    s.on('error', (err) => {
+      console.error('[kbridge] socket error', err);
+      failAll(err instanceof Error ? err : new Error(String(err)));
+      socket = null;
+    });
+    s.on('close', () => {
+      socket = null;
+    });
+    return s;
+  }
+
+  async function call<Op extends KbridgeRequest['op']>(
+    op: Op,
+    params: KbridgeOpParams[Op],
+    signal?: AbortSignal,
+  ): Promise<KbridgeResponse> {
+    if (signal?.aborted) {
+      throw new Error('kbridge call aborted');
+    }
+
+    const id = crypto.randomUUID();
+    const partial = buildKbridgeRequest(op, params);
+    const message: KbridgeRequest = { ...partial, id };
+    const payload = encodeMessage(message);
+    const frame = Buffer.alloc(4 + payload.length);
+    frame.writeUInt32BE(payload.length, 0);
+    payload.copy(frame, 4);
+
+    const s = connectSocket();
+
+    const responsePromise = new Promise<KbridgeResponse>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        inflight.delete(id);
+        reject(new Error(`kbridge call timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      // Register BEFORE write so a fast reply cannot race past the waiter (#392).
+      inflight.set(id, { resolve, reject, timer });
+
+      if (signal) {
+        const onAbort = () => {
+          const entry = inflight.get(id);
+          if (!entry) return;
+          clearTimeout(entry.timer);
+          inflight.delete(id);
+          entry.reject(new Error('kbridge call aborted'));
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      s.write(frame, (err) => {
+        if (err) {
+          const entry = inflight.get(id);
+          if (entry) {
+            clearTimeout(entry.timer);
+            inflight.delete(id);
+          }
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+
+    return responsePromise;
+  }
+
+  return {
+    socketPath,
+    timeoutMs,
+    /** Test seam: current inflight map size. */
+    inflightSize: () => inflight.size,
+    ping: (signal?: AbortSignal) => call('ping', {} as KbridgeOpParams['ping'], signal),
+    health: (signal?: AbortSignal) => call('health', {} as KbridgeOpParams['health'], signal),
+    resolveCombo: (name: string, model: string, signal?: AbortSignal) =>
+      call('combo.resolve', { name, model }, signal),
+    recordUsage: (
+      provider: string,
+      model: string,
+      tokens: number,
+      cost: number,
+      signal?: AbortSignal,
+    ) => call('usage.record', { provider, model, tokens, cost }, signal),
+  };
 }
 
-async function call<Op extends KbridgeRequest['op']>(
-  op: Op,
-  params: KbridgeOpParams[Op]
-): Promise<KbridgeResponse> {
-  const id = crypto.randomUUID();
-  const partial = buildKbridgeRequest(op, params);
-  const message: KbridgeRequest = { ...partial, id };
-  const payload = encodeMessage(message);
-  // length-prefix framing: 4-byte BE length + msgpack payload
-  const frame = Buffer.alloc(4 + payload.length);
-  frame.writeUInt32BE(payload.length, 0);
-  payload.copy(frame, 4);
-
-  const s = connectSocket();
-  await new Promise<void>((resolve, reject) => {
-    s.write(frame, (err) => err ? reject(err) : resolve());
-  });
-
-  return new Promise((resolve, reject) => {
-    inflight.set(id, { resolve: resolve as (r: KbridgeResponse) => void, reject });
-  });
-}
+const defaultClient = createKbridgeClient();
 
 export const kbridge = {
-  ping: () => call('ping', {} as KbridgeOpParams['ping']),
-  health: () => call('health', {} as KbridgeOpParams['health']),
-  resolveCombo: (name: string, model: string) =>
-    call('combo.resolve', { name, model }),
-  recordUsage: (provider: string, model: string, tokens: number, cost: number) =>
-    call('usage.record', { provider, model, tokens, cost }),
+  ping: defaultClient.ping,
+  health: defaultClient.health,
+  resolveCombo: defaultClient.resolveCombo,
+  recordUsage: defaultClient.recordUsage,
 };
 
 export function kbridgeAvailable(): boolean {
-  return !!process.env.OMNIRoute_GATEWAY_SOCKET;
+  return Boolean(
+    process.env.OMNIROUTE_GATEWAY_SOCKET?.trim() ||
+      process.env.OMNIRoute_GATEWAY_SOCKET?.trim(),
+  );
 }

--- a/apps/bff/src/middleware/auth.ts
+++ b/apps/bff/src/middleware/auth.ts
@@ -4,6 +4,8 @@ import { env } from '../env';
 
 const BEARER = /^Bearer\s+([a-z0-9._-]{16,256})$/i;
 const APIKEY = /^[A-Za-z0-9._-]{16,256}$/;
+/** Upstream auth proxy sets `session=...` (see proxy Set-Cookie forwarding tests). */
+const SESSION_COOKIE = /(?:^|;\s*)session=([^\s;]+)/i;
 
 function verifyHmac(key: string): boolean {
   const expected = env.BFF_API_KEY;
@@ -16,6 +18,27 @@ function verifyHmac(key: string): boolean {
 export interface AuthContext {
   keyPrefix: string;
   raw: string;
+  /** How the request satisfied the production trust boundary. */
+  via: 'api-key' | 'session-cookie';
+}
+
+/**
+ * Production auth model (#392):
+ * - Machine / automation: Bearer or x-api-key matching BFF_API_KEY
+ * - Browser dashboard / tRPC: session cookie established via /api/auth/* (never BFF_API_KEY in the browser)
+ */
+export function hasBrowserSession(cookieHeader: string | undefined | null): boolean {
+  if (!cookieHeader) return false;
+  const match = SESSION_COOKIE.exec(cookieHeader);
+  const value = match?.[1] ?? '';
+  return value.length >= 8;
+}
+
+function unauthorized(c: Context) {
+  return c.json(
+    { ok: false, error: { code: 'UNAUTHORIZED', message: 'invalid or missing api key or session' } },
+    401,
+  );
 }
 
 export const requireAuth = (): MiddlewareHandler => async (c: Context, next: Next) => {
@@ -23,13 +46,28 @@ export const requireAuth = (): MiddlewareHandler => async (c: Context, next: Nex
   const m = h.match(BEARER);
   const raw = m ? m[1] : c.req.header('x-api-key') ?? '';
   if (!raw || !APIKEY.test(raw) || !verifyHmac(raw)) {
-    return c.json(
-      { ok: false, error: { code: 'UNAUTHORIZED', message: 'invalid or missing api key' } },
-      401,
-    );
+    return unauthorized(c);
   }
-  c.set('auth', { keyPrefix: raw.slice(0, 8), raw } satisfies AuthContext);
+  c.set('auth', { keyPrefix: raw.slice(0, 8), raw, via: 'api-key' } satisfies AuthContext);
   await next();
+};
+
+/** API key OR non-empty upstream session cookie (browser path). */
+export const requireAuthOrSession = (): MiddlewareHandler => async (c: Context, next: Next) => {
+  const h = c.req.header('authorization') ?? '';
+  const m = h.match(BEARER);
+  const raw = m ? m[1] : c.req.header('x-api-key') ?? '';
+  if (raw && APIKEY.test(raw) && verifyHmac(raw)) {
+    c.set('auth', { keyPrefix: raw.slice(0, 8), raw, via: 'api-key' } satisfies AuthContext);
+    await next();
+    return;
+  }
+  if (hasBrowserSession(c.req.header('cookie'))) {
+    c.set('auth', { keyPrefix: 'session', raw: '', via: 'session-cookie' } satisfies AuthContext);
+    await next();
+    return;
+  }
+  return unauthorized(c);
 };
 
 export function getAuth(c: Context): AuthContext | undefined {

--- a/apps/bff/src/security-boundary.test.ts
+++ b/apps/bff/src/security-boundary.test.ts
@@ -7,6 +7,7 @@ beforeAll(async () => {
   vi.resetModules();
   vi.stubEnv("NODE_ENV", "production");
   vi.stubEnv("BFF_API_KEY", API_KEY);
+  vi.stubEnv("BFF_CORS_ORIGINS", "http://localhost:4321,https://app.example.com");
   app = (await import("./index")).default;
 }, 60_000);
 
@@ -28,6 +29,11 @@ describe("BFF production security boundary", () => {
     });
     expect(authenticatedDashboard.status).toBe(200);
 
+    const sessionDashboard = await app.request("http://localhost/api/dashboard/providers", {
+      headers: { cookie: "session=browser-session-token" },
+    });
+    expect(sessionDashboard.status).toBe(200);
+
     const anonymousTrpc = await app.request("http://localhost/api/trpc/health");
     expect(anonymousTrpc.status).toBe(401);
 
@@ -35,6 +41,11 @@ describe("BFF production security boundary", () => {
       headers: { authorization: `Bearer ${API_KEY}` },
     });
     expect(authenticatedTrpc.status).toBe(200);
+
+    const sessionTrpc = await app.request("http://localhost/api/trpc/health", {
+      headers: { cookie: "session=browser-session-token" },
+    });
+    expect(sessionTrpc.status).toBe(200);
 
     const telemetry = await app.request("http://localhost/api/v1/telemetry/web-vitals", {
       method: "POST",
@@ -69,5 +80,29 @@ describe("BFF production security boundary", () => {
     expect(response.status).toBe(200);
     expect(upstreamFetch).toHaveBeenCalledOnce();
     expect(upstreamFetch.mock.calls[0]?.[0]).toBe("http://localhost:20128/api/auth/login");
+  });
+
+  it("forwards auth callback Set-Cookie and accepts the session on dashboard", async () => {
+    const upstreamHeaders = new Headers({ "content-type": "application/json" });
+    upstreamHeaders.append("set-cookie", "session=callback-session-abc; Path=/; HttpOnly");
+    const upstreamFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200, headers: upstreamHeaders }),
+    );
+
+    const callback = await app.request("http://localhost/api/auth/callback?code=test", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: "test", state: "s" }),
+    });
+    expect(callback.status).toBe(200);
+    expect(upstreamFetch.mock.calls[0]?.[0]).toBe("http://localhost:20128/api/auth/callback?code=test");
+    expect(callback.headers.getSetCookie()).toEqual([
+      "session=callback-session-abc; Path=/; HttpOnly",
+    ]);
+
+    const followUp = await app.request("http://localhost/api/dashboard/providers", {
+      headers: { cookie: "session=callback-session-abc" },
+    });
+    expect(followUp.status).toBe(200);
   });
 });

--- a/apps/bff/src/trpc/router.ts
+++ b/apps/bff/src/trpc/router.ts
@@ -20,22 +20,34 @@ const ComboSchema = z.object({
   strategy: z.enum(['first-success', 'round-robin', 'cost-optimized', 'latency-optimized']).default('first-success'),
 });
 
+const unavailable = (source: string) =>
+  ({ ok: false as const, status: 'unavailable' as const, source });
+
 export const appRouter = router({
   health: publicProcedure.query(() => ({ status: 'ok', ts: new Date().toISOString() })),
 
   providers: router({
     list: publicProcedure.query(() => []),
     byId: publicProcedure.input(z.object({ id: z.string() })).query(({ input: _input }) => null),
-    create: publicProcedure.input(ProviderSchema).mutation(({ input }) => ({ ok: true, provider: input })),
-    delete: publicProcedure.input(z.object({ id: z.string() })).mutation(() => ({ ok: true })),
+    create: publicProcedure.input(ProviderSchema).mutation(() => ({
+      ...unavailable('no-provider-store'),
+      provider: null,
+    })),
+    delete: publicProcedure.input(z.object({ id: z.string() })).mutation(() => unavailable('no-provider-store')),
   }),
 
   combos: router({
     list: publicProcedure.query(() => []),
     byId: publicProcedure.input(z.object({ id: z.string() })).query(() => null),
-    create: publicProcedure.input(ComboSchema).mutation(({ input }) => ({ ok: true, combo: input })),
-    update: publicProcedure.input(ComboSchema).mutation(({ input }) => ({ ok: true, combo: input })),
-    delete: publicProcedure.input(z.object({ id: z.string() })).mutation(() => ({ ok: true })),
+    create: publicProcedure.input(ComboSchema).mutation(() => ({
+      ...unavailable('no-combo-store'),
+      combo: null,
+    })),
+    update: publicProcedure.input(ComboSchema).mutation(() => ({
+      ...unavailable('no-combo-store'),
+      combo: null,
+    })),
+    delete: publicProcedure.input(z.object({ id: z.string() })).mutation(() => unavailable('no-combo-store')),
   }),
 
   usage: router({
@@ -50,8 +62,11 @@ export const appRouter = router({
 
   keys: router({
     list: publicProcedure.query(() => []),
-    create: publicProcedure.input(z.object({ name: z.string() })).mutation(({ input: _input }) => ({ ok: true })),
-    revoke: publicProcedure.input(z.object({ id: z.string() })).mutation(() => ({ ok: true })),
+    create: publicProcedure.input(z.object({ name: z.string() })).mutation(() => ({
+      ...unavailable('no-key-store'),
+      key: null,
+    })),
+    revoke: publicProcedure.input(z.object({ id: z.string() })).mutation(() => unavailable('no-key-store')),
   }),
 
   flags: router({
@@ -59,7 +74,9 @@ export const appRouter = router({
       { key: 'new-dashboard', default: true, rollout: 100, userOverride: null },
       { key: 'beta-compression', default: false, rollout: 25, userOverride: null },
     ]),
-    setOverride: publicProcedure.input(z.object({ key: z.string(), value: z.boolean().nullable() })).mutation(() => ({ ok: true })),
+    setOverride: publicProcedure
+      .input(z.object({ key: z.string(), value: z.boolean().nullable() }))
+      .mutation(() => unavailable('no-flag-store')),
   }),
 });
 

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1,13 +1,10 @@
 import { hc } from 'hono/client';
+import { bffApiUrl, bffBaseUrl } from '../bff-origin';
 
-const BFF_BASE = typeof window !== 'undefined'
-  ? (window as any).__OMNIRoute_BFF_URL__ ?? 'http://localhost:4322'
-  : 'http://localhost:4322';
-
-export const api = hc(BFF_BASE);
+export const api = hc(bffBaseUrl());
 
 export async function apiGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${BFF_BASE}${path}`, { credentials: 'include' });
+  const res = await fetch(bffApiUrl(path), { credentials: 'include' });
   if (!res.ok) throw new Error(`API ${path} failed: ${res.status}`);
   return res.json() as Promise<T>;
 }

--- a/apps/web/src/lib/bff-origin.ts
+++ b/apps/web/src/lib/bff-origin.ts
@@ -1,0 +1,42 @@
+const DEFAULT_BFF_ORIGIN = 'http://localhost:4322';
+
+type BrowserBffGlobals = Window & {
+  __OMNIROUTE_BFF_URL__?: string;
+  /** Legacy typo kept for compatibility with older injectors. */
+  __OMNIRoute_BFF_URL__?: string;
+};
+
+function sanitizeOrigin(raw: string): string | null {
+  try {
+    const url = new URL(raw.trim());
+    if (!['http:', 'https:'].includes(url.protocol)) return null;
+    if (url.username || url.password) return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Browser BFF base URL — injected global, same-origin, or local default.
+ * Never embeds BFF_API_KEY (#392).
+ */
+export function bffBaseUrl(): string {
+  if (typeof window === 'undefined') return DEFAULT_BFF_ORIGIN;
+  const g = window as BrowserBffGlobals;
+  const injected = g.__OMNIROUTE_BFF_URL__ ?? g.__OMNIRoute_BFF_URL__;
+  if (typeof injected === 'string') {
+    const origin = sanitizeOrigin(injected);
+    if (origin) return origin;
+  }
+  // SvelteKit Vite default is :4321; BFF default is :4322.
+  if (window.location?.port === '4321') return DEFAULT_BFF_ORIGIN;
+  if (window.location?.origin) return window.location.origin;
+  return DEFAULT_BFF_ORIGIN;
+}
+
+export function bffApiUrl(pathname: string): string {
+  const base = bffBaseUrl().replace(/\/$/, '');
+  const path = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return `${base}${path}`;
+}

--- a/apps/web/src/lib/trpc/client.ts
+++ b/apps/web/src/lib/trpc/client.ts
@@ -1,14 +1,11 @@
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from '../../../../bff/src/trpc/router';
-
-const BFF_BASE = typeof window !== 'undefined'
-  ? (window as any).__OMNIRoute_BFF_URL__ ?? 'http://localhost:4322'
-  : 'http://localhost:4322';
+import { bffApiUrl } from '../bff-origin';
 
 export const trpc = createTRPCClient<AppRouter>({
   links: [
     httpBatchLink({
-      url: `${BFF_BASE}/api/trpc`,
+      url: bffApiUrl('/api/trpc'),
       fetch: (input, init) => fetch(input as RequestInfo | URL, { ...init, credentials: 'include' }),
     }),
   ],

--- a/apps/web/src/routes/callback/+page.svelte
+++ b/apps/web/src/routes/callback/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import Card from '$lib/components/ui/Card.svelte';
+  import { bffApiUrl } from '$lib/bff-origin';
 
   let status = $state<'pending' | 'success' | 'error'>('pending');
   let message = $state('Processing OAuth callback...');
@@ -25,7 +26,7 @@
     }
 
     try {
-      const res = await fetch('http://localhost:4322/api/auth/callback', {
+      const res = await fetch(bffApiUrl('/api/auth/callback'), {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         credentials: 'include',

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Button from '$lib/components/ui/Button.svelte';
   import Card from '$lib/components/ui/Card.svelte';
+  import { bffApiUrl } from '$lib/bff-origin';
 
   let email = $state('');
   let password = $state('');
@@ -12,7 +13,7 @@
     submitting = true;
     error = null;
     try {
-      const res = await fetch('http://localhost:4322/api/auth/login', {
+      const res = await fetch(bffApiUrl('/api/auth/login'), {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         credentials: 'include',


### PR DESCRIPTION
## Summary
Second #392 slice (stacked on #449 auth/CORS/tRPC):

- Register KBridge inflight waiters **before** socket write (closes fast-reply race)
- Enforce request deadlines (`KBRIDGE_TIMEOUT_MS`, default 5s) and `AbortSignal` cancellation
- Document Windows transport: named pipe `\\.\pipe\omniroute-gateway` via `OMNIROUTE_GATEWAY_SOCKET` (same `net.connect(path)` API as Unix sockets)
- Unit tests for path resolution, race registration, timeout, and abort

## Test plan
- [x] `bunx vitest run src/kbridge/client.test.ts` (5/5)
- [ ] CI Build on this PR
- [ ] Merge after #449 (or rebase onto `main` once #449 lands)

Depends on / stacks with: #449


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser session-cookie authentication alongside API-key authentication.
  * Added flexible BFF origin configuration for deployed and local environments.
  * Added configurable gateway connectivity with timeouts, cancellation, and platform-specific transport support.

* **Bug Fixes**
  * Improved OAuth and API requests to use the configured backend and preserve session cookies.
  * Prevented unsupported persistence operations from reporting false success; unavailable operations now return explicit status information.
  * Improved CORS origin validation and deduplication.

* **Tests**
  * Expanded coverage for authentication, CORS, gateway communication, endpoint honesty, and session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->