### PR TITLE
fix(workflow): reconstruct wrapper object for gh api check-runs

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,7 +1,10 @@
 name: Auto Release (channel resolver)
 
-# Auto-builds the most primitive / unstable release channel whose CI gates
-# are satisfied for the current main HEAD.
+# Auto-builds the most primitive/unstable channel release type
+# (per the trigger rule: 24hr OR adds>=5000 OR removes>=5000).
+# The OmniRoute release system uses a forced dispatch model for testing.
+# The trigger/resolve/publish cycle is governed by scripts/release/{trigger-evaluator,channel-resolver}.mjs
+# and config/release/{channels,ci-matrix}.json. See docs/ops/RELEASE_CHANNELS.md for the full model.
 #
 #   trigger   — 24hr OR adds>=5000 OR removes>=5000 (per
 #               config/release/channels.json#autoTrigger)
@@ -176,11 +179,26 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/release-artifacts
-          # Pull check-runs with pagination. The resolver tolerates up to 5
-          # pages (500 runs) which is enough for the full CI matrix.
-          gh api --paginate "/repos/${{ github.repository }}/commits/${SHA}/check-runs?per_page=100" \
-            > /tmp/release-artifacts/check-runs.json || echo '{"check_runs":[]}' > /tmp/release-artifacts/check-runs.json
-          COUNT="$(node -e 'process.stdout.write(String(JSON.parse(require("fs").readFileSync("/tmp/release-artifacts/check-runs.json","utf8")).total_count||0))')"
+          # Pull check-runs one page at a time. The OmniRoute check-run
+          # matrix has < 100 runs per commit, so the loop completes on
+          # page 1 in practice. We hand-roll the wrapper object
+          # { check_runs: [...], total_count: N } that
+          # channel-resolver.mjs expects.
+          page=1
+          all_runs="[]"
+          while :; do
+            PAGE=$(gh api "repos/${{ github.repository }}/commits/${SHA}/check-runs?per_page=100&page=${page}" \
+              || echo '{"check_runs":[]}')
+            runs_in_page=$(echo "$PAGE" | node -e 'process.stdout.write(JSON.stringify(JSON.parse(require("fs").readFileSync(0,"utf8")).check_runs||[]))')
+            all_runs=$(node -e "process.stdout.write(JSON.stringify([...JSON.parse(process.argv[1]), ...JSON.parse(process.argv[2])]))" "$all_runs" "$runs_in_page")
+            count=$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).length))' "$runs_in_page")
+            if [ "$count" -lt 100 ]; then break; fi
+            page=$((page+1))
+            if [ "$page" -gt 10 ]; then echo "::warning::check-runs pagination exceeded 10 pages, truncating"; break; fi
+          done
+          echo "{\"check_runs\": $all_runs, \"total_count\": $(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).length))' "$all_runs")}" \
+            > /tmp/release-artifacts/check-runs.json
+          COUNT=$(node -e 'process.stdout.write(String(JSON.parse(require("fs").readFileSync("/tmp/release-artifacts/check-runs.json","utf8")).total_count||0))')
           echo "Fetched $COUNT check-runs for SHA ${SHA}"
 
       - name: Run channel resolver


### PR DESCRIPTION
The resolver step used `gh api ...check-runs --paginate` which returns ONE JSON object per line (one per page), not a single wrapper object with {check_runs, total_count}. The downstream parse threw, the catch wrote `{}` to disk, channel-resolver.mjs saw zero check-runs, and walkPromotion returned n/a — all publish jobs skipped even when trigger fired correctly (e.g. run 30081898242 on a +1,960,948 LOC delta).

Replaced with manual pagination loop that reconstructs the `{check_runs, total_count}` wrapper channel-resolver.mjs expects. Hard cap at 10 pages (1,000 runs) with ::warning:: if exceeded.