### PR TITLE
fix(governance): replace silent try/catch with explicit log.error in 5 modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,13 @@ coverage/
 reports/mutation/
 stryker-output-*.json
 
+# AgilePlus local DB — spec/cycle state, regenerated from kitty-specs/ via `agileplus specify`
+# The DB contains transient per-machine state; the source of truth is the .md specs.
+.agileplus/
+agileplus-*.db
+agileplus-*.db-shm
+agileplus-*.db-wal
+
 
 # Memory Bank and Cursor rules (local-only AI agent context)
 memory-bank/

--- a/open-sse/config/credentialLoader.ts
+++ b/open-sse/config/credentialLoader.ts
@@ -16,7 +16,9 @@
 
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
+import { createLogger } from "@/shared/utils/logger";
 
+const log = createLogger("open-sse:credential-loader");
 // Fields that can be overridden per provider
 const CREDENTIAL_FIELDS = [
   "clientId",
@@ -47,8 +49,10 @@ function resolveCredentialsPath(): string {
     resolveDataDir = require("@/lib/dataPaths").resolveDataDir;
   } catch (err) {
     const fallbackDataDir = process.env.DATA_DIR || join(process.cwd(), "data");
-    console.warn(
-      `[CREDENTIALS] Could not load dataPaths module, using fallback: ${fallbackDataDir}`
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    log.error(
+      { err, fallbackDataDir },
+      `Could not load dataPaths module (${errorMessage}); using fallback credentials path: ${fallbackDataDir}`
     );
     return join(fallbackDataDir, "provider-credentials.json");
   }

--- a/open-sse/services/tierResolver.ts
+++ b/open-sse/services/tierResolver.ts
@@ -3,7 +3,9 @@ import { PROVIDER_TIER } from "./tierTypes";
 import { getModelPricing } from "./providerCostData";
 import { isExplicitlyFree } from "./providerCostData";
 import { mergeTierConfig, DEFAULT_TIER_CONFIG } from "./tierConfig";
+import { createLogger } from "@/shared/utils/logger";
 
+const log = createLogger("open-sse:tier-resolver");
 let dbPersistenceChecked = false;
 
 const tierCache = new Map<string, TierAssignment>();
@@ -112,7 +114,11 @@ export function setTierConfig(config?: Partial<TierConfig> | null): void {
     try {
       const { loadTierConfig } = require("../../src/lib/db/tierConfig");
       currentConfig = loadTierConfig();
-    } catch {
+    } catch (err) {
+      log.error(
+        { err, module: "../../src/lib/db/tierConfig" },
+        "Could not load tierConfig module; using default tier configuration"
+      );
       currentConfig = DEFAULT_TIER_CONFIG;
     }
   } else {

--- a/src/lib/quota/storeFactory.ts
+++ b/src/lib/quota/storeFactory.ts
@@ -67,8 +67,15 @@ async function readDbSettings(): Promise<QuotaStoreSettings> {
         kvUrl: typeof obj.kvUrl === "string" ? obj.kvUrl : undefined,
       };
     }
-  } catch {
-    // DB not available — fall through to env
+  } catch (err) {
+    // DB not available — fall through to env. Surface the failure loudly
+    // so a corrupted settings module can't silently disable the configured
+    // QuotaStore driver (fail-fast governance: do not hide TS compile /
+    // runtime errors at the DB boundary).
+    log.error(
+      { err },
+      "readDbSettings: getSettings() failed — falling back to env-only config",
+    );
   }
   return {};
 }
@@ -128,9 +135,15 @@ export async function getQuotaStore(): Promise<QuotaStore> {
         log.info({ redisUrl: redisUrl.replace(/:[^:@]*@/, ":***@") }, "QuotaStore: using Redis driver");
         return _store;
       } catch (err) {
-        log.warn(
-          { err: (err as Error)?.message },
-          "Redis QuotaStore unavailable — falling back to sqlite"
+        // Fail-fast: log.error (not warn) so a corrupted redisQuotaStore
+        // import / missing ioredis dep surfaces in monitoring. The URL is
+        // redacted to avoid leaking credentials in error logs.
+        log.error(
+          {
+            err,
+            redisUrl: redisUrl.replace(/:[^:@]*@/, ":***@"),
+          },
+          "Redis QuotaStore unavailable — falling back to sqlite",
         );
         // Fall through to sqlite
       }

--- a/src/lib/resilience/anomalyHook.ts
+++ b/src/lib/resilience/anomalyHook.ts
@@ -13,8 +13,11 @@ import { isFeatureFlagEnabled } from "@/lib/featureFlags";
 import { resolveSelfHealingSettings } from "./selfHealingSettings";
 import { SelfHealingManager } from "./selfHealingManager";
 import { createAnomalyDetector } from "./anomalyDetector";
+import { createLogger } from "@/shared/utils/logger";
 
 type Manager = SelfHealingManager;
+
+const log = createLogger("resilience:anomalyHook");
 
 let _manager: Manager | null = null;
 let _providerManagerRegistry: Map<string, unknown> | null = null;
@@ -60,7 +63,16 @@ function getProviderManagerRegistry(): Map<string, unknown> {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const mod = require("@/engine/providers") as { providerRegistry?: Map<string, unknown> };
       _providerManagerRegistry = mod.providerRegistry ?? new Map();
-    } catch {
+    } catch (err) {
+      // Fail-fast: a missing/corrupted @/engine/providers module must NOT
+      // silently leave the self-healing probe dispatching into an empty
+      // registry. Log loud, then keep an empty Map so resilience keeps
+      // running (detector + manager can still observe anomalies), but the
+      // dispatch path will no-op visibly in monitoring.
+      log.error(
+        { err },
+        "getProviderManagerRegistry: failed to load @/engine/providers — playbook dispatch will no-op",
+      );
       _providerManagerRegistry = new Map();
     }
   }


### PR DESCRIPTION
## **User description**
fix(governance): replace silent try/catch with explicit log.error in 5 modules

Builds on PR #505 (quota keystore type-drift fix). The audit of that PR
revealed 5 additional silent fail-open catch patterns across `src/` and
`open-sse/` that hide the same class of bug: a TypeScript compile error
or missing module is silently swallowed at runtime, falling back to a
default with no operator-visible signal.

This commit replaces those silent catches with explicit `log.error` calls
that surface the actual error to monitoring. Fallback behavior is
preserved (each fallback is intentional, but it must be LOUD).

Changes:

1. `src/lib/quota/storeFactory.ts:67-77` — `readDbSettings` now logs the
   actual error when `getSettings()` fails or `@/lib/db/settings` import
   fails. Same root cause as the previously-fixed Keyv/Redis catches.

2. `src/lib/quota/storeFactory.ts:138-147` — Redis driver catch upgraded
   from `log.warn` to `log.error`. Includes the configured Redis URL
   with the password segment redacted (`:***@`).

3. `src/lib/resilience/anomalyHook.ts` — `getProviderManagerRegistry`
   now logs the actual error when `@/engine/providers` fails to load.
   Empty Map fallback retained (resilience must continue running), but
   the failure is now visible in monitoring.

4. `open-sse/services/tierResolver.ts` — `setTierConfig` now logs the
   actual error when `../../src/lib/db/tierConfig` fails to load.
   `DEFAULT_TIER_CONFIG` fallback retained (pricing must continue), but
   the failure is now visible.

5. `open-sse/config/credentialLoader.ts` — `resolveCredentialsPath` now
   uses `log.error` (pino) instead of `console.warn`. Includes both the
   original error and the fallback path. Security-sensitive path; must
   keep working, but the failure must be loud.

6. `.gitignore` — exclude `.agileplus/` and `agileplus-*.db*` (local
   AgilePlus DB state, regenerated from `.md` specs via `agileplus
   specify`). The DB contains transient per-machine state and shouldn't
   be in version control.

Verification:
- TSC: 0 NEW errors (8 pre-existing quota keystore errors remain, those
  are what PR #505 fixes; this PR is independent of PR #505)
- Vitest quota suite: 18/18 pass (6 keyv + 4 contract + 8 e2e)
- Node:test factory: 6/6 pass
- Resilience tests: 61 pass / 1 pre-existing flake
  (resilience-provider-cooldown-api-3556.test.ts: "rejects providerCooldown
  max below min" — verified pre-existing by reverting only anomalyHook.ts
  and reproducing the same failure)

Out of scope (filed as separate bugs):
- `src/lib/resilience/anomalyHook.ts:13` imports `isFeatureFlagEnabled`
  from `@/lib/featureFlags`, but the module lives at
  `src/lib/db/featureFlags.ts`. The file is currently unloadable from
  tests; this PR doesn't touch the import because that's a separate bug.
- The Resilience subagent identified but did not fix the
  `tsconfig.typecheck-core.json` doesn't include `src/lib/resilience/`
  files — separate follow-up.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Surface configuration and module failures instead of hiding them

### What Changed
- Configuration and provider-loading failures now appear as error events with the original error details.
- Quota storage falls back to environment settings or SQLite as before, while Redis failures are reported as errors with credentials redacted.
- Resilience and tier resolution retain their safe defaults when modules cannot load, but the fallback is now visible in monitoring.
- Credential loading reports the fallback data path when its path module is unavailable.

### Impact
`✅ Visible configuration failures`
`✅ Safer Redis error logging`
`✅ Resilience continues with monitored fallbacks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
