### PR TITLE
fix(governance): align default Mergify config with schema

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,13 +20,13 @@ pull_request_rules:
           {{ title }} (#{{ number }})
 
           Co-authored-by: {{ author }}
-      post_merge:
-        action: close
 
   # Auto-merge dependabot/Renovate PRs when CI passes
   - name: Auto-merge dependency updates
     conditions:
-      - author=dependabot[bot] | renovate[bot]
+      - or:
+          - author = dependabot[bot]
+          - author = renovate[bot]
       - check-success=ci
       - -conflict
       - -closed
@@ -37,13 +37,14 @@ pull_request_rules:
           {{ title }} (#{{ number }})
 
           Co-authored-by: {{ author }}
-      post_merge:
-        action: close
 
   # Auto-merge bot PRs (CI configs, formatting) when CI passes
   - name: Auto-merge bot housekeeping PRs
     conditions:
-      - author=trunk-io[bot] | mergify[bot] | github-actions[bot]
+      - or:
+          - author = trunk-io[bot]
+          - author = mergify[bot]
+          - author = github-actions[bot]
       - check-success=ci
       - check-success=lint
       - -conflict
@@ -61,7 +62,7 @@ pull_request_rules:
       request_reviews:
         teams:
           - phenotype/core
-        github_accounts:
+        users:
           - KooshaPari
 
   # Label PRs based on changed files
@@ -102,7 +103,7 @@ pull_request_rules:
     conditions:
       - -closed
       - -draft
-      - age>=30d
+      - created-at <= 30 days ago
       - "#review-requested=0"
     actions:
       comment:


### PR DESCRIPTION
## Summary
- align bot-author conditions with Mergify's structured `or` syntax
- use the supported `users` key for review requests
- remove unsupported `post_merge` actions
- express stale-PR age with the supported `created-at <= 30 days ago` timestamp condition

## Evidence
- Current Mergify rule syntax: https://docs.mergify.com/workflow/rule-syntax/
- Request review action parameters: https://docs.mergify.com/workflow/actions/request_reviews/
- Relative timestamps: https://docs.mergify.com/configuration/data-types/

This is a protected configuration-only PR; no branch protection bypass or force push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated pull request management rules for clearer dependency and housekeeping bot matching.
  * Improved reviewer assignment configuration.
  * Updated stale pull request detection to use creation date.
  * Removed automatic post-merge closing actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->