### PR TITLE
fix(workflow): use --ignore-scripts in npm ci to skip native build

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -287,9 +287,14 @@ jobs:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install + build
+      - name: Install + build (skip native build steps)
         run: |
-          npm ci
+          # --ignore-scripts skips the postinstall hooks of native packages like
+          # better-sqlite3@7.6.2 whose prebuilt binaries don't match V8 12.4
+          # (Node 24) APIs. The tarball we publish to npm/dockers has none of
+          # this — npm install without --ignore-scripts only matters for the
+          # build environment, not the published artifact.
+          npm ci --ignore-scripts
           npm run build:cli
 
       - name: "Pre-flight: validate npm-publish readiness"


### PR DESCRIPTION
Latest auto-release run (30199064919) failed in `Publish npm` with a `better-sqlite3@7.6.2` native build error — C++ source references v8 iterator/next/done APIs that don't exist in the runner's Node 24 v8. Adding `--ignore-scripts` to `npm ci` skips postinstall hooks that trigger native compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to skip package installation scripts while preserving the CLI build step.
  * Added explanatory notes to clarify the installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->