### PR TITLE
fix(build): narrow PACK_ARTIFACT_ROOT_ALLOWED_PATH_PREFIXES to runtime-only

### DIFF
--- a/scripts/build/pack-artifact-policy.ts
+++ b/scripts/build/pack-artifact-policy.ts
@@ -125,20 +125,17 @@ export const PACK_ARTIFACT_ROOT_ALLOWED_EXACT_PATHS: string[] = [
 ];
 
 export const PACK_ARTIFACT_ROOT_ALLOWED_PATH_PREFIXES: string[] = [
+  // Runtime-shipped vendor packages (compiled JS, kept narrow).
   "@omniroute/opencode-plugin/",
   "@omniroute/opencode-provider/",
+  // CLI entrypoints + their bundled runtime helpers (not bin/cli/runtime/).
   "bin/cli/",
-  // Broad open-sse + src source dirs added to package.json "files" in v3.8.21
-  // to allow TypeScript-first imports from the published package.
-  "open-sse/",
-  "src/domain/",
-  "src/lib/",
-  "src/models/",
-  "src/mitm/",
-  "src/server/",
-  "src/shared/",
-  "src/sse/",
-  "src/types/",
+  // Compiled server bundles only — never raw source. Runtime-loaded .ts files
+  // (open-sse/utils/setupPolyfill.ts, src/shared/utils/nodeRuntimeSupport.ts)
+  // are pinned individually in PACK_ARTIFACT_ROOT_ALLOWED_EXACT_PATHS /
+  // PACK_ARTIFACT_REQUIRED_PATHS; do NOT re-widen src/* or open-sse/ here,
+  // otherwise the rebuild inflates the tarball past the npm registry limit.
+  "dist/",
 ];
 
 export const PACK_ARTIFACT_REQUIRED_PATHS: string[] = [


### PR DESCRIPTION
E413 Payload Too Large was failing publish-npm because the rebuild-then-prune pipeline shipped 8,441 files / 352 MB packed / 776 MB unpacked.

Tightens `PACK_ARTIFACT_ROOT_ALLOWED_PATH_PREFIXES` (scripts/build/pack-artifact-policy.ts:127-142) to ship only:
- `@omniroute/opencode-plugin/` (tsx-loaded runtime entry)
- `@omniroute/opencode-provider/` (tsx-loaded runtime entry)
- `bin/cli/` (compiled CLI)
- `dist/` (compiled output)

The two runtime-critical .ts files (`src/shared/utils/nodeRuntimeSupport.ts` and `open-sse/utils/setupPolyfill.ts`) remain in the tarball via `PACK_ARTIFACT_REQUIRED_PATHS` and `PACK_ARTIFACT_ROOT_ALLOWED_EXACT_PATHS`.

Local validator: exit 0, pack --dry-run reports 264 files / 1.8 MB unpacked.