### PR TITLE
fix(ci): remove invalid workflow references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
           echo ""
           echo "=== Detected ==="
-          echo "rust=${{ steps.detect.outputs.has_rust }} deny=${{ steps.detect.outputs.has_deny }} python=${{ steps.detect.outputs.has_python }} go=${{ steps.detect.outputs.has_go }} typescript=${{ steps.detect.outputs.has_typescript }} security=${{ steps.detect.outputs.has_security }} trunk=${{ steps.detect.outputs.has_trunk }}"
+          echo "Detection outputs written to GITHUB_OUTPUT"
 
   rust:
     name: Rust
@@ -211,7 +211,7 @@ jobs:
             "go:${{ needs.go.result }}" \
             "typescript:${{ needs.typescript.result }}" \
             "security:${{ needs.security.result }}" \
-            "dep-review:${{ needs.dependency-review.result }}" \
+            "dep-review:${{ needs.dep-review.result }}" \
             ; do
             name="${pair%%:*}"
             result="${pair#*:}"


### PR DESCRIPTION
## **User description**
## Summary
- remove the detect-step self-reference to outputs before the step completes
- use the declared `dep-review` job key in the aggregate gate

## Validation
- `git diff --check` passed
- actionlint reports no expression/property errors for this workflow; existing shellcheck SC2086/SC2129 informational findings remain
- no native dependency or feature changes included

This is a bounded follow-up to the merged #481/#487 main state.


___

## **CodeAnt-AI Description**
Correct CI workflow checks and reporting

### What Changed
- CI detection now reports that its outputs were written without referencing them before the detection step completes
- The aggregate lint gate now checks the dependency review job using its declared name
- Dependency review failures and cancellations are correctly included in the final CI result

### Impact
`✅ Reliable CI workflow execution`
`✅ Dependency review failures block the aggregate gate`
`✅ Clearer detection step output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CI status reporting for dependency review checks.
  * Updated workflow messaging to accurately describe where detection results are recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->