### PR TITLE
fix(mitm): remove stray closing brace in manager.ts

### DIFF
--- a/src/mitm/manager.ts
+++ b/src/mitm/manager.ts
@@ -709,8 +709,6 @@ export async function startMitm( // NOSONAR - legacy orchestration flow is cover
   }
 }
 
-}
-
 /**
  * Stop MITM proxy
  * @param {string} sudoPassword - Sudo password for DNS cleanup


### PR DESCRIPTION
Deleting line 712 balances the file (195 opens / 195 closes) and unblocks the prepublish webpack build. Surfaces only now that the scope-ownership guard bypasses npm publish and the prepublish build:cli step actually runs.