### PR TITLE
fix(workflow): use stdin for pagination, not argv

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -189,17 +189,19 @@ jobs:
           while :; do
             PAGE=$(gh api "repos/${{ github.repository }}/commits/${SHA}/check-runs?per_page=100&page=${page}" \
               || echo '{"check_runs":[]}')
-            runs_in_page=$(echo "$PAGE" | node -e 'process.stdout.write(JSON.stringify(JSON.parse(require("fs").readFileSync(0,"utf8")).check_runs||[]))')
-            all_runs=$(node -e "process.stdout.write(JSON.stringify([...JSON.parse(process.argv[1]), ...JSON.parse(process.argv[2])]))" "$all_runs" "$runs_in_page")
-            count=$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).length))' "$runs_in_page")
+            runs_in_page=$(printf '%s' "$PAGE" | node -e 'let s="";process.stdin.on("data",c=>s+=c).on("end",()=>{process.stdout.write(JSON.stringify(JSON.parse(s).check_runs||[]))})')
+            # Concat via stdin to avoid the ARG_MAX limit (100-check-run pages overflow argv).
+            all_runs=$(printf '%s' "$all_runs"$'\n'"$runs_in_page" \
+              | node -e 'let s="";process.stdin.on("data",c=>s+=c).on("end",()=>{const lines=s.split("\n");const a=JSON.parse(lines[0]);const b=JSON.parse(lines[1]);process.stdout.write(JSON.stringify([...a,...b]))})')
+            count=$(printf '%s' "$runs_in_page" | node -e 'let s="";process.stdin.on("data",c=>s+=c).on("end",()=>{process.stdout.write(String(JSON.parse(s).length))})')
             if [ "$count" -lt 100 ]; then break; fi
             page=$((page+1))
             if [ "$page" -gt 10 ]; then echo "::warning::check-runs pagination exceeded 10 pages, truncating"; break; fi
           done
-          echo "{\"check_runs\": $all_runs, \"total_count\": $(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).length))' "$all_runs")}" \
+          total_count=$(printf '%s' "$all_runs" | node -e 'let s="";process.stdin.on("data",c=>s+=c).on("end",()=>{process.stdout.write(String(JSON.parse(s).length))})')
+          printf '{"check_runs":%s,"total_count":%s}' "$all_runs" "$total_count" \
             > /tmp/release-artifacts/check-runs.json
-          COUNT=$(node -e 'process.stdout.write(String(JSON.parse(require("fs").readFileSync("/tmp/release-artifacts/check-runs.json","utf8")).total_count||0))')
-          echo "Fetched $COUNT check-runs for SHA ${SHA}"
+          echo "Fetched $total_count check-runs for SHA ${SHA}"
 
       - name: Run channel resolver
         id: resolve


### PR DESCRIPTION
Fixes Argument list too long on 100+ check-run pages. The prior fix passed a JSON array as CLI arg to node which overflowed argv. Replaced with stdin pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated release processing for large sets of check runs.
  * Prevented failures caused by command-line size limits when aggregating check-run data.
  * Improved accuracy and reliability of fetched check-run counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->