### PR TITLE
fix(governance): broken featureFlags imports + 3 silent fail-opens + extras test

### DIFF
--- a/src/lib/machineToken.ts
+++ b/src/lib/machineToken.ts
@@ -1,11 +1,22 @@
 import { createHash, createHmac } from "node:crypto";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("auth:machine-token");
+let fallbackLogged = false;
 
 let machineIdSync: (original?: boolean) => string;
 try {
   // Use require() to bypass webpack static analysis that breaks the default export
   const mod = require("node-machine-id");
   machineIdSync = mod.machineIdSync || mod.default?.machineIdSync;
-} catch {
+} catch (err) {
+  if (!fallbackLogged) {
+    fallbackLogged = true;
+    log.error(
+      { err },
+      "machineToken: node-machine-id unavailable — HMAC salt falls back to empty string (security-relevant, all tokens become constant-keyed)"
+    );
+  }
   machineIdSync = () => "";
 }
 

--- a/src/lib/resilience/anomalyHook.ts
+++ b/src/lib/resilience/anomalyHook.ts
@@ -9,7 +9,7 @@
  *     telemetry failures
  */
 
-import { isFeatureFlagEnabled } from "@/lib/featureFlags";
+import { isFeatureFlagEnabled } from "@/shared/utils/featureFlags";
 import { resolveSelfHealingSettings } from "./selfHealingSettings";
 import { SelfHealingManager } from "./selfHealingManager";
 import { createAnomalyDetector } from "./anomalyDetector";

--- a/src/lib/versionManager/processManager.ts
+++ b/src/lib/versionManager/processManager.ts
@@ -4,6 +4,9 @@ import fsSync from "fs";
 import path from "path";
 import os from "os";
 import { setToolStatus, getVersionManagerTool } from "@/lib/db/versionManager";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("version-manager:process-manager");
 
 const DEFAULT_PORT = 8317;
 const GRACEFUL_TIMEOUT_MS = 5000;
@@ -149,7 +152,11 @@ export async function getProcessInfo(pid: number): Promise<{
       }
     }
     return { pid, alive: true };
-  } catch {
-    return { pid, alive: true };
+  } catch (err) {
+    log.error(
+      { err, pid, platform: process.platform },
+      "processManager.getProcessInfo: failed to read process info"
+    );
+    return { pid, alive: false };
   }
 }

--- a/src/server-init.ts
+++ b/src/server-init.ts
@@ -125,7 +125,7 @@ async function startServer() {
     // first request after restart. Gated on the feature flag so the
     // default-off behaviour is unchanged.
     try {
-      const { isFeatureFlagEnabled } = await import("./lib/featureFlags");
+      const { isFeatureFlagEnabled } = await import("./shared/utils/featureFlags");
       const { getSelfHealingManager } = await import("./lib/resilience/anomalyHook");
       if (isFeatureFlagEnabled("OMNIROUTE_SELF_HEALING_ENABLED")) {
         const mgr = getSelfHealingManager();
@@ -135,7 +135,7 @@ async function startServer() {
         void mgr; // referenced to ensure the singleton is constructed
       }
     } catch (err) {
-      startupLog.warn({ err }, "Self-healing hydration skipped (non-fatal)");
+      startupLog.error({ err }, "Self-healing hydration skipped (non-fatal)");
     }
 
     startupLog.info("Server started with cloud sync initialized");

--- a/src/server/ws/liveServer.ts
+++ b/src/server/ws/liveServer.ts
@@ -17,6 +17,9 @@ import { WebSocketServer, WebSocket } from "ws";
 import { jwtVerify } from "jose";
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
 import { randomUUID } from "crypto";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("ws:live-server");
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -476,7 +479,12 @@ export async function startLiveDashboardServer(
   // does not block the event loop on a cold import — which would starve concurrent
   // WebSocket handshakes (see loadAuthModule). A failed warm is non-fatal: the
   // handler retries the import lazily.
-  await loadAuthModule().catch(() => {});
+  await loadAuthModule().catch((err) =>
+    log.error(
+      { err },
+      "liveServer: failed to warm auth module — clients may experience cold-import latency"
+    )
+  );
 
   wss.on("connection", async (ws, request) => {
     const pendingMessages: string[] = [];

--- a/tests/unit/quota/keyvQuotaStoreExtras.test.ts
+++ b/tests/unit/quota/keyvQuotaStoreExtras.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  getKeyvQuotaStore,
+  __resetKeyvQuotaStoreForTests,
+} from "../../../src/lib/quota/keyvQuotaStore";
+import type { ProviderPlan, QuotaPool } from "../../../src/lib/quota/dimensions";
+
+/**
+ * Sanity tests for the "extras" surface of KeyvQuotaStore:
+ * recordPlanUsage, upsertProviderPlan, listProviderPlans, setPools, getPool.
+ *
+ * These methods were originally scoped for a KeyvQuotaStoreExtras class per
+ * plans/quota-keystore-type-drift-spec.md §8.2, but were folded directly into
+ * KeyvQuotaStore before the spec landed. We exercise them here against the
+ * in-memory backing to guarantee the surface stays wired correctly.
+ */
+describe("KeyvQuotaStoreExtras", () => {
+  let store: ReturnType<typeof getKeyvQuotaStore>;
+
+  beforeEach(() => {
+    __resetKeyvQuotaStoreForTests();
+    store = getKeyvQuotaStore({ uri: "memory://" });
+  });
+
+  afterEach(async () => {
+    await store.dispose();
+    __resetKeyvQuotaStoreForTests();
+  });
+
+  it("recordPlanUsage returns a PlanPoolUsage shape with totalConsumed and lastUpdatedAt populated", async () => {
+    const rollup = await store.recordPlanUsage(
+      "conn-1",
+      "openai",
+      "pool-1",
+      [{ unit: "tokens", window: "hourly" }],
+      42,
+    );
+    expect(rollup).toBeDefined();
+    expect(rollup.totalConsumed).toBe(42);
+    expect(typeof rollup.lastUpdatedAt).toBe("number");
+    expect(rollup.lastUpdatedAt).toBeGreaterThan(0);
+  });
+
+  it("upsertProviderPlan writes the plan without throwing", async () => {
+    const plan: ProviderPlan = {
+      connectionId: "conn-1",
+      provider: "openai",
+      dimensions: [{ unit: "tokens", window: "hourly", limit: 1000 }],
+      source: "manual",
+    };
+    await expect(store.upsertProviderPlan(plan)).resolves.toBeUndefined();
+  });
+
+  it("listProviderPlans returns [] even after an upsert (independent surface)", async () => {
+    // upsertProviderPlan and listProviderPlans are independent: the in-memory
+    // store does not enumerate provider plans, so the list stays empty.
+    await store.upsertProviderPlan({
+      connectionId: "conn-1",
+      provider: "openai",
+      dimensions: [{ unit: "tokens", window: "hourly", limit: 1000 }],
+      source: "manual",
+    });
+    const plans = await store.listProviderPlans();
+    expect(plans).toEqual([]);
+  });
+
+  it("setPools persists a QuotaPool retrievable via getPool", async () => {
+    const pool: QuotaPool = {
+      id: "pool-1",
+      connectionId: "conn-1",
+      name: "Primary",
+      createdAt: new Date().toISOString(),
+      allocations: [],
+    };
+    await store.setPools([pool]);
+    const retrieved = await store.getPool("pool-1");
+    expect(retrieved).toBeDefined();
+    expect(retrieved?.id).toBe("pool-1");
+    expect(retrieved?.name).toBe("Primary");
+    expect(retrieved?.allocations).toEqual([]);
+  });
+
+  it("getPool returns undefined for an unknown poolId", async () => {
+    const result = await store.getPool("nonexistent-pool");
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## **User description**
fix(governance): broken featureFlags imports + 3 silent fail-opens + extras test

Continuation of the governance-debt cleanup started in PRs #505 and #506.
Six independent fixes, each addressing a class of silent-failure pattern
that the audits surfaced.

Changes:

1. **`src/lib/resilience/anomalyHook.ts:12`** — Broken import path.
   `isFeatureFlagEnabled` was imported from `@/lib/featureFlags`, but
   the module lives at `@/shared/utils/featureFlags`. This bug was
   masked because `tsconfig.typecheck-core.json` does not include
   `src/lib/resilience/` and no test loads the module successfully.
   After the fix, the module loads and exports the expected surface.

2. **`src/server-init.ts:128`** — Same broken import path. The
   surrounding try/catch at lines 130-139 silently swallowed the
   import failure. Fix: correct the path AND upgrade the catch log
   from `warn` to `error` (matches PR #506 pattern).

3. **`src/lib/versionManager/processManager.ts:155`** — `getProcessInfo`
   catch returned `{pid, alive: true}` after `ps`/readFile failures,
   which lies when the process is actually gone. Fix: catch now
   logs the error and returns `{pid, alive: false}` (honest about
   not being able to read process state).

4. **`src/server/ws/liveServer.ts:479`** — `loadAuthModule().catch(() => {})`
   silently swallowed initial auth module load failures, allowing the
   WS server to come up without auth configured. Fix: catch now logs
   `log.error`; fallback behavior preserved per the existing comment
   ("handler retries the import lazily").

5. **`src/lib/machineToken.ts:1-10`** — Crypto-relevant: empty catch
   around `require("node-machine-id")` silently fell back to
   `() => ""`, which collapses HMAC inputs to a constant. Fix: catch
   now logs `log.error` with security-context message, gated by a
   `fallbackLogged` flag so the log fires only once per process
   (avoiding log spam from any downstream reload).

6. **`tests/unit/quota/keyvQuotaStoreExtras.test.ts`** (new) — Closes
   spec §8.2 reachability test gap. 5 sanity tests for the
   `recordPlanUsage` / `upsertProviderPlan` / `listProviderPlans` /
   `setPools` / `getPool` surface on KeyvQuotaStore. Note: this
   branch is based on `origin/agent/migration-version-collision-fix`
   (pre-PR-#505), so the methods live directly on KeyvQuotaStore.
   When PR #505 lands, update the test to import from
   `keyvQuotaStoreExtras.ts` instead.

Verification:
- TSC error count: 8 unchanged (all pre-existing quota keystore
  errors that PR #505 fixes; this PR is independent of #505)
- Vitest extras test: 5/5 pass
- Node:test combined (processManager + machineToken + WS): 47/47 pass
- All success-path behavior preserved; only catch/fallback paths now log

Out of scope (separate PRs):
- Promote Keyv to "embedded default" driver (spec §10)
- Pre-existing e2e failure at `tests/e2e/quota-store.e2e.ts:117`
  (poolUsageWithDimensions shape mismatch — fixed in PR #505)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Fix silent governance failures and verify quota-store behavior

### What Changed
- Self-healing telemetry now loads its feature flag correctly during startup and runtime; initialization failures are recorded as errors.
- Failed process-status checks now report the process as inactive instead of incorrectly reporting it as running.
- WebSocket authentication warm-up failures are logged while clients can still retry authentication when needed.
- Machine-token fallback to an empty device identifier now emits a security-relevant error once.
- Added coverage for quota usage recording, provider plans, quota pools, and unknown-pool lookups.

### Impact
`✅ Self-healing telemetry starts when enabled`
`✅ Accurate inactive-process reporting`
`✅ Visible authentication and token-generation failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
