### PR TITLE
fix(ci): replace invalid mergify review team with owner user

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -58,10 +58,9 @@ pull_request_rules:
     conditions:
       - -closed
       - -draft
+      - author != KooshaPari
     actions:
       request_reviews:
-        teams:
-          - phenotype/core
         users:
           - KooshaPari
 


### PR DESCRIPTION
Replace invalid Mergify `request_reviews` team target and align rule with existing ownership behavior.

Changes:
- Change `.mergify.yml` on `main` from:
  - `request_reviews.teams: [phenotype/core]`
  - to `request_reviews.users: [KooshaPari]`
- Keep governance self-check guard: `author != KooshaPari` so owner PRs do not trigger self-review requests.

Why:
- PR #496 reports `Invalid requested teams` with `Team 'phenotype/core' is not part of the organization`.
- This value is present only in `origin/main`'s `.mergify.yml`, not in PR branch config.
- This change is minimal and local to `main` governance behavior with low blast radius.
