### PR TITLE
fix(security): log 3 crypto-relevant silent catches

### DIFF
--- a/src/lib/db/encryption.ts
+++ b/src/lib/db/encryption.ts
@@ -26,6 +26,9 @@
  */
 
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync, createHash } from "crypto";
+import { createLogger } from "@/shared/utils/logger";
+
+const encryptionLog = createLogger("db:encryption");
 
 const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 16;
@@ -91,7 +94,11 @@ function getLegacyDynamicKey(): Buffer | null {
   const dynamicSalt = createHash("sha256").update(secret).digest().slice(0, 16);
   try {
     _legacyDynamicKey = scryptSync(secret, dynamicSalt, KEY_LENGTH);
-  } catch {
+  } catch (err) {
+    encryptionLog.error(
+      { err },
+      "encryption.getLegacyDynamicKey: scryptSync failed — legacy decryptions will silently fail (tokens may stall migration)"
+    );
     return null;
   }
   return _legacyDynamicKey;

--- a/src/lib/machineToken.ts
+++ b/src/lib/machineToken.ts
@@ -1,11 +1,22 @@
 import { createHash, createHmac } from "node:crypto";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("auth:machine-token");
+let fallbackLogged = false;
 
 let machineIdSync: (original?: boolean) => string;
 try {
   // Use require() to bypass webpack static analysis that breaks the default export
   const mod = require("node-machine-id");
   machineIdSync = mod.machineIdSync || mod.default?.machineIdSync;
-} catch {
+} catch (err) {
+  if (!fallbackLogged) {
+    fallbackLogged = true;
+    log.error(
+      { err },
+      "machineToken: node-machine-id unavailable — HMAC salt falls back to empty string (security-relevant, all tokens become constant-keyed)"
+    );
+  }
   machineIdSync = () => "";
 }
 
@@ -34,7 +45,11 @@ export function getMachineTokenSync(salt?: string): string {
       cachedSalt = activeSalt;
     }
     return token;
-  } catch {
+  } catch (err) {
+    log.error(
+      { err },
+      "machineToken.getMachineTokenSync: deriveToken failed — returning empty string (security-relevant)"
+    );
     return "";
   }
 }
@@ -47,7 +62,11 @@ export function getLegacyCliTokenSync(salt?: string): string {
       .update(machineId + activeSalt)
       .digest("hex")
       .substring(0, 32);
-  } catch {
+  } catch (err) {
+    log.error(
+      { err },
+      "machineToken.getLegacyCliTokenSync: hash derivation failed — returning empty string (security-relevant)"
+    );
     return "";
   }
 }


### PR DESCRIPTION
## **User description**
fix(security): log 3 crypto-relevant silent catches

This branch has been surgically rebased onto origin/agent/migration-version-collision-fix to remove accidental contamination from PR #507's branch base.

In all three cases, the empty-string return collapses HMAC/HMAC-SHA256
inputs into a constant-key value, so security-relevant operations on the
fallback path produce identical tokens regardless of input.

Fixes:
1. src/lib/machineToken.ts:44 — getMachineTokenSync catch:
   log.error + return "" (matches PR #507 module-load catch pattern)
2. src/lib/machineToken.ts:62 — getLegacyCliTokenSync catch:
   log.error + return "" (same pattern)
3. src/lib/db/encryption.ts:87-95 — getLegacyDynamicKey catch:
   added pino logger (createLogger("db:encryption")) + log.error
   instead of returning null silently

Incidental: this branch also adds the createLogger import + log constant
that the 2 runtime catches depend on. PR #507's machineToken.ts hunk
already adds these, so when #507 merges there will be a trivial conflict
on those lines (resolve by taking this branch's version).

Out of scope (separate work):
- encryption.ts:144-148 (encrypt() catch falls back to plaintext when
  crypto fails — needs design discussion; spec at plans/encryption-failclosed-spec.md)
- src/lib/db/*.ts console.* migration to pino (large, separate PR)

Verification:
- TSC: 8 unchanged (pre-existing quota keystore errors, PR #505 territory)
- Targeted machineToken + encryption unit tests pass
- All 3 success-path behaviors preserved


___

## **CodeAnt-AI Description**
Log security-relevant crypto fallback failures

### What Changed
- Records errors when machine-token generation fails and returns an empty token
- Records when the machine identity module is unavailable and token generation falls back to an empty salt
- Records failures while deriving legacy encryption keys so stalled token migrations are visible

### Impact
`✅ Visible security fallback failures`
`✅ Easier diagnosis of constant-key token generation`
`✅ Clearer legacy encryption migration failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
