### PR TITLE
fix(security): 4 audit findings + migrate encryption.ts to pino

### DIFF
--- a/open-sse/services/autoRefreshDaemon.ts
+++ b/open-sse/services/autoRefreshDaemon.ts
@@ -11,6 +11,9 @@
  */
 
 import { TOKEN_EXTRACTION_CONFIGS } from "./tokenExtractionConfig";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("open-sse:auto-refresh-daemon");
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -74,10 +77,14 @@ class AutoRefreshDaemon {
     this.running = true;
 
     // Run an initial check immediately
-    this.check().catch(() => {});
+    this.check().catch((err) => {
+      log.error({ err, phase: "initial" }, "AutoRefreshDaemon credential check failed");
+    });
 
     this.timerId = setInterval(() => {
-      this.check().catch(() => {});
+      this.check().catch((err) => {
+        log.error({ err, phase: "periodic" }, "AutoRefreshDaemon credential check failed");
+      });
     }, this.checkIntervalMs);
     // Don't keep the process alive solely for this periodic daemon.
     (this.timerId as { unref?: () => void })?.unref?.();

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -1,6 +1,9 @@
 import crypto from "crypto";
 import { getProviderConnections, updateProviderConnection } from "@/lib/localDb";
 import { buildConfigSyncEnvelope, toLegacyCloudSyncPayload } from "@/lib/sync/bundle";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("cloud-sync");
 
 const CLOUD_URL = process.env.CLOUD_URL || process.env.NEXT_PUBLIC_CLOUD_URL;
 const CLOUD_SYNC_TIMEOUT_MS = Number(process.env.CLOUD_SYNC_TIMEOUT_MS || 12000);
@@ -40,16 +43,19 @@ function toDateMs(value: unknown): number {
 //   2. We verify the signature with `crypto.timingSafeEqual` before parsing the
 //      JSON, so a MITM on the CLOUD_URL channel — or a misconfigured CLOUD_URL
 //      pointing at an attacker — cannot inject providers/tokens.
-// If `OMNIROUTE_CLOUD_SYNC_SECRET` is unset, signature validation is logged but
-// not enforced (back-compat for users on v3.8.x who haven't issued a shared
-// secret yet). The enforce-by-default switch will flip in v3.9.
+// If `OMNIROUTE_CLOUD_SYNC_SECRET` is unset, unsigned responses remain in legacy
+// unverified mode for backwards compatibility. Responses that include a signature
+// cannot be verified without the secret and are rejected fail-closed.
 export function verifyCloudSignature(rawBody: string, sigHeader: string | null): boolean {
   if (!CLOUD_SYNC_SECRET) {
     if (sigHeader) {
-      // We can't verify, but the server is at least trying. Pass through.
-      return true;
+      log.error(
+        { signatureLength: sigHeader.length },
+        "[cloudSync] Cloud response carries X-Cloud-Sig but OMNIROUTE_CLOUD_SYNC_SECRET is not set — rejecting unverifiable signed payload."
+      );
+      return false;
     }
-    console.warn(
+    log.warn(
       "[cloudSync] OMNIROUTE_CLOUD_SYNC_SECRET is not set and the Cloud response carries no X-Cloud-Sig. " +
         "Token sync runs in legacy unverified mode — set the secret to enforce HMAC verification."
     );

--- a/src/lib/db/encryption.ts
+++ b/src/lib/db/encryption.ts
@@ -26,6 +26,9 @@
  */
 
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync, createHash } from "crypto";
+import { createLogger } from "@/shared/utils/logger";
+
+const encryptionLog = createLogger("db:encryption");
 
 const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 16;
@@ -66,7 +69,8 @@ function getStaticKey(): Buffer | null {
     _staticKey = scryptSync(secret, STATIC_SALT, KEY_LENGTH);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(
+    encryptionLog.error(
+      { err },
       `[Encryption] Failed to derive key from STORAGE_ENCRYPTION_KEY: ${message}. ` +
         `Generate a valid key with: openssl rand -base64 32`
     );
@@ -91,7 +95,11 @@ function getLegacyDynamicKey(): Buffer | null {
   const dynamicSalt = createHash("sha256").update(secret).digest().slice(0, 16);
   try {
     _legacyDynamicKey = scryptSync(secret, dynamicSalt, KEY_LENGTH);
-  } catch {
+  } catch (err) {
+    encryptionLog.error(
+      { err },
+      "encryption.getLegacyDynamicKey: scryptSync failed — legacy decryptions will silently fail (tokens may stall migration)"
+    );
     return null;
   }
   return _legacyDynamicKey;
@@ -111,7 +119,7 @@ export function encrypt(plaintext: string | null | undefined): string | null | u
 
   const key = getStaticKey();
   if (!key) {
-    console.warn(
+    encryptionLog.error(
       "[Encryption] STORAGE_ENCRYPTION_KEY not set. Storing plaintext (passthrough mode)."
     );
     return plaintext; // passthrough mode
@@ -131,7 +139,8 @@ export function encrypt(plaintext: string | null | undefined): string | null | u
     return `${PREFIX}${iv.toString("hex")}:${encrypted}:${authTag}`;
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(
+    encryptionLog.error(
+      { err },
       `[Encryption] Encryption failed: ${message}. ` +
         `Check your STORAGE_ENCRYPTION_KEY — generate one with: openssl rand -base64 32`
     );
@@ -155,7 +164,7 @@ export function decrypt(ciphertext: string | null | undefined): string | null | 
 
   const staticKey = getStaticKey();
   if (!staticKey) {
-    console.warn(
+    encryptionLog.error(
       "[Encryption] Found encrypted data but STORAGE_ENCRYPTION_KEY is not set. Cannot decrypt."
     );
     return null;
@@ -164,7 +173,7 @@ export function decrypt(ciphertext: string | null | undefined): string | null | 
   const body = ciphertext.slice(PREFIX.length);
   const parts = body.split(":");
   if (parts.length !== 3) {
-    console.error("[Encryption] Malformed encrypted value");
+    encryptionLog.error("[Encryption] Malformed encrypted value");
     return null;
   }
 
@@ -194,14 +203,14 @@ export function decrypt(ciphertext: string | null | undefined): string | null | 
       return decrypted;
     }
 
-    console.error(
+    encryptionLog.error(
       `[Encryption] Decryption failed. Ciphertext prefix: ${ciphertext.slice(0, 30)}... ` +
         `Auth tag validation likely failed.`
     );
     return null;
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error("[Encryption] Decryption failed:", message);
+    encryptionLog.error({ err }, `[Encryption] Decryption failed: ${message}`);
     return null;
   }
 }

--- a/src/lib/oauth/providers/antigravity.ts
+++ b/src/lib/oauth/providers/antigravity.ts
@@ -5,6 +5,9 @@ import {
   getAntigravityLoadCodeAssistMetadata,
 } from "@omniroute/open-sse/services/antigravityHeaders.ts";
 import { extractCodeAssistOnboardTierId } from "@omniroute/open-sse/services/codeAssistSubscription.ts";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("oauth:antigravity");
 
 // Bound every Antigravity post-exchange call. Without this an unreachable/slow
 // upstream made the `/exchange` request (and therefore the whole OAuth login)
@@ -98,7 +101,13 @@ export const antigravity = {
     const userInfoRes = await fetch(`${ANTIGRAVITY_CONFIG.userInfoUrl}?alt=json`, {
       headers: { Authorization: `Bearer ${tokens.access_token}` },
       signal: AbortSignal.timeout(POSTEXCHANGE_TIMEOUT_MS),
-    }).catch(() => null);
+    }).catch((err) => {
+      log.warn(
+        { err, userInfoUrl: ANTIGRAVITY_CONFIG.userInfoUrl },
+        "Antigravity userInfo fetch failed; continuing without user info"
+      );
+      return null;
+    });
     const userInfo = userInfoRes?.ok ? await userInfoRes.json() : {};
 
     let projectId = "";

--- a/src/lib/vscode/serviceTierVariants.ts
+++ b/src/lib/vscode/serviceTierVariants.ts
@@ -1,6 +1,9 @@
 import { CODEX_FAST_TIER_DEFAULT_SUPPORTED_MODELS } from "@/lib/providers/codexFastTier";
 import { resolveFamilyFirstPublishedModelId } from "@/lib/vscode/familyFirstModelIds";
 import { normalizeServiceTierId, type ServiceTierId } from "@/shared/utils/serviceTierLabels";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("vscode:service-tier-variants");
 
 const SERVICE_TIER_VARIANT_PATTERN = /__tier_(priority|flex)$/i;
 const SUPPORTED_VSCODE_SERVICE_TIERS: readonly ServiceTierId[] = ["priority", "flex"];
@@ -181,7 +184,13 @@ export async function rewriteVscodeServiceTierRequest(request: Request): Promise
   const body = await request
     .clone()
     .json()
-    .catch(() => null);
+    .catch((err) => {
+      log.warn(
+        { err },
+        "Failed to parse VS Code service-tier request body; leaving request unchanged"
+      );
+      return null;
+    });
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return request;
   }


### PR DESCRIPTION
## **User description**
Completes the audit-driven governance work that PR #509 started. Eight independent fixes:

Security fixes (audit findings F5, F6, F9, F10):

1. src/lib/cloudSync.ts:47-56 — HMAC verification fail-open when CLOUD_SYNC_SECRET is unset. Now returns false (fail-closed) when a sigHeader is present but cannot be verified, instead of accepting any response. Legacy unverified mode (no sigHeader) is preserved.

2. src/lib/oauth/providers/antigravity.ts:101 — fetch() of userInfo during OAuth was swallowed silently, causing downstream code to use default projectId/tierId. Now logs warn with structured context.

3. open-sse/services/autoRefreshDaemon.ts:77,80 — periodic credential refresh errors were silently swallowed, allowing expired tokens to persist undetected. Now logs error per cycle.

4. src/lib/vscode/serviceTierVariants.ts:184 — request body parse failures during tier-rewrite were silently no-op'd. Now logs warn.

Refactor:

5. src/lib/db/encryption.ts — migrated ~7 console.* calls to pino logger (encryptionLog). Following the PR #509 pattern of createLogger("db:encryption"). The catch fallback behavior is preserved exactly; only logging changes.

Out of scope:
- encryption.ts:144-148 plaintext fallback (separate spec at plans/encryption-failclosed-spec.md, deferred for design discussion)
- src/lib/db/*.ts console.* migration for other files (separate PR)


___

## **CodeAnt-AI Description**
Fail closed on unverifiable cloud sync responses and surface hidden security errors

### What Changed
- Cloud sync now rejects responses that include a signature when the verification secret is missing, preventing unverifiable payloads from being accepted.
- Background credential checks and OAuth user-info failures now report errors instead of failing silently.
- Invalid VS Code service-tier request bodies are left unchanged and now produce a warning for diagnosis.
- Encryption failures, malformed values, and plaintext fallback use structured error logging while preserving existing encryption behavior.

### Impact
`✅ Fewer unauthorized cloud sync payloads accepted`
`✅ Clearer credential refresh and OAuth failure visibility`
`✅ Safer handling of malformed encryption and request data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
