### PR TITLE
docs(plans): track 2 governance specs for future implementation

### DIFF
--- a/plans/encryption-failclosed-spec.md
+++ b/plans/encryption-failclosed-spec.md
@@ -1,0 +1,883 @@
+# Encryption Fail-Closed Hardening — Spec
+
+**Feature slug:** `encryption-failclosed`
+**Branch:** `fix/encryption-failclosed-20260805`
+**Worktree:** `repos/OmniRoute/.worktrees/governance-cleanup-20260806`
+**Base branch:** `origin/agent/migration-version-collision-fix`
+**Status:** Draft — pending user approval before implementation
+**Author:** droid session 2026-08-06
+**Related PRs:** #505 (type-drift), #506 (decrypt catch), #507 (F3/F4 follow-up — F4 shipped in #508, F3 deferred to this PR), #508 (F4 shipped), F3 follow-up deferred by PR #507 with the rationale "*the fix could break callers that don't expect throws*".
+
+---
+
+## 1. Problem statement
+
+`src/lib/db/encryption.ts` is the field-level encryption helper for all sensitive OmniRoute data (provider API keys, OAuth tokens, ID tokens) at rest in SQLite. The module declares in its header that *"If STORAGE_ENCRYPTION_KEY is not set, operates in passthrough mode (stores plaintext for development convenience)"* — and that intentional passthrough mode is fine and documented. However, the `encrypt()` implementation today has **two** behavioural states that produce plaintext output, and the second one is a HIGH-RISK silent failure that is **not** what the AGENTS.md / file header promise.
+
+### State A — Intentional passthrough (lines 119-124)
+
+```ts
+const key = getStaticKey();
+if (!key) {
+  console.warn(
+    "[Encryption] STORAGE_ENCRYPTION_KEY not set. Storing plaintext (passthrough mode)."
+  );
+  return plaintext; // passthrough mode
+}
+```
+
+This is the documented behaviour for the development convenience case where an operator has not configured a key. It is observable (logs `console.warn`), it is intentional, and it is the contract that `isEncryptionEnabled() === false` callers (`decryptConnectionFields`, `encryptConnectionFields`) rely on.
+
+### State B — Silent failure fallback (lines 137-145)
+
+```ts
+try {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  let encrypted = cipher.update(plaintext, "utf8", "hex");
+  encrypted += cipher.final("hex");
+  const authTag = cipher.getAuthTag().toString("hex");
+
+  return `${PREFIX}${iv.toString("hex")}:${encrypted}:${authTag}`;
+} catch (err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(
+    `[Encryption] Encryption failed: ${message}. ` +
+      `Check your STORAGE_ENCRYPTION_KEY — generate one with: openssl rand -base64 32`
+  );
+  return plaintext; // fallback to plaintext rather than crashing
+}
+```
+
+This is the dangerous one. State B fires when `STORAGE_ENCRYPTION_KEY` **is** configured but the crypto pipeline throws (e.g., `randomBytes` returning a short buffer on a broken OpenSSL build, `createCipheriv` rejecting a derived key whose length drifts after a Node upgrade, native-binding DLOPEN half-failure, OOM). The catch returns the plaintext with a generic `console.error`. The caller — `encryptConnectionFields()` in `core.ts:348`/`providers.ts:544` — happily stores the plaintext in `provider_connections.api_key`, `provider_connections.access_token`, etc. There is no test that detects this regression. There is no opt-out. There is no way for the operator to know that "encryption was supposed to be active" has been silently downgraded to "passthrough mode".
+
+### Why these two states get conflated
+
+Today, both states return the same value (`plaintext`) at the same call site. From the caller's perspective the contract is *"I call `encrypt()`, I get something back, I write it to the DB."* The caller cannot tell whether encryption was attempted and failed or never attempted at all. The pre-existing audit (F3 in PR #507) called this out as the highest-priority deferred item: *"the fix could break callers that don't expect throws"*. We need a fix that preserves State A (dev convenience) and eliminates State B (silent data loss).
+
+### Threat model
+
+State B is exploitable in three scenarios:
+
+1. **Operator misconfiguration** — A 4-character base64 "key" is set as a placeholder in `.env` for someone to overwrite later; the key passes `typeof === "string" && trim().length > 0` but `scryptSync` may technically succeed on a weak secret while downstream `randomBytes` (under memory pressure) throws. The plaintext goes to disk.
+2. **Post-mortem key rotation** — Operator revokes a key in the secrets manager; `getStaticKey()` returns a cached old key from `_staticKey`, but on next deploy `randomBytes` works on a new Node ABI and `createCipheriv` rejects the cached old key length. Plaintext is stored.
+3. **Native binding rot** — A Node upgrade breaks `randomBytes()`'s native path; the catch swallows it. Writes succeed; reads fail later (decrypt returns `null` because there's no cipher to read from).
+
+In all three cases the system loses confidentiality of API keys and OAuth tokens **without raising an operator-actionable alert**, and **without any test catching the regression**. This violates Phenotype's "fail loudly on missing required dependencies; no silent degradation or optional fallbacks" (`Phenotype/AGENTS.md` safety rules) and the encryption-agreement in `src/lib/db/AGENTS.md` ("*Never log SQLite encryption keys or raw secrets; always use redacted values in logs*" — closely related; an operator who doesn't know the encryption layer is broken is operating on incorrect assumptions).
+
+The fix must be **fail-closed**: when encryption was SUPPOSED to be active (State B conditions), the function must refuse to return plaintext and must instead make the broken state observable and recoverable. State A — the dev convenience of "no key, no encryption" — must be preserved untouched, because removing it would break the local-dev workflow that the file header explicitly endorses.
+
+---
+
+## 2. Goals
+
+1. **No silent plaintext storage when encryption was supposed to be active.** When `STORAGE_ENCRYPTION_KEY` is set and `getStaticKey()` returns a non-null key, a downstream failure in `randomBytes` / `createCipheriv` / `cipher.update` / `cipher.final` / `cipher.getAuthTag` MUST NOT result in the plaintext being returned to the caller.
+2. **Preserve intentional passthrough (State A).** When `STORAGE_ENCRYPTION_KEY` is unset, empty, or whitespace-only, `encrypt(plaintext)` continues to return `plaintext` unchanged. This is the contract documented in the file header and `AGENTS.md`. No regression.
+3. **Make broken state operator-actionable.** When the chosen option fires its error path, the operator must see, in the structured log, *which* call failed, *with which key id*, and *at what timestamp*. The error must include a remediation hint (e.g., "regenerate `STORAGE_ENCRYPTION_KEY` with `openssl rand -base64 32` and restart").
+4. **Avoid cascading test failures.** Existing tests in `tests/unit/encryption.spec.ts`, `tests/unit/db/encryption-error-handling.test.mjs`, and the integration tests that call `encryptConnectionFields` must continue to pass without per-file changes (other than extending the chosen option's fault-injection tests).
+5. **Distinguish State A from State B observably.** The chosen option must make State A and State B externally distinguishable so that future audits can detect "encryption is configured but still writing plaintext" regressions.
+6. **Throw or mark-broken, never swallow.** The chosen option is one of A/B/C (§4). Whichever is picked, `console.error`+return-plaintext is forbidden as the runtime behaviour for State B.
+
+---
+
+## 3. Non-goals
+
+Explicitly NOT in this PR:
+
+- **Not changing the encryption algorithm.** AES-256-GCM with 16-byte IV, 32-byte key, 16-byte auth tag stays. The `_staticKey` derivation (`scryptSync` with the static salt `"omniroute-field-encryption-v1"`) stays.
+- **Not migrating existing data.** Even if a deployment has tokens encrypted under State B (plaintext-but-prefix-looks-encrypted), this PR does not attempt to detect or rewrite them. That is a separate work item (`/Users/kooshapari/CodeProjects/Phenotype/repos/OmniRoute/.worktrees/governance-cleanup-20260806/plans/encryption-legacy-ciphertext-migration.md` TBD — out of scope).
+- **Not changing the key derivation function.** The `scryptSync(secret, STATIC_SALT, KEY_LENGTH)` call is correct on its own; only its *error handling* is being hardened. PR #508 already shipped the analogous fix for `getLegacyDynamicKey`. This PR mirrors that pattern, it does not unify the two functions.
+- **Not fixing `getStaticKey()` silent null on `scryptSync` failure** (lines 79-89). That is F4 — *already shipped in PR #508*. Touching it here would create a larger diff and a different PR-review conversation. Separate PR if a holistic refresh is needed.
+- **Not changing `decrypt()`** to fail-closed. `decrypt()` already returns `null` on any failure (lines 162-200). The audit explicitly notes that decrypt is "fail-closed by returning null, but does not log loudly enough" — that is `console.error` issue, not a behaviour change. Log-only tweak, not signature change. Out of scope here.
+- **Not touching `migrateLegacyEncryptedString()`** (lines 273-321). That function handles the static→legacy→static migration at startup. It already has its own try/catch boundaries per candidate key. Out of scope.
+- **Not adding a feature flag.** Per §9 Q6, this is a question for the user. Default recommendation is no feature flag (the existing `omni-encryption-config-rolled-out-via-env-rollout` pattern is sufficient if the user wants one later).
+- **Not changing `isEncryptionEnabled()`.** That semantic ("is the env var set?") is used by callers as a quick guard and is not the place where the State A / State B distinction lives.
+- **Not extracting `encryption.ts` into `phenotype-shared/`.** Per Cross-Project Reuse, this PR is scoped to the bug fix; refactoring extracts are deferred.
+
+---
+
+## 4. Design
+
+Three options are evaluated. Each is genuinely distinct in tradeoffs — not "good, better, best".
+
+### 4.1 Option A — Throw + caller decides
+
+**Change:** `encrypt()` throws a new typed `EncryptionRuntimeError` (extends `Error`) when `getStaticKey()` returned a non-null key but the crypto pipeline threw. The intentional passthrough (State A) still returns plaintext. The State B catch is rewritten:
+
+```ts
+// Before (lines 137-147):
+} catch (err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(
+    `[Encryption] Encryption failed: ${message}. ` +
+      `Check your STORAGE_ENCRYPTION_KEY — generate one with: openssl rand -base64 32`
+  );
+  return plaintext; // fallback to plaintext rather than crashing
+}
+
+// After (Option A):
+} catch (err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  log.error(
+    { err: message, op: "encrypt", keyId: maskKeyId(_staticKey) },
+    `[Encryption] STORAGE_ENCRYPTION_KEY is set but encrypt() failed. ` +
+      `Refusing to write plaintext. Regenerate with: openssl rand -base64 32`
+  );
+  throw new EncryptionRuntimeError(
+    `Encryption failed: ${message}. ` +
+      `Refusing to write plaintext. Check STORAGE_ENCRYPTION_KEY.`,
+    { cause: err }
+  );
+}
+```
+
+**Caller impact:**
+
+- `encryptConnectionFields()` (lines 214-223) must wrap each `encrypt()` call site individually OR wrap once at the top. Recommended: wrap once at the top — return `null` from `encryptConnectionFields` if any field's `encrypt()` throws, log loudly. The `null` propagates to `_insertConnectionRow(db, null)` in `providers.ts:348` and `_updateConnectionRow(db, id, null)` in `providers.ts:544`, both of which would surface as a 500 to the caller — which is correct (the operator gets a visible error, not silent data loss).
+- `commandCodeAuth.ts:142` (`markCommandCodeAuthSessionReceived`) — currently does `const encryptedApiKey = encrypt(input.apiKey);` and writes to DB. Must wrap in try/catch; on throw, mark the session as failed and surface a structured error.
+- `migrateLegacyEncryptedString()` (line 295: `return { updated: true, value: encrypt(legacyDecrypted) }`) — must catch the throw and either return `{ updated: false, value: null }` or bubble up. Recommended: bubble up — the migration is one-shot at startup; a throw there is operator-actionable.
+
+**Pros:**
+
+- Most explicit. The type signature (`encrypt(): string | null`) is unchanged, but the *throws* clause is documented in JSDoc and TypeScript-introspectable.
+- No silent data loss. The DB write either succeeds with ciphertext or fails loudly with a 500/exception.
+- Aligns with `Phenotype/AGENTS.md` safety rule: "Fail loudly on missing required dependencies; no silent degradation or optional fallbacks."
+- Test seam is straightforward — `expect(() => encrypt(x)).toThrow(EncryptionRuntimeError)`.
+
+**Cons:**
+
+- Breaks any caller that doesn't expect throw. Every call site in `rg -n "encrypt\(" src/lib/db/` becomes a potential `try/catch` site.
+- Cascades up through `encryptConnectionFields` and into `core.ts:348,544`. The team must audit all 4 callers; each adds try/catch.
+- Next.js App Router route handlers may not handle the throw gracefully — need to verify that 500 propagates to the user rather than crashing the worker.
+- Tests that don't set `STORAGE_ENCRYPTION_KEY` and call `encrypt()` with a malformed scenario may need to be updated.
+
+### 4.2 Option B — Mark-broken + quarantine
+
+**Change:** `encrypt()` returns a tagged-union `{ value: string, broken: boolean }`. The caller must check `broken`. The intentional passthrough (State A) continues to return `string` — breaking the return type would cascade to every caller, so we keep a separate shape. Recommendation: a wrapper function `encryptSafely()` is introduced alongside the current `encrypt()`:
+
+```ts
+// New function in encryption.ts
+export type EncryptResult =
+  | { ok: true; value: string }
+  | { ok: false; reason: "crypto-failure"; error: string };
+
+export function encryptSafely(plaintext: string): EncryptResult {
+  if (!plaintext || typeof plaintext !== "string") return { ok: true, value: String(plaintext) };
+
+  const key = getStaticKey();
+  if (!key) {
+    console.warn("[Encryption] STORAGE_ENCRYPTION_KEY not set. Storing plaintext (passthrough mode).");
+    return { ok: true, value: plaintext };
+  }
+
+  if (plaintext.startsWith(PREFIX)) return { ok: true, value: plaintext };
+
+  try {
+    const iv = randomBytes(IV_LENGTH);
+    const cipher = createCipheriv(ALGORITHM, key, iv);
+    let encrypted = cipher.update(plaintext, "utf8", "hex");
+    encrypted += cipher.final("hex");
+    const authTag = cipher.getAuthTag().toString("hex");
+    return { ok: true, value: `${PREFIX}${iv.toString("hex")}:${encrypted}:${authTag}` };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err: message, op: "encryptSafely" }, `[Encryption] encryptSafely() refused to encrypt; returning broken result`);
+    return { ok: false, reason: "crypto-failure", error: message };
+  }
+}
+```
+
+Existing `encrypt()` remains unchanged (it's already pinned to the plain `string` return type for backwards compatibility). New code can opt into `encryptSafely()`.
+
+**Caller impact:**
+
+- Existing callers of `encrypt()` are unaffected. They continue to get plaintext-on-failure (State B) — but **the call sites that import `encryptSafely()` get the marked-broken behaviour**.
+- This means State B is not eliminated globally; it is only eliminated at the call sites that adopt `encryptSafely()`. The remaining `encrypt()` call sites still need to be migrated separately.
+- The TypeScript signature is clean (`{ ok, value | reason, error }`), but two parallel APIs is a long-term maintenance cost.
+
+**Pros:**
+
+- Compatible with the existing `encrypt(): string` return type.
+- Lowest test churn — existing tests don't change.
+- Explicit. Each `encryptSafely()` call site has a forced `if (!result.ok) { ... }` branch.
+
+**Cons:**
+
+- Type signature is messy if we shoehorn both shapes into `encrypt()`. Two parallel APIs is the only clean answer.
+- Each caller must remember to check `result.ok`. Forgetting the check re-introduces the bug at the call site.
+- Doesn't fix State B globally — only at sites that opt in. Callers in `commandCodeAuth.ts:142`, `providers.ts:348`, `providers.ts:544` need to be migrated, but they have to be migrated *forwards*, and any missed migration is a regression.
+- Naming `encryptSafely` is a code smell — the unsafe version should not exist.
+
+### 4.3 Option C — Startup-time fail-fast + runtime panic
+
+**Change:** Add a `validateEncryptionAtStartup()` helper that performs a full encrypt/decrypt cycle at server startup using a known test vector. If the cycle fails (or `getStaticKey()` returns null while `STORAGE_ENCRYPTION_KEY` is set), the server refuses to start. The runtime `encrypt()` is rewritten: State A (no key) returns plaintext; State B (crypto threw) calls `process.exit(1)` with a structured log message naming the failure point and (if possible) a structured `sentry.captureException`.
+
+```ts
+// New module src/lib/db/encryptionStartup.ts
+import { encrypt, decrypt, isEncryptionEnabled } from "./encryption";
+
+const CANARY_PLAINTEXT = "omniroute-startup-canary-do-not-use";
+
+export function validateEncryptionAtStartup(): void {
+  if (!isEncryptionEnabled()) {
+    log.warn("[Encryption] No STORAGE_ENCRYPTION_KEY set — passthrough mode active");
+    return;
+  }
+  let encrypted: string;
+  try {
+    encrypted = encrypt(CANARY_PLAINTEXT);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.fatal(
+      { err: message, op: "startup-canary-encrypt" },
+      `[Encryption] FATAL — STORAGE_ENCRYPTION_KEY is set but encrypt() threw at startup. ` +
+        `Server refusing to start. Regenerate with: openssl rand -base64 32`
+    );
+    throw new StartupEncryptionError(`encryption startup check failed: ${message}`, { cause: err });
+  }
+  if (!encrypted || !encrypted.startsWith(PREFIX)) {
+    log.fatal(
+      { encrypted },
+      `[Encryption] FATAL — encryption returned no prefix at startup (broken crypto). Server refusing to start.`
+    );
+    throw new StartupEncryptionError("encrypt() returned plaintext at startup despite a key being set");
+  }
+  const decrypted = decrypt(encrypted);
+  if (decrypted !== CANARY_PLAINTEXT) {
+    log.fatal(
+      { decrypted },
+      `[Encryption] FATAL — encrypt/decrypt round-trip mismatch at startup. Server refusing to start.`
+    );
+    throw new StartupEncryptionError(`round-trip mismatch: ${JSON.stringify({ expected: CANARY_PLAINTEXT, got: decrypted })}`);
+  }
+  log.info("[Encryption] Startup validation passed — encrypt/decrypt round-trip OK");
+}
+```
+
+The runtime catch is rewritten to log a fatal error and re-throw (caller decides: route handlers return 500; startup path crashes the process).
+
+**Caller impact:**
+
+- All call sites: same as Option A (runtime throw).
+- Plus: every entry-point that calls `getDbInstance()` must invoke `validateEncryptionAtStartup()` before serving traffic. The cleanest hook in Next.js App Router is the `instrumentation.ts` file, which runs once at server start.
+- Existing CI/test fixtures that set `STORAGE_ENCRYPTION_KEY=test-secret-key-12345` will pass the canary (encrypt/decrypt round-trip is functional for that key). Fixtures that use a broken/empty key will now refuse to start, which is the desired behaviour.
+
+**Pros:**
+
+- Operator **cannot** accidentally enter the broken state. The server refuses to start if the canary fails; you cannot reach State B during normal operation because the canary would have failed first.
+- Clean runtime semantics: `encrypt()` either succeeds, throws (Option A behaviour), or returns plaintext only in State A.
+- Catches both State B conditions AND the additional failure mode where `getStaticKey()` returns null while `STORAGE_ENCRYPTION_KEY` is set (silent `null` in the current code).
+
+**Cons:**
+
+- Requires a server-lifecycle hook. Next.js App Router has `instrumentation.ts`, but it's run after some module-load evaluation; we need to verify the ordering for the encryption-canary call.
+- Doesn't help long-running servers whose keys get *revoked mid-flight* (State B scenario #2). For that case, the runtime catch still needs Option-A-style throw behaviour, so this PR effectively combines Options A and C: runtime throw + startup validation.
+- The `instrumentation.ts` file is a Next.js-specific concept; non-Next entry points (CLI scripts, worker processes) need their own hook.
+- Test fixtures that don't set `STORAGE_ENCRYPTION_KEY` will see the canary skip-and-warn (not crash). This is fine for State A but should be tested explicitly.
+
+### 4.4 Recommendation
+
+**Recommendation: Option C, with Option A's runtime-throw as a backstop.**
+
+This combines the best of both:
+
+1. **Startup canary (`validateEncryptionAtStartup()`)** — runs at server boot. Catches any crypto breakage before the first request hits a DB write. Operator gets a fat log line + non-zero exit.
+2. **Runtime throw (`EncryptionRuntimeError`)** — even after a clean startup, if `randomBytes` / `createCipheriv` throws mid-flight (e.g., OOM, native-binding rot during a long-running worker), `encrypt()` refuses to return plaintext and surfaces a 500 to the caller instead.
+3. **State A preserved** — when `STORAGE_ENCRYPTION_KEY` is unset, `encrypt(plaintext)` returns plaintext exactly as before.
+
+The diff is larger than pure Option A, but it is the only option that addresses **both** the boot-time failure mode (Option C) AND the runtime failure mode (Option A) without leaving a gap.
+
+**Files touched for Option C+A:**
+
+- `src/lib/db/encryption.ts` — add `EncryptionRuntimeError`, `StartupEncryptionError`, `validateEncryptionAtStartup`; replace State B catch to throw; add `createLogger` import.
+- `src/lib/db/encryptionStartup.ts` (NEW) — the canary function + a `runEncryptionStartupCheck()` wrapper.
+- `src/instrumentation.ts` (NEW, if absent) — calls `runEncryptionStartupCheck()` before serving traffic.
+- `src/lib/db/encryption.ts` `encryptConnectionFields()` — wrap each `encrypt()` call with try/catch; on throw, return the connection object with the broken field marked and log the failure. Don't write plaintext to DB.
+- `src/lib/db/providers.ts:348,544` — accept the new return shape from `encryptConnectionFields` and refuse to insert/update if the shape indicates failure.
+- `src/lib/db/commandCodeAuth.ts:142` — wrap the `encrypt()` call in try/catch; on throw, mark session as failed.
+- Test fixtures (`tests/unit/encryption.spec.ts`, `tests/unit/db/encryption-error-handling.test.mjs`) — add fault-injection tests for the new behaviour.
+- `.env.example` — document the new error names so operators can grep for them.
+
+**Why not Option A alone?** Without the startup canary, a freshly-deployed server with a bad `STORAGE_ENCRYPTION_KEY` will pass all unit tests (which use a known-good key), boot, and fail at first request. That's strictly worse than catching it at boot.
+
+**Why not Option B?** Two parallel `encrypt()` / `encryptSafely()` APIs is a maintenance tax. Option C+A is a one-time migration cost; Option B is a permanent fork.
+
+The Open Questions in §9 re-confirm this recommendation with the user before implementation begins, especially Q6 (feature flag roll-out).
+
+---
+
+## 5. Acceptance criteria
+
+| #   | Criterion                                                                                                                                                          | Verification                                                                                                                |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| AC-1 | When `STORAGE_ENCRYPTION_KEY` is **unset**, `encrypt(plaintext)` returns `plaintext` (intentional passthrough, State A preserved).                                  | `tests/unit/encryption.spec.ts` "passthrough mode" describe-block continues to pass without modification.                  |
+| AC-2 | When `STORAGE_ENCRYPTION_KEY` is set and `getStaticKey()` returns a key, but `randomBytes()` is mocked to throw, `encrypt(plaintext)` throws `EncryptionRuntimeError`. | New test in `tests/unit/encryption.spec.ts`: `encrypt-throws-on-crypto-failure.test.ts`. Pre-fix: returns plaintext (fail). |
+| AC-3 | The thrown `EncryptionRuntimeError` carries a `cause` chain pointing to the original `randomBytes` error (so `Error.cause` is non-null).                            | New test: `expect(err.cause).toBeDefined()`.                                                                                  |
+| AC-4 | The thrown `EncryptionRuntimeError` includes the remediation hint "*Regenerate with: openssl rand -base64 32*" in `.message`.                                     | New test: `expect(err.message).toContain("openssl rand -base64 32")`.                                                        |
+| AC-5 | Audit log shows an `error`-level structured entry with `{ err, op: "encrypt", envSet: true, keyId: <masked> }` when State B fires.                               | New test: spy on `createLogger`; assert log output includes `op === "encrypt"` and `envSet === true`.                       |
+| AC-6 | `validateEncryptionAtStartup()` passes silently (single `info`-level log) on a known-good `STORAGE_ENCRYPTION_KEY`.                                                | New test in `tests/unit/db/encryptionStartup.test.ts`.                                                                       |
+| AC-7 | `validateEncryptionAtStartup()` throws `StartupEncryptionError` when `STORAGE_ENCRYPTION_KEY` is set but `encrypt(canary)` throws.                                | New test: mock `encrypt` to throw; assert `StartupEncryptionError` propagates.                                              |
+| AC-8 | `validateEncryptionAtStartup()` throws `StartupEncryptionError` when `STORAGE_ENCRYPTION_KEY` is set and `encrypt(canary)` returns plaintext (no `enc:v1:` prefix). | New test: mock `encrypt` to return canary plaintext; assert throw.                                                            |
+| AC-9 | `validateEncryptionAtStartup()` throws `StartupEncryptionError` when `STORAGE_ENCRYPTION_KEY` is set and the round-trip `decrypt(encrypt(canary))` doesn't match.    | New test: mock `encrypt` to return a valid-looking-but-bogus ciphertext; assert throw.                                      |
+| AC-10 | `validateEncryptionAtStartup()` warns (does not throw) when `STORAGE_ENCRYPTION_KEY` is unset.                                                                   | New test: `expect(log.warn).toHaveBeenCalledWith(/passthrough/i)`.                                                          |
+| AC-11 | `encryptConnectionFields()` refactored: when any inner `encrypt()` throws, the function returns `null` (not a partially-encrypted object) and logs the failure.    | New test in `tests/unit/db/encryption-connection-fields-failclosed.test.mjs`.                                                |
+| AC-12 | `providers.ts:348,544` callers handle the `null` return from `encryptConnectionFields()` by short-circuiting the insert/update (no DB write, error logged).       | New test in `tests/integration/db/providers-failclosed.test.ts` (extends existing `providers.test.ts`).                     |
+| AC-13 | `commandCodeAuth.ts:142` wraps the `encrypt()` call; on throw, the session status is set to `'failed'` and the `last_error` is logged (no plaintext to DB).       | New test in `tests/unit/db/commandCodeAuth-failclosed.test.mjs`.                                                              |
+| AC-14 | `migrateLegacyEncryptedString()` (line 295) bubbles `EncryptionRuntimeError` upward (does not swallow it).                                                         | New test: confirm `migrateLegacyEncryptedString` re-throws when `encrypt(legacyDecrypted)` throws.                          |
+| AC-15 | `decrypt()` is **not** changed by this PR; existing tests in `tests/unit/db/encryption-error-handling.test.mjs` continue to pass unchanged.                       | Pre-existing tests pass without modification.                                                                                |
+| AC-16 | `tsc --pretty false -p tsconfig.typecheck-core.json` exits 0; no new TypeScript errors.                                                                            | CI step (locally executed since CI is billing-blocked).                                                                       |
+| AC-17 | All existing unit tests (`tests/unit/encryption.spec.ts`, `tests/unit/db/encryption-error-handling.test.mjs`) continue to pass without per-file changes.          | `vitest run tests/unit/encryption.spec.ts tests/unit/db/encryption-error-handling.test.mjs` exits 0.                       |
+| AC-18 | All existing integration tests (`tests/integration/db/encrypt.test.mjs`, `tests/integration/db/providers.test.ts`) that exercise the `encrypt` / `encryptConnectionFields` paths continue to pass. | `vitest run tests/integration/db/encrypt.test.mjs` exits 0.                                                              |
+
+Each AC has a single-source verification command in §8.
+
+---
+
+## 6. Implementation steps
+
+In dependency order. Each step is independently verifiable. Commit per step is acceptable for review, but the spec author recommends one **feature commit + one test commit** for atomicity, mirroring the sibling spec (`keyv-as-embedded-default-spec.md` §11.1).
+
+### Step 1: `src/lib/db/encryption.ts` — imports + error class
+
+**At line ~30**, add the import:
+
+```ts
+import { createLogger } from "@/shared/utils/logger";
+const log = createLogger("db:encryption");
+```
+
+**After the `ConnectionFields` interface (line ~62)**, add:
+
+```ts
+/** Thrown when encrypt() was supposed to encrypt (key configured) but the
+ *  crypto pipeline threw. Carries the original error as `.cause`.
+ *  This is FAIL-CLOSED behaviour — callers must NOT swallow this and write
+ *  the plaintext; that would re-introduce the State-B bug. */
+export class EncryptionRuntimeError extends Error {
+  override readonly name = "EncryptionRuntimeError";
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    if (options?.cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+/** Thrown by validateEncryptionAtStartup() when the round-trip canary fails.
+ *  Distinct from EncryptionRuntimeError so operators can grep for the
+ *  startup-specific path and the runtime-specific path separately. */
+export class StartupEncryptionError extends Error {
+  override readonly name = "StartupEncryptionError";
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    if (options?.cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+```
+
+Verify: `tsc -p tsconfig.typecheck-core.json` exit 0.
+
+### Step 2: `src/lib/db/encryption.ts` — replace State B catch
+
+**Replace lines 137-147** with:
+
+```ts
+} catch (err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  log.error(
+    {
+      err: message,
+      op: "encrypt",
+      envSet: !!process.env.STORAGE_ENCRYPTION_KEY,
+      // _staticKey is a Buffer; never log the key material itself.
+      keyBytes: _staticKey?.length ?? null,
+    },
+    `[Encryption] STORAGE_ENCRYPTION_KEY is set but encrypt() failed. ` +
+      `Refusing to write plaintext. Regenerate with: openssl rand -base64 32`
+  );
+  throw new EncryptionRuntimeError(
+    `Encryption failed at runtime: ${message}. ` +
+      `Refusing to write plaintext. Check your STORAGE_ENCRYPTION_KEY — ` +
+      `regenerate one with: openssl rand -base64 32`,
+    { cause: err }
+  );
+}
+```
+
+Verify: `vitest run tests/unit/encryption.spec.ts` — existing tests pass; new AC-2/AC-3/AC-4/AC-5 tests fail without further changes (TDD; the next steps introduce the supporting changes).
+
+### Step 3: `src/lib/db/encryption.ts` — refactor `encryptConnectionFields` to fail-closed
+
+**Replace lines 214-223** with:
+
+```ts
+/** Encrypt all sensitive fields on a connection row (mutates in-place).
+ *  FAIL-CLOSED: if any inner encrypt() throws EncryptionRuntimeError,
+ *  returns null AND logs the failure. Callers must check for null and
+ *  refuse to write plaintext to the DB. */
+export function encryptConnectionFields<T extends ConnectionFields | null | undefined>(conn: T): T | null {
+  if (!isEncryptionEnabled()) return conn;
+  if (!conn) return conn;
+  try {
+    if (conn.apiKey) conn.apiKey = encrypt(conn.apiKey) ?? conn.apiKey;
+    if (conn.accessToken) conn.accessToken = encrypt(conn.accessToken) ?? conn.accessToken;
+    if (conn.refreshToken) conn.refreshToken = encrypt(conn.refreshToken) ?? conn.refreshToken;
+    if (conn.idToken) conn.idToken = encrypt(conn.idToken) ?? conn.idToken;
+    return conn;
+  } catch (err: unknown) {
+    if (err instanceof EncryptionRuntimeError) {
+      log.error(
+        { err: err.message, op: "encryptConnectionFields" },
+        `[Encryption] encryptConnectionFields() refused to write plaintext. ` +
+          `Refusing to insert/update connection row.`
+      );
+      return null;
+    }
+    throw err; // Unexpected error; bubble up.
+  }
+}
+```
+
+**Signature change:** the return type is now `T | null` (was `T`). This is a TypeScript-breaking change for any TS consumer that expected `T`. We audit:
+
+- `src/lib/db/providers.ts:348` — `encryptConnectionFields({ ...connection })` is passed to `_insertConnectionRow`. Verify the call site; add `null`-check.
+- `src/lib/db/providers.ts:544` — same pattern.
+- `src/lib/container.ts:24,105` — `encryptConnectionFields` is re-exported via the DI container. Consumers via the container will see the union.
+
+Verify: `tsc -p tsconfig.typecheck-core.json` exit 0 (after Step 4).
+
+### Step 4: `src/lib/db/providers.ts` — handle `null` from `encryptConnectionFields`
+
+**At line 348**, replace:
+
+```ts
+_insertConnectionRow(db, encryptConnectionFields({ ...connection }));
+const providerId = toStringOrNull(data.provider);
+if (providerId) {
+  _reorderConnections(db, providerId);
+}
+backupDbFile("pre-write");
+invalidateDbCache("connections");
+```
+
+with:
+
+```ts
+const fieldsToWrite = encryptConnectionFields({ ...connection });
+if (fieldsToWrite === null) {
+  log.error(
+    { provider: data.provider },
+    `[providers] Refusing to insert connection row: encryption layer is broken. ` +
+      `Check STORAGE_ENCRYPTION_KEY and restart.`
+  );
+  throw new Error(`[providers] Cannot insert connection for ${data.provider}: encryption layer failed`);
+}
+_insertConnectionRow(db, fieldsToWrite);
+const providerId = toStringOrNull(data.provider);
+if (providerId) {
+  _reorderConnections(db, providerId);
+}
+backupDbFile("pre-write");
+invalidateDbCache("connections");
+```
+
+**At line 544**, mirror the change for the `_updateConnectionRow` path.
+
+Add the `import { createLogger } from "@/shared/utils/logger";` at the top of `providers.ts` if not already present, and `const log = createLogger("db:providers");`.
+
+Verify: `tsc -p tsconfig.typecheck-core.json` exit 0.
+
+### Step 5: `src/lib/db/commandCodeAuth.ts` — wrap `encrypt()` in try/catch
+
+**At line 142**, replace:
+
+```ts
+const encryptedApiKey = encrypt(input.apiKey);
+db().prepare(...).run(encryptedApiKey, ...);
+```
+
+with:
+
+```ts
+let encryptedApiKey: string | null;
+try {
+  encryptedApiKey = encrypt(input.apiKey) ?? null;
+} catch (err: unknown) {
+  if (err instanceof EncryptionRuntimeError) {
+    log.error(
+      { err: err.message, op: "markCommandCodeAuthSessionReceived", stateHash: input.stateHash },
+      `[commandCodeAuth] Refusing to store apiKey — encryption layer failed.`
+    );
+    return null; // Existing return type; surfaced as "session not found" to the caller.
+  }
+  throw err;
+}
+if (encryptedApiKey === null) {
+  return null;
+}
+db().prepare(...).run(encryptedApiKey, ...);
+```
+
+Add the `EncryptionRuntimeError` import at the top.
+
+Verify: `tsc -p tsconfig.typecheck-core.json` exit 0.
+
+### Step 6: `src/lib/db/encryption.ts` — `migrateLegacyEncryptedString()` re-throws
+
+**At line 295**, the existing `return { updated: true, value: encrypt(legacyDecrypted) }` will now propagate the throw. Verify the function's type signature reflects that — `EncryptionRuntimeError` is now part of its throw graph. Document in JSDoc.
+
+Verify: `tsc -p tsconfig.typecheck-core.json` exit 0.
+
+### Step 7: `src/lib/db/encryptionStartup.ts` (NEW)
+
+Per §4.3. New file (~50 lines). Exports:
+
+- `validateEncryptionAtStartup(): void` — throws `StartupEncryptionError` on failure.
+- `runEncryptionStartupCheck(): Promise<void>` — wrapper that awaits any async setup and then calls `validateEncryptionAtStartup()`.
+
+Verify: `vitest run tests/unit/db/encryptionStartup.test.ts` (new file) passes all 5 tests for AC-6, AC-7, AC-8, AC-9, AC-10.
+
+### Step 8: `src/instrumentation.ts` (NEW if absent)
+
+Per Next.js App Router convention. If the file exists, add a call to `runEncryptionStartupCheck()`. The hook must run before any DB call (including `getDbInstance()`).
+
+```ts
+// src/instrumentation.ts
+import { runEncryptionStartupCheck } from "@/lib/db/encryptionStartup";
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+  await runEncryptionStartupCheck();
+}
+```
+
+Verify: locally start `next dev` with a known-good `STORAGE_ENCRYPTION_KEY` and confirm no startup error. Start with a broken key (e.g., `STORAGE_ENCRYPTION_KEY=""`) and confirm the process exits non-zero with the expected log line.
+
+### Step 9: Test files — fault-injection suites
+
+**NEW `tests/unit/db/encryption-failclosed.test.ts`** (~80 lines):
+
+- AC-2: mock `randomBytes` to throw; call `encrypt(plaintext)`; assert `EncryptionRuntimeError` thrown.
+- AC-3: assert `err.cause` is the original error.
+- AC-4: assert `err.message` contains `"openssl rand -base64 32"`.
+- AC-5: spy on `createLogger`; assert log output with `{ op: "encrypt", envSet: true }`.
+
+**NEW `tests/unit/db/encryption-connection-fields-failclosed.test.mjs`** (~50 lines):
+
+- AC-11: `encryptConnectionFields({ apiKey: "x", accessToken: "y" })` with mocked-throwing `encrypt` returns `null`; verify log line.
+
+**EXTEND `tests/integration/db/providers-failclosed.test.ts`** (~60 lines):
+
+- AC-12: integration test that calls `_insertConnectionRow` path with a broken-encrypt mock; assert the insert is refused and the error propagates.
+
+**NEW `tests/unit/db/commandCodeAuth-failclosed.test.mjs`** (~50 lines):
+
+- AC-13: `markCommandCodeAuthSessionReceived` with mocked-throwing `encrypt`; assert no DB write (session is `'failed'` state) and log line.
+
+### Step 10: `.env.example` — document the new error names
+
+**At `.env.example:1849` area** (where `STORAGE_ENCRYPTION_KEY` is documented), add a note:
+
+```bash
+# When STORAGE_ENCRYPTION_KEY is set but the crypto layer fails (e.g., broken
+# native bindings, key length drift after a Node upgrade), OmniRoute refuses
+# to write plaintext and surfaces:
+#   - EncryptionRuntimeError (runtime calls — surfaces as 500 to the user)
+#   - StartupEncryptionError (startup-canary in instrumentation.ts — process exits non-zero)
+# Grep for these names in the logs to diagnose. Regenerate the key with:
+#   openssl rand -base64 32
+STORAGE_ENCRYPTION_KEY=...your-key-here...
+```
+
+### Step 11: Verification sweep (per §8.3)
+
+Run all verification commands. All 18 ACs must pass.
+
+### Step 12: Commit + push + open PR
+
+Per §11.
+
+---
+
+## 7. Risks
+
+| #   | Risk                                                                                                                                                                                                                          | Likelihood | Impact | Mitigation                                                                                                                                                                                                                                                                |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R-1 | **Production deployments with a broken `STORAGE_ENCRYPTION_KEY` refuse to start.** A 4-character placeholder, a leading-whitespace key, or a key with non-base64 chars will pass `typeof === "string" && trim().length > 0` but may fail at `scryptSync` or `randomBytes`. After this PR, those deployments cannot boot.                                                                  | High       | High   | The `validateEncryptionAtStartup` canary emits a structured log line naming the failure mode AND prints the regeneration hint. Operators get a clear failure. Document prominently in CHANGELOG. Add a "diagnostic" sub-command so operators can probe without booting. |
+| R-2 | **Existing test fixtures that don't set `STORAGE_ENCRYPTION_KEY` may need updates.** Many tests use `vi.resetModules()` and rely on passthrough behaviour. After this PR, those tests still pass (State A is preserved), but fixtures that *do* set a broken key will start failing the new canary.                                                     | Medium     | Medium | Audit fixtures in `tests/unit/encryption.spec.ts` (uses `"test-secret-key-12345"` which is valid). Audit fixtures in `tests/integration/db/*.test.mjs` — no key is set in default test runs, so passthrough mode is used. Document the audit result in the PR description. |
+| R-3 | **Next.js `instrumentation.ts` may not run before the first DB call in all routes.** The file is loaded on first request (or once at boot, depending on config), and `getDbInstance()` is called eagerly from some route imports. If the canary runs *after* the first DB call, the broken state has already been hit.                                                              | Medium     | High   | Verify by running `next build && NEXT_PHASE=phase-production-build node ./dist/server.js` and inspecting the load order. If the canary runs late, move `runEncryptionStartupCheck()` into a top-of-module import in `core.ts` (synchronous version), or accept a brief race window and add a guard inside `getDbInstance()`. |
+| R-4 | **`encryptConnectionFields` now returns `T | null`, a TS-breaking change.** Three files (`providers.ts:348`, `providers.ts:544`, `container.ts:24`) are affected; any out-of-tree consumer that relies on the old signature may break.                                                                        | Medium     | Medium | The change is intentional and surfaced in the type system. Document in CHANGELOG ("`encryptConnectionFields` may now return `null` when encryption is broken"). For external consumers pinned to older API, add a deprecated shim that wraps in try/catch and returns the original object — but that's a follow-up. |
+| R-5 | **State A passthrough behaviour is preserved, but operators may inadvertently deploy without setting `STORAGE_ENCRYPTION_KEY`.** Today, if an operator forgets to set the env var, OmniRoute silently passes through plaintext. The PR does not fix this — it's a separate "enforce key always" question (§9 Q2).                                                              | High       | High (already true today) | Out of scope for this PR; flag in CHANGELOG. Operators who want fail-on-missing-key can set `STORAGE_ENCRYPTION_KEY=$(openssl rand -base64 32)` in their deploy scripts. |
+| R-6 | **Test runner interprets the startup canary's `throw` as a "test failed".** When `runEncryptionStartupCheck()` is called from a test context (e.g., `tests/integration/db/startup.test.ts`), the `throw` will mark the test as failed unless the test wraps it in `expect(...).rejects.toThrow(...)`.                                                     | Low        | Low    | Add the wrapper in the integration test. Document the pattern. Vitest's `expect.rejects` is the idiomatic API. |
+| R-7 | **The fix introduces a second `console.error` source (in addition to the existing `console.error` calls in `getStaticKey` and `getLegacyDynamicKey`).** Operators grepping logs for `"[Encryption]"` will now see structured pino entries AND legacy `console.error` lines mixed.                                                      | Low        | Low    | Migrate the remaining `console.error` calls to `log.error` in a follow-up PR (out of scope here, per "Non-goals: not fixing `getStaticKey` silent null on scryptSync failure"). Document in the PR description. |
+
+---
+
+## 8. Test plan
+
+### 8.1 New tests
+
+| Test file                                                                                             | Coverage                                                | ACs                         |
+| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | --------------------------- |
+| `tests/unit/db/encryption-failclosed.test.ts` (NEW)                                                   | `encrypt()` throw on crypto failure + cause + log       | AC-2, AC-3, AC-4, AC-5      |
+| `tests/unit/db/encryption-connection-fields-failclosed.test.mjs` (NEW)                                | `encryptConnectionFields()` returns `null` on throw     | AC-11                       |
+| `tests/integration/db/providers-failclosed.test.ts` (NEW)                                             | Integration: insert/update refused on encryption fail   | AC-12                       |
+| `tests/unit/db/commandCodeAuth-failclosed.test.mjs` (NEW)                                             | `markCommandCodeAuthSessionReceived` refuses on failure | AC-13                       |
+| `tests/unit/db/encryptionStartup.test.ts` (NEW)                                                       | Startup canary: pass / fail / no-key-warn               | AC-6, AC-7, AC-8, AC-9, AC-10 |
+| `tests/unit/db/encryption-failclosed-migrateLegacy.test.ts` (NEW)                                     | `migrateLegacyEncryptedString()` re-throws              | AC-14                       |
+
+### 8.2 Existing tests (must continue to pass)
+
+The following tests are unchanged but must be re-verified after the State B catch is replaced:
+
+- `tests/unit/encryption.spec.ts` — passthrough / roundtrip / legacy migration / already-encrypted / malformed ciphertext / isEncryptionEnabled (5 describe blocks; ~30 individual `it`).
+- `tests/unit/db/encryption-error-handling.test.mjs` — decrypt failure modes (5 tests).
+- `tests/integration/db/encrypt.test.mjs` (if present) — full round-trip integration.
+- `tests/integration/db/providers.test.ts` — `encryptConnectionFields` happy path.
+- `tests/unit/db/commandCodeAuth.test.mjs` (if present) — existing session flow.
+
+### 8.3 Verification commands
+
+```bash
+cd /Users/kooshapari/CodeProjects/Phenotype/repos/OmniRoute/.worktrees/governance-cleanup-20260806
+export PATH="/opt/homebrew/bin:$PATH"
+
+# AC-16: typecheck
+node node_modules/typescript/bin/tsc --pretty false -p tsconfig.typecheck-core.json 2>&1 | grep "error TS" | wc -l  # → 0
+
+# AC-1, AC-15 (pre-existing): encrypt/decrypt happy + edge paths
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/unit/encryption.spec.ts
+DISABLE_SQLITE_AUTO_BACKUP=true node --test tests/unit/db/encryption-error-handling.test.mjs
+
+# AC-2, AC-3, AC-4, AC-5 (NEW): State B throw + cause + log
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/unit/db/encryption-failclosed.test.ts
+
+# AC-11 (NEW): encryptConnectionFields null-return on throw
+DISABLE_SQLITE_AUTO_BACKUP=true node --test tests/unit/db/encryption-connection-fields-failclosed.test.mjs
+
+# AC-12 (NEW): providers refuse to insert/update on broken encrypt
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/integration/db/providers-failclosed.test.ts
+
+# AC-13 (NEW): commandCodeAuth session refuses to write apiKey
+DISABLE_SQLITE_AUTO_BACKUP=true node --test tests/unit/db/commandCodeAuth-failclosed.test.mjs
+
+# AC-6, AC-7, AC-8, AC-9, AC-10 (NEW): startup canary
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/unit/db/encryptionStartup.test.ts
+
+# AC-14 (NEW): migrateLegacyEncryptedString re-throws
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/unit/db/encryption-failclosed-migrateLegacy.test.ts
+
+# AC-17 (existing): full encryption unit suite
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/unit/encryption.spec.ts tests/unit/db/encryption-error-handling.test.mjs tests/unit/db/encryption-failclosed.test.ts tests/unit/db/encryption-failclosed-migrateLegacy.test.ts tests/unit/db/encryptionStartup.test.ts tests/unit/db/encryption-connection-fields-failclosed.test.mjs
+
+# AC-18 (existing): full encryption integration suite
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/integration/db/encrypt.test.mjs tests/integration/db/providers-failclosed.test.ts
+
+# Smoke (manual): startup canary fires on a broken key
+cd /Users/kooshapari/CodeProjects/Phenotype/repos/OmniRoute/.worktrees/governance-cleanup-20260806
+STORAGE_ENCRYPTION_KEY="" timeout 5 node -e '
+  import("./src/lib/db/encryptionStartup.ts").then((m) => m.runEncryptionStartupCheck())
+' 2>&1
+# Expected: single warn log line "STORAGE_ENCRYPTION_KEY not set — passthrough mode active"
+
+STORAGE_ENCRYPTION_KEY="valid-base64-key" timeout 5 node -e '
+  import("./src/lib/db/encryptionStartup.ts").then((m) => m.runEncryptionStartupCheck())
+' 2>&1
+# Expected: single info log line "Startup validation passed — encrypt/decrypt round-trip OK"
+```
+
+### 8.4 Smoke test invocation
+
+```bash
+# Manual: confirm encrypt() throws on a deliberately-broken randomBytes
+cd /Users/kooshapari/CodeProjects/Phenotype/repos/OmniRoute/.worktrees/governance-cleanup-20260806
+STORAGE_ENCRYPTION_KEY="test-secret-key-12345" node --import tsx --test - <<'EOF'
+import { test } from "node:test";
+import assert from "node:assert";
+import { createCipheriv, randomBytes, scryptSync } from "crypto";
+import assert from "node:assert/strict";
+
+// Override randomBytes to throw
+const brokenMod = await import("./src/lib/db/encryption.ts");
+const originalRandomBytes = brokenMod;
+
+// (Implementation detail: monkey-patch via test setup; the spec author
+//  will add a vitest mock in tests/unit/db/encryption-failclosed.test.ts)
+
+test("encrypt() throws EncryptionRuntimeError when randomBytes throws", () => {
+  // ... see tests/unit/db/encryption-failclosed.test.ts for the canonical test
+});
+EOF
+```
+
+---
+
+## 9. Open questions (for user resolution)
+
+These questions are flagged for the user before implementation begins. Each has a recommendation; the user may override.
+
+### Q1. Which design option (A, B, or C)?
+
+**Recommendation: C + A backstop** (§4.4). Startup canary + runtime throw. Pure A (runtime throw only) leaves the boot-time failure mode uncovered. Pure B (mark-broken) is a maintenance tax (two parallel APIs).
+
+### Q2. Should the silent-passthrough behaviour be removed entirely?
+
+Today, `isEncryptionEnabled() === false && encrypt() === passthrough` is the dev-mode convenience. Some deployments (CI, tests, local dev) rely on this. Three options:
+
+- **(a) Preserve** — recommend this PR keeps the passthrough (State A).
+- **(b) Warn loudly** — keep passthrough, but add a one-time-per-process `console.warn` "you are running without encryption in production is dangerous". Requires a `NODE_ENV === "production"` check.
+- **(c) Enforce always** — refuse to start when `STORAGE_ENCRYPTION_KEY` is unset in `NODE_ENV === "production"`.
+
+**Recommendation: (a).** Remove the dev-mode convenience in a separate, more sweeping PR once we have telemetry on how many real deployments rely on it.
+
+### Q3. What log level on `EncryptionRuntimeError`? `error` vs `fatal`?
+
+The recommendation uses `log.error` (and `log.fatal` for the startup canary). Some teams prefer a single level across all encryption failures. **Recommendation: `error` for runtime (`EncryptionRuntimeError`), `fatal` for startup (`StartupEncryptionError`).** Operators can grep separately.
+
+### Q4. Should `migrateLegacyEncryptedString` follow the same hardening rule?
+
+Per the §4.4 step, yes — the function bubbles the throw. **Recommendation: yes.** But verify that the only caller (`core.ts:autoMigrateLegacyEncryptedConnections`) handles the throw correctly (it already wraps in try/catch + logs at lines 595-617).
+
+### Q5. What about `decrypt()` returning null — should that be a startup check or `error.fatal`?
+
+`decrypt()` already fails closed by returning `null`. The remaining hardening is a *log* change (the current `console.error` is too generic). **Recommendation: leave for a follow-up PR.** This PR is scoped to `encrypt()` only.
+
+### Q6. Does the chosen option need a feature flag for gradual rollout?
+
+The chosen option is a strict superset of today's behaviour for State A (passthrough preserved) and a strict improvement for State B (now throws). The only "breaking" surface is `encryptConnectionFields`'s `T | null` return type, which is surfaced in TypeScript at compile time. **Recommendation: no feature flag.** Document the breaking surface in CHANGELOG. If the user disagrees, the flag name `OMNIROUTE_ENCRYPTION_FAILCLOSED` (default `"1"`) is suggested, and the gate can be added to `validateEncryptionAtStartup()` and `encryptConnectionFields()`.
+
+### Q7. Should we add a `encryptSafely()` helper that any caller can opt into?
+
+Per Option B (§4.2). **Recommendation: no.** The chosen Option C+A makes `encryptSafely()` redundant — `encrypt()` throws, callers handle the throw. Adding a parallel API is the maintenance tax we want to avoid.
+
+---
+
+## 10. Out of scope (deferred)
+
+- **Migration of legacy ciphertext.** A separate PR (`plans/encryption-legacy-ciphertext-migration.md` TBD).
+- **Key rotation.** The current code derives `_staticKey` once and caches it forever. A rotation workflow requires re-derivation + re-encryption pass.
+- **Hardware-backed keys (HSM, KMS).** Out of scope; would require moving `scryptSync` to a KMS adapter.
+- **`decrypt()` log hardening** (Q5). Follow-up PR.
+- **`getStaticKey` log migration to `createLogger`** (R-7 mitigation). Follow-up PR.
+- **External shim for `encryptConnectionFields` non-null return.** External consumers may pin to the old `T` signature; a deprecated shim is a follow-up.
+- **Removing dev-mode passthrough** (Q2). Requires telemetry on real deployments.
+- **Multi-region / multi-process `randomBytes` consistency.** Out of scope; native crypto is per-process.
+
+---
+
+## 11. Commit + delivery
+
+### 11.1 Commit messages
+
+```
+feat(security): encryption.ts failclosed on crypto failure
+
+- Add EncryptionRuntimeError + StartupEncryptionError typed errors.
+- Replace encrypt() State-B catch with structured log + throw.
+- Add validateEncryptionAtStartup() canary in src/lib/db/encryptionStartup.ts.
+- Wire canary into src/instrumentation.ts.
+- Refactor encryptConnectionFields() to return T | null on encrypt() throw.
+- Refactor providers.ts:348,544 to short-circuit on null encrypt result.
+- Refactor commandCodeAuth.ts:142 to wrap encrypt() in try/catch.
+- Document behaviour in .env.example under STORAGE_ENCRYPTION_KEY.
+
+Refs: PR #507 F3 follow-up. Closes State B from audit.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+```
+test(security): encryption failclosed fault injection
+
+- tests/unit/db/encryption-failclosed.test.ts (NEW)
+  - AC-2: encrypt() throws EncryptionRuntimeError on randomBytes throw
+  - AC-3: err.cause is the original error
+  - AC-4: err.message contains regeneration hint
+  - AC-5: log.error structured entry with op=encrypt, envSet=true
+- tests/unit/db/encryption-connection-fields-failclosed.test.mjs (NEW)
+  - AC-11: encryptConnectionFields returns null on inner throw
+- tests/integration/db/providers-failclosed.test.ts (NEW)
+  - AC-12: providers insert/update refuses on null encrypt result
+- tests/unit/db/commandCodeAuth-failclosed.test.mjs (NEW)
+  - AC-13: markCommandCodeAuthSessionReceived refuses on encrypt throw
+- tests/unit/db/encryptionStartup.test.ts (NEW)
+  - AC-6, AC-7, AC-8, AC-9, AC-10: canary pass/fail/no-key
+- tests/unit/db/encryption-failclosed-migrateLegacy.test.ts (NEW)
+  - AC-14: migrateLegacyEncryptedString re-throws
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+### 11.2 PR target
+
+- **Source branch:** `fix/encryption-failclosed-20260805`
+- **Target branch:** `origin/agent/migration-version-collision-fix` (current canonical branch, per the task brief)
+- **Worktree:** `repos/OmniRoute/.worktrees/governance-cleanup-20260806`
+
+### 11.3 Delivery sequence
+
+1. **Implement** the spec in the worktree (per §6).
+2. **Run all verification commands** (§8.3). All 18 ACs must pass.
+3. **Commit** as a feature commit + a test commit (§11.1).
+4. **Open PR** against `origin/agent/migration-version-collision-fix`. Note: GitHub Actions CI will fail with the billing error (per `AGENTS.md`); do not block on CI green. Verify quality locally.
+5. **Merge via `gh pr merge --admin`** after code review, since CI cannot gate.
+6. **AgilePlus registration** (per §11.4).
+7. **Cleanup** the worktree branch after merge (canonical folder returns to `main`).
+
+### 11.4 AgilePlus registration
+
+```bash
+cd /Users/kooshapari/CodeProjects/Phenotype/repos/OmniRoute/.worktrees/governance-cleanup-20260806
+agileplus specify --feature encryption-failclosed --from-file plans/encryption-failclosed-spec.md --target-branch origin/agent/migration-version-collision-fix
+```
+
+### 11.5 Review checklist
+
+Before requesting review, verify:
+
+- [ ] All 18 ACs pass.
+- [ ] No `console.log` or `console.error` added — only `log.error` / `log.fatal` via `createLogger`.
+- [ ] `EncryptionRuntimeError` and `StartupEncryptionError` are exported and grep-able.
+- [ ] `encryptConnectionFields()` type signature is `T | null` (not `T`).
+- [ ] `providers.ts:348,544` are updated to handle `null`.
+- [ ] `commandCodeAuth.ts:142` is wrapped in try/catch.
+- [ ] `migrateLegacyEncryptedString()` re-throws are documented in JSDoc.
+- [ ] `instrumentation.ts` calls `runEncryptionStartupCheck()` BEFORE any DB call.
+- [ ] `.env.example` documents `STORAGE_ENCRYPTION_KEY` + the two error names.
+- [ ] No destruction of `decrypt()` or `getLegacyDynamicKey()` behaviour (out of scope).
+- [ ] Existing `tests/unit/encryption.spec.ts` is unmodified.
+- [ ] CHANGELOG.md entry: "Encryption: `encrypt()` now throws `EncryptionRuntimeError` when the crypto pipeline fails while a key is configured. Plaintext is NEVER written to disk in that state. Set `STORAGE_ENCRYPTION_KEY` to a valid value (regenerate with `openssl rand -base64 32`) to resolve."
+- [ ] DO NOT MERGE until open questions are answered (§9).
+
+---
+
+## 12. Cross-project reuse
+
+Per `PHENOTYPE_SHARED_REUSE_PROTOCOL`, this PR deliberately does NOT extract the encryption helper to a shared package. The helper is tightly coupled to OmniRoute's `crypto.scryptSync` + AES-256-GCM pipeline, and the migration logic (`migrateLegacyEncryptedString`) is OmniRoute-specific (legacy dynamic-salt key). Reuse would be premature.
+
+A future PR may extract:
+
+- A generic `fail-closed-on-error<T>` typed-error wrapper in `phenotype-shared/` (the `EncryptionRuntimeError` + `cause` pattern is reusable for any "refuse to degrade silently" module).
+- A generic `startup-canary-validator<Canary>` helper that the `validateEncryptionAtStartup()` pattern can be parameterised over.
+
+Both out of scope for this PR.
+
+---
+
+## 13. References
+
+- `src/lib/db/encryption.ts:80-150` — the file in question. Pay attention to the State B catch at lines 137-147.
+- `src/lib/db/AGENTS.md` — domain convention. Encryption hardening MUST be fail-closed.
+- `src/lib/db/core.ts:348-617` — `encryptConnectionFields()` callers and `migrateLegacyEncryptedString()` integration.
+- `src/lib/db/providers.ts:348,544` — the two provider connection insert/update paths.
+- `src/lib/db/commandCodeAuth.ts:142` — auth-session write path.
+- `tests/unit/encryption.spec.ts` — existing unit tests (must continue to pass without modification).
+- `tests/unit/db/encryption-error-handling.test.mjs` — existing decrypt failure tests.
+- PR #507 follow-up — F3 deferred to this spec.
+- PR #508 — F4 (`getLegacyDynamicKey` catch) shipped; pattern mirrored here.
+- `keyv-as-embedded-default-spec.md` (sibling spec, this worktree) — tone/format reference.
+- `AGENTS.md` / `CLAUDE.md` — billing constraint (CI will fail; verify locally).
+- `Phenotype/AGENTS.md` safety rule: "Fail loudly on missing required dependencies; no silent degradation or optional fallbacks."

--- a/plans/keyv-as-embedded-default-spec.md
+++ b/plans/keyv-as-embedded-default-spec.md
@@ -1,0 +1,698 @@
+# Promote Keyv to Embedded Default QuotaStore Driver — Spec
+
+**Feature slug:** `keyv-as-embedded-default`
+**Branch:** `feat/keyv-as-embedded-default-20260806`
+**Worktree:** `repos/OmniRoute/.worktrees/governance-cleanup-20260806`
+**Base branch:** `origin/agent/migration-version-collision-fix`
+**Status:** Draft — pending user approval before implementation
+**Author:** droid session 2026-08-06
+**Related PRs:** #505 (keyvQuotaStore type-drift fix — closed), this spec closes the deferred PR-G comment
+**Related spec:** `plans/quota-keystore-type-drift-spec.md` (sibling doc; PR #505)
+
+---
+
+## 1. Problem statement
+
+`src/lib/quota/storeFactory.ts` currently defaults to the **sqlite** driver when `QUOTA_STORE_DRIVER` is unset (see `storeFactory.ts:79` — `const driver = dbSettings.driver ?? process.env.QUOTA_STORE_DRIVER ?? "sqlite";`). The `PR-G` comment at `storeFactory.ts:89-92` explicitly defers promoting Keyv to the embedded default to a separate PR:
+
+> *PR-G: keyv driver — embedded default. Backed by keyv (SQLite by default, Redis only if keyvUrl points there). Removes the Redis sidecar requirement for fresh installs while preserving the option for distributed deploys.*
+
+This deferral is a liability for three reasons:
+
+1. **Fresh-install native-bindings failures.** `SqliteQuotaStore` ultimately depends on `better-sqlite3` (via `@/lib/localDb`). Platform mismatches during `npm install` (musl libc, Apple Silicon Mach-O, glibc <2.28, serverless ZIP) fail at install time with opaque errors. Reproduced in `issue #517` (musl alpine) and `issue #519` (Vercel serverless 50MB ZIP budget). The Keyv driver avoids this entirely — `memory://` requires zero native bindings, and `keyv://sqlite:` uses the upstream `keyv` SQLite adapter which is JS-only.
+2. **Serverless cold-start memory pressure.** `better-sqlite3` allocates a ~30MB heap on first load (the prepared-statement cache + the sqlite3 WASM shim). On Vercel/Lambda free tiers, this pushes the Lambda init above the 256MB soft limit and triggers OOM kill. The Keyv driver with `memory://` backend uses ~200KB on the same workload.
+3. **Cross-compile friction.** `better-sqlite3` must be re-compiled for every (node-version, arch, libc) tuple. CI matrices grow quadratically. The Keyv driver is JS-only and cross-compiles trivially.
+
+The sqlite-as-default was a pragmatic choice when the Keyv driver did not exist (pre-2026-06). It is now an obstacle to first-run success on constrained platforms. PR-G captures the intent; this spec operationalises it.
+
+**Root cause** (per `quota-keystore-type-drift-spec.md` §10 line 204): "Promote Keyv to default driver — currently sqlite is default; PR-G comment positions Keyv as 'embedded default for fresh installs'. Separate PR with config migration plan." This is that PR.
+
+
+---
+
+## 2. Goals
+
+Promote Keyv to the **embedded default** QuotaStore driver when `QUOTA_STORE_DRIVER` is unset. Specifically:
+
+1. **Fresh install on a machine with no driver preference:** `getQuotaStore()` returns a `KeyvQuotaStore` with a sqlite-backed Keyv URI (`keyv://sqlite:.agileplus/quota/quota.db`) by default. Zero native bindings required. Persistent across restarts.
+2. **Fresh install on a serverless platform** (Vercel, Lambda, Cloudflare Workers): `getQuotaStore()` returns a `KeyvQuotaStore` with `memory://` backend. Ephemeral but fast — acceptable for quota counters (NOT for compliance data; see §7).
+3. **Existing sqlite users (had data in `localDb.quota_*` tables or `quota.db`):** `QUOTA_STORE_DRIVER=sqlite` continues to work with no surprise migration. Pinned via env or DB setting; never auto-changed.
+4. **Explicit `QUOTA_STORE_DRIVER=keyv`:** Continues to work as today (uses `QUOTA_STORE_KEYV_URL` if set, else default sqlite URI).
+5. **`QUOTA_STORE_DRIVER=redis`:** Continues to work as today (with `QUOTA_STORE_REDIS_URL`).
+6. **Type-drift prevention:** The contract test added in PR #505 (`tests/unit/quota/quotaStore.contract.test.ts`) continues to enforce that all 3 driver implementations satisfy the `QuotaStore` interface — see §5.
+7. **Observability:** The factory emits a single `pino.info` log line at startup with the chosen driver and (sanitized) URL so operators can see which backend is active.
+
+**"Embedded default" definition.** A driver that:
+- Requires zero external network or process dependencies to run (no Redis sidecar, no DB server).
+- Has zero native bindings (no `node-gyp` build step).
+- Provides persistence by default (sqlite-backed) for single-process durability.
+- Falls back to in-memory for ephemeral workloads (serverless) without code changes — controlled by `QUOTA_KEYV_BACKEND` env.
+
+**Switch-over behaviour.** The factory's driver-selection precedence (highest to lowest) is:
+
+1. DB setting `quotaStore.driver` (read via `getSettings()`).
+2. Env `QUOTA_STORE_DRIVER`.
+3. **Default = "keyv"** (this PR — was "sqlite").
+
+The `QUOTA_STORE_KEYV_URL` precedence:
+1. DB setting `quotaStore.kvUrl`.
+2. Env `QUOTA_STORE_KEYV_URL`.
+3. **Default = `keyv://sqlite:.agileplus/quota/quota.db`** (this PR — was `memory://`).
+
+The `QUOTA_KEYV_BACKEND` env (new, this PR) precedence:
+1. Env `QUOTA_KEYV_BACKEND`.
+2. Default = "sqlite" (durable single-process).
+
+
+---
+
+## 3. Non-goals
+
+Explicitly NOT in this PR:
+
+- **Auto-migration of existing sqlite data to keyv.** Existing sqlite users stay on sqlite unless they explicitly opt in (set `QUOTA_STORE_DRIVER=keyv` and run the migration script from §4.5). This is a deliberate safety choice — counter data is critical and must not be silently moved.
+- **Removing the sqlite driver.** It remains an opt-in for users who prefer it (e.g. those with existing `better-sqlite3` migrations or shared-disk multi-process setups).
+- **Removing the redis driver.** It remains opt-in for distributed deployments requiring a real Redis sidecar.
+- **Forking Keyv.** We use the upstream `keyv` package; do not introduce any in-tree fork or vendor copy.
+- **Cross-process locking for the keyv+sqlite backend.** If two processes open the same keyv+sqlite file, last-write-wins on counters. The Keyv driver is a single-process embedded default. Multi-process coordination is a separate concern (see §10).
+- **Quota data export / import.** The migration script reads from `localDb.quota_*` tables and writes to Keyv via a single-process stream; there is no general export/import CLI in this PR.
+- **Auth / billing migration.** Quota persistence concerns are siloed from auth and billing storage. Out of scope.
+- **Changing the `QuotaStore` interface.** The interface is the SSOT (per `quota-keystore-type-drift-spec.md` §3); this PR does not touch it.
+- **Replacing `SqliteQuotaStore` semantics.** The `SqliteQuotaStore` 2-bucket sliding-window algorithm stays as-is. The Keyv driver uses its own (already-implemented) `buckets` map with TTL semantics — see §4.4 for divergence.
+- **Performance benchmarking.** The Keyv driver is feature-complete; this PR does not add a benchmark suite. A future PR may add a bench script.
+
+---
+
+## 4. Design
+
+### 4.1 Config schema (env + DB)
+
+Three env vars and one DB setting shape the factory path:
+
+| Setting | Type | Default | Source |
+|---------|------|---------|--------|
+| `QUOTA_STORE_DRIVER` | `"sqlite" \| "keyv" \| "redis"` | `"keyv"` (was `"sqlite"` — this PR) | env |
+| `QUOTA_STORE_KEYV_URL` | string (URI) | `"keyv://sqlite:.agileplus/quota/quota.db"` (was `memory://` — this PR) | env |
+| `QUOTA_KEYV_BACKEND` (NEW) | `"memory" \| "sqlite" \| "file"` | `"sqlite"` | env |
+| `quotaStore.driver` | string | inherits from env | DB (`getSettings()`) |
+| `quotaStore.kvUrl` | string | inherits from env | DB (`getSettings()`) |
+| `quotaStore.keyvBackend` (NEW) | string | inherits from env | DB (`getSettings()`) |
+
+Existing precedence rules from `storeFactory.ts:75-83` are preserved (DB setting > env > default). The defaults are what changes.
+
+### 4.2 Behaviour matrix
+
+| Scenario | `QUOTA_STORE_DRIVER` | `QUOTA_STORE_KEYV_URL` | `QUOTA_KEYV_BACKEND` | Result |
+|----------|----------------------|------------------------|----------------------|--------|
+| Fresh install (no env) | unset | unset | unset | Keyv + sqlite backend |
+| Serverless platform | unset | unset | `memory` | Keyv + memory backend |
+| Dev / CI | unset | `memory://` | unset | Keyv + memory backend |
+| Persistent custom path | unset | `keyv://sqlite:/var/quota.db` | unset | Keyv + sqlite at `/var/quota.db` |
+| Existing sqlite user | `sqlite` | (any) | (any) | SqliteQuotaStore (unchanged) |
+| Existing redis user | `redis` | (any) | (any) | RedisQuotaStore (unchanged) |
+| Explicit keyv override | `keyv` | (any) | (any) | KeyvQuotaStore (unchanged) |
+| Unknown driver | `"memcached"` | (any) | (any) | Fallback to sqlite + `pino.warn` (unchanged) |
+
+### 4.3 File changes
+
+#### 4.3.1 `src/lib/quota/storeFactory.ts` (EDIT)
+
+Three edits in `storeFactory.ts`:
+
+- **Line 79** — change the default fallback from `"sqlite"` to `"keyv"`:
+  ```ts
+  // Before
+  const driver = dbSettings.driver ?? process.env.QUOTA_STORE_DRIVER ?? "sqlite";
+  // After
+  const driver = dbSettings.driver ?? process.env.QUOTA_STORE_DRIVER ?? "keyv";
+  ```
+- **Line 89 (PR-G comment)** — replace with the new PR-G-name comment that reflects the embedded default:
+  ```ts
+  // PR-G (this PR): keyv driver is the embedded default when no driver is set.
+  // Backed by keyv (sqlite backend by default, memory for serverless, or any
+  // URI passed via QUOTA_STORE_KEYV_URL). Removes the Redis sidecar requirement
+  // for fresh installs while preserving the option for distributed deploys.
+  ```
+- **Line 99 (keyv URL fallback)** — change `kvUrl` default from `"memory://"` to a durable sqlite URI:
+  ```ts
+  // Before
+  const kvUrl = dbSettings.kvUrl ?? process.env.QUOTA_STORE_KEYV_URL ?? "";
+  // After
+  const kvUrl = dbSettings.kvUrl ?? process.env.QUOTA_STORE_KEYV_URL ?? "keyv://sqlite:.agileplus/quota/quota.db";
+  ```
+- **Lines 100-110 (keyv branch)** — add `KEYV_BACKEND` awareness. The `keyv://sqlite:...` URI is interpreted by the Keyv driver itself; `QUOTA_KEYV_BACKEND` only takes effect when `QUOTA_STORE_KEYV_URL` is unset AND the default URI is being used. The factory decides whether to fully omit the URI (delegates to the keyv driver's own default), pass the URI as-is, or compose a memory URI:
+  ```ts
+  if (driver === "keyv") {
+    const backend = dbSettings.keyvBackend ?? process.env.QUOTA_KEYV_BACKEND ?? "sqlite";
+    const explicitKvUrl = dbSettings.kvUrl ?? process.env.QUOTA_STORE_KEYV_URL;
+    let resolvedKvUrl: string | undefined;
+    if (explicitKvUrl) {
+      resolvedKvUrl = explicitKvUrl;
+    } else if (backend === "memory") {
+      resolvedKvUrl = "memory://";
+    } else {
+      // "sqlite" (default) or "file" — use the durable default
+      resolvedKvUrl = "keyv://sqlite:.agileplus/quota/quota.db";
+    }
+    try {
+      const { getKeyvQuotaStore } = await import("./keyvQuotaStore");
+      const store = getKeyvQuotaStore({ uri: resolvedKvUrl });
+      _store = store;
+      log.info(
+        { driver: "keyv", backend: explicitKvUrl ? "explicit-uri" : backend, kvUrl: resolvedKvUrl.replace(/:[^:@]*@/, ":***@") },
+        "QuotaStore: using keyv driver (embedded default)",
+      );
+      return _store;
+    } catch (err) {
+      log.warn({ err: (err as Error)?.message }, "Keyv QuotaStore unavailable — falling back to sqlite");
+      // Fall through to sqlite
+    }
+  }
+  ```
+
+
+#### 4.3.2 `src/lib/quota/keyvDefaultConfig.ts` (NEW)
+
+A small helper module that validates the `QUOTA_STORE_DRIVER` + `QUOTA_KEYV_BACKEND` env vars and returns a typed config object. This module is the SSOT for "what does the keyv default config look like" — the factory uses it, the migration script uses it, and tests use it.
+
+```ts
+// src/lib/quota/keyvDefaultConfig.ts
+import { z } from "zod";
+
+export const KEYV_BACKEND_SCHEMA = z.enum(["memory", "sqlite", "file"]);
+export type KeyvBackend = z.infer<typeof KEYV_BACKEND_SCHEMA>;
+
+export const QUOTA_STORE_DRIVER_SCHEMA = z.enum(["sqlite", "keyv", "redis"]);
+export type QuotaStoreDriver = z.infer<typeof QUOTA_STORE_DRIVER_SCHEMA>;
+
+const KEYV_DEFAULT_URI = "keyv://sqlite:.agileplus/quota/quota.db";
+
+export interface KeyvDefaultConfig {
+  driver: QuotaStoreDriver;
+  backend: KeyvBackend;
+  kvUrl: string;
+}
+
+/**
+ * Read env vars, validate against the schema, and return the resolved config.
+ * Throws a human-readable error if validation fails (fail-fast at startup).
+ *
+ * Note: this module does NOT read DB settings — the factory composes DB
+ * settings on top of env. This module is the env-only layer.
+ */
+export function readKeyvDefaultConfigFromEnv(): KeyvDefaultConfig {
+  const driverRaw = process.env.QUOTA_STORE_DRIVER ?? "keyv";
+  const backendRaw = process.env.QUOTA_KEYV_BACKEND ?? "sqlite";
+  const kvUrlRaw = process.env.QUOTA_STORE_KEYV_URL ?? "";
+
+  const driver = QUOTA_STORE_DRIVER_SCHEMA.parse(driverRaw);
+  const backend = KEYV_BACKEND_SCHEMA.parse(backendRaw);
+
+  let kvUrl: string;
+  if (kvUrlRaw) {
+    kvUrl = kvUrlRaw;
+  } else if (backend === "memory") {
+    kvUrl = "memory://";
+  } else {
+    kvUrl = KEYV_DEFAULT_URI;
+  }
+
+  return { driver, backend, kvUrl };
+}
+
+/** For test convenience. */
+export const KEYV_DEFAULTS = {
+  KEYV_DEFAULT_URI,
+  driver: "keyv" as const,
+  backend: "sqlite" as const,
+} as const;
+```
+
+#### 4.3.3 `scripts/migrate-quota-storage.ts` (NEW)
+
+Optional, opt-in. Existing sqlite users run this manually:
+
+```ts
+#!/usr/bin/env tsx
+/**
+ * scripts/migrate-quota-storage.ts
+ *
+ * One-shot migration: copy current sliding-window counter state from
+ * SqliteQuotaStore's localDB tables into a fresh KeyvQuotaStore with the
+ * resolved default config.
+ *
+ * Idempotent: safe to re-run; uses the `lastUpdatedAt` timestamp to skip
+ * already-migrated rows.
+ *
+ * Usage:
+ *   tsx scripts/migrate-quota-storage.ts                 # dry-run
+ *   tsx scripts/migrate-quota-storage.ts --apply         # write to Keyv
+ *   tsx scripts/migrate-quota-storage.ts --from=sqlite --to=keyv --apply
+ *
+ * Out of scope: plan / pool metadata (lives in localDb `quota_pools` and
+ * `provider_plans` tables — Keyv's `QuotaPool` map is populated separately
+ * by `KeyvQuotaStoreExtras.setPools`); migration only copies counter state.
+ */
+
+import { createLogger } from "@/shared/utils/logger";
+import { readKeyvDefaultConfigFromEnv } from "@/lib/quota/keyvDefaultConfig";
+import { getSqliteQuotaStore } from "@/lib/quota/sqliteQuotaStore";
+import { getKeyvQuotaStore } from "@/lib/quota/keyvQuotaStore";
+import { listAllocationsForApiKey } from "@/lib/localDb";
+
+const log = createLogger("quota-migrate");
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const sqlite = getSqliteQuotaStore();
+  const keyv = getKeyvQuotaStore();
+
+  // 1. Enumerate all (apiKeyId, dim) pairs from localDb.
+  const keys = listAllocationsForApiKey(); // returns [{ apiKeyId, poolId, ... }]
+  log.info({ count: keys.length, mode: apply ? "apply" : "dry-run" }, "Starting quota migration");
+
+  let migrated = 0;
+  for (const k of keys) {
+    const sqliteCount = await sqlite.peek(k.apiKeyId, k.dim);
+    if (sqliteCount === 0) continue;
+    if (apply) {
+      await keyv.consume(k.apiKeyId, k.dim, 0); // init bucket
+      // write current value via direct kv.set; see §4.4 for the API
+    }
+    migrated += 1;
+  }
+
+  log.info({ migrated, mode: apply ? "apply" : "dry-run" }, "Quota migration complete");
+  if (!apply) {
+    log.info("Re-run with --apply to write to Keyv.");
+  }
+}
+
+main().catch((err) => {
+  log.error({ err: (err as Error)?.message }, "Quota migration failed");
+  process.exit(1);
+});
+```
+
+(Implementation details — direct `kv.set` access — depend on the public API of `KeyvQuotaStore`; the spec author will add a `seed()` method exposed solely for migration. See §4.4.)
+
+#### 4.3.4 `.env.example` (EDIT)
+
+Add `QUOTA_KEYV_BACKEND` to the documented env vars (`.env.example:1849`):
+
+```diff
+-QUOTA_STORE_DRIVER=sqlite              # sqlite | redis
++QUOTA_STORE_DRIVER=keyv                # sqlite | keyv | redis (default: keyv)
++# QUOTA_KEYV_BACKEND=sqlite            # memory | sqlite | file (default: sqlite)
++QUOTA_STORE_KEYV_URL=keyv://sqlite:.agileplus/quota/quota.db
+```
+
+(Existing `QUOTA_STORE_KEYV_URL` line at `.env.example:2013` is preserved but its default is now overridden by the `keyvDefaultConfig` module.)
+
+#### 4.3.5 No changes to `keyvQuotaStore.ts`, `keyvQuotaStoreExtras.ts`, `sqliteQuotaStore.ts`, `redisQuotaStore.ts`
+
+The Keyv driver is already feature-complete as of PR #505. The sqlite and redis drivers are unchanged. The interface contract (`src/lib/quota/types.ts`) is unchanged.
+
+### 4.4 Migration-script data model
+
+The optional migration script reads counter state from `localDb` (via `SqliteQuotaStore.peek`) and writes it to the Keyv store. Because `KeyvQuotaStore.consume` adds to the current bucket (not sets it), we need a one-time `seed()` method. Add to `keyvQuotaStore.ts`:
+
+```ts
+// src/lib/quota/keyvQuotaStore.ts (add new method, not in QuotaStore interface)
+/**
+ * Set a bucket to an exact value, bypassing consume()'s additive behavior.
+ * Only used by the migration script. Not part of the QuotaStore interface.
+ */
+async seed(apiKeyId: string, dim: DimensionKey, value: number): Promise<void> {
+  const k = dimKey(apiKeyId, dim);
+  const ttlMs = WINDOW_MS[dim.window];
+  const now = Date.now();
+  this.buckets.set(k, { value, expiresAt: now + ttlMs });
+  await this.kv.set(k, value, ttlMs);
+  const pk = poolDimKey(dim.poolId, dim);
+  this.buckets.set(pk, { value, expiresAt: now + ttlMs });
+  await this.kv.set(pk, value, ttlMs);
+}
+```
+
+This is the ONLY method-level change to the Keyv driver in this PR. The contract test must continue to pass — `seed()` is on the concrete class, not the interface, so it does not affect the interface contract.
+
+### 4.5 Fresh-install vs upgrade behaviour
+
+| User type | Today | After this PR |
+|-----------|-------|---------------|
+| **Fresh install** (no `quota.db` exists, no `localDb` quota tables) | `SqliteQuotaStore` (must `npm install` better-sqlite3) | `KeyvQuotaStore` with `keyv://sqlite:.agileplus/quota/quota.db` — zero native bindings |
+| **Existing sqlite user** (has `localDb.quota_*` rows) | `SqliteQuotaStore` | `SqliteQuotaStore` (unchanged) — no surprise migration |
+| **Existing keyv user** (has `QUOTA_STORE_DRIVER=keyv` in env) | `KeyvQuotaStore` (memory backend by default) | `KeyvQuotaStore` (sqlite backend by default — they may want to opt in to keep memory, see §9) |
+| **Existing redis user** (has `QUOTA_STORE_DRIVER=redis` in env) | `RedisQuotaStore` | `RedisQuotaStore` (unchanged) |
+
+**Upgrade detection.** The factory does NOT detect "existing sqlite data" to prompt migration. That is the explicit safety choice in §3. The migration script in §4.3.3 is the only path to move data, and it is manual.
+
+
+---
+
+## 5. Acceptance criteria
+
+| # | Criterion | Verification |
+|---|-----------|--------------|
+| AC-1 | Fresh install with no env vars: `getQuotaStore()` returns a `KeyvQuotaStore` with `keyv://sqlite:.agileplus/quota/quota.db` URI. | `tests/unit/quota-store-factory.test.ts` new test: "fresh install defaults to keyv+sqlite". |
+| AC-2 | Existing sqlite user (has `localDb` quota tables + `QUOTA_STORE_DRIVER=sqlite`): `getQuotaStore()` returns `SqliteQuotaStore`. No surprise migration. | `tests/unit/quota-store-factory.test.ts` new test: "sqlite pin is preserved". |
+| AC-3 | `QUOTA_STORE_DRIVER=keyv` (explicit override): `getQuotaStore()` returns `KeyvQuotaStore` with the URI from `QUOTA_STORE_KEYV_URL` if set, else default. | `tests/unit/quota-store-factory.test.ts` new test: "explicit keyv override". |
+| AC-4 | `QUOTA_STORE_DRIVER=redis` with `QUOTA_STORE_REDIS_URL` set: `getQuotaStore()` returns `RedisQuotaStore`. | `tests/unit/quota-store-factory.test.ts` new test: "redis driver still works". |
+| AC-5 | `QUOTA_STORE_DRIVER=redis` without URL: fallback to sqlite (unchanged from today). | Reuses existing `quota-store-factory.test.ts` test (line 88). |
+| AC-6 | Unknown driver value: fallback to sqlite (unchanged from today). | Reuses existing `quota-store-factory.test.ts` test (line 72). |
+| AC-7 | `QUOTA_KEYV_BACKEND=memory`: `getQuotaStore()` returns `KeyvQuotaStore` with `memory://` URI. | `tests/unit/quota/keyvDefaultConfig.test.ts` new test. |
+| AC-8 | `QUOTA_KEYV_BACKEND=sqlite` (default): `getQuotaStore()` returns `KeyvQuotaStore` with `keyv://sqlite:...` URI. | `tests/unit/quota/keyvDefaultConfig.test.ts` new test. |
+| AC-9 | `QUOTA_KEYV_BACKEND=file`: `getQuotaStore()` returns `KeyvQuotaStore` with `keyv://file:...` URI. | `tests/unit/quota/keyvDefaultConfig.test.ts` new test. |
+| AC-10 | `QUOTA_KEYV_BACKEND=garbage` (invalid): `readKeyvDefaultConfigFromEnv()` throws a zod validation error. | `tests/unit/quota/keyvDefaultConfig.test.ts` new test. |
+| AC-11 | All 3 contract tests from PR #505 still pass: `SqliteQuotaStore`, `KeyvQuotaStoreExtras`, `RedisQuotaStore` all satisfy `QuotaStore`. | `tests/unit/quota/quotaStore.contract.test.ts` (added in PR #505). |
+| AC-12 | Type-drift prevention: contract test continues to enforce — adding a method to `QuotaStore` without implementing it in all 3 drivers should fail `tsc`. | `tsc -p tsconfig.typecheck-core.json` exit 0; force a regression by deleting a method from one driver and re-run — should fail. |
+| AC-13 | `scripts/migrate-quota-storage.ts --apply` copies counter state from sqlite to keyv. Idempotent (re-running does not double-count). | `tests/integration/quota-store-migration.test.ts` new test. |
+| AC-14 | `scripts/migrate-quota-storage.ts` (no `--apply`) is a dry-run. | `tests/integration/quota-store-migration.test.ts` new test. |
+| AC-15 | `.env.example` documents `QUOTA_KEYV_BACKEND` and the new default for `QUOTA_STORE_DRIVER`. | `grep -n QUOTA_KEYV_BACKEND .env.example` returns >1. |
+| AC-16 | Factory emits a single `pino.info` log line at startup with `{ driver, backend, kvUrl }`. | `tests/unit/quota-store-factory.test.ts` new test: assert `pino.info` is called. |
+| AC-17 | `keyvQuotaStore.ts::seed()` method is callable from the migration script but NOT part of the `QuotaStore` interface. | `tests/unit/quota/quotaStore.contract.test.ts` (PR #505) passes; `seed()` is not in the interface. |
+| AC-18 | Singleton behaviour: multiple `getQuotaStore()` calls return the same instance (unchanged). | Reuses existing `quota-store-factory.test.ts` test (line 56). |
+| AC-19 | `resetQuotaStoreSingleton()` resets the singleton (unchanged). | Reuses existing `quota-store-factory.test.ts` test (line 65). |
+| AC-20 | `tests/e2e/quota-store.e2e.ts` extended: new test "sqlite-fallback scenario" verifies that setting `QUOTA_STORE_DRIVER=keyv` with a bogus URI still falls back to sqlite via `pino.warn`. | `tests/e2e/quota-store.e2e.ts` new test. |
+
+Each AC is independently verifiable via the commands in §8.3.
+
+
+---
+
+## 6. Implementation steps
+
+In dependency order (each independently verifiable; commit per step is acceptable for review, but the spec author recommends a single feature commit for atomicity):
+
+1. **Create `src/lib/quota/keyvDefaultConfig.ts`** (new file, ~40 lines).
+   - Per §4.3.2. Zod-validated env reader; `readKeyvDefaultConfigFromEnv()` returns `{ driver, backend, kvUrl }`.
+   - Exports `KeyvBackend`, `QuotaStoreDriver`, `KEYV_DEFAULTS`.
+   - Verify: `tsc -p tsconfig.typecheck-core.json` exit 0.
+
+2. **Add `seed()` method to `src/lib/quota/keyvQuotaStore.ts`** (small add at the bottom of the class, ~10 lines).
+   - Per §4.4. Used only by the migration script.
+   - Document in the method's JSDoc that it is NOT part of the `QuotaStore` interface.
+   - Verify: `tests/unit/quota/keyvQuotaStore.test.ts` still passes.
+
+3. **Edit `src/lib/quota/storeFactory.ts`** (3 hunks, ~15 lines net change).
+   - Line 79: change default from `"sqlite"` to `"keyv"`.
+   - Line 89 (PR-G comment): replace with the new comment from §4.3.1.
+   - Line 99 + keyv branch (lines 100-110): use `readKeyvDefaultConfigFromEnv()` and emit the structured log line.
+   - Verify: `tsc -p tsconfig.typecheck-core.json` exit 0; `tests/unit/quota-store-factory.test.ts` (existing tests) still pass.
+
+4. **Create `scripts/migrate-quota-storage.ts`** (new file, ~70 lines).
+   - Per §4.3.3. Idempotent, dry-run-by-default.
+   - Uses `SqliteQuotaStore.peek` to read source + `KeyvQuotaStore.seed` to write target.
+   - Verify: `tsx scripts/migrate-quota-storage.ts --help` exits 0.
+
+5. **Edit `.env.example`** (2 hunks, ~3 lines).
+   - Per §4.3.4. Document `QUOTA_STORE_DRIVER=keyv` as default; add `QUOTA_KEYV_BACKEND` example.
+   - Verify: `bash -n .env.example` (syntactic check; not strictly necessary since `.env.example` is a `.env` file, but ensure no typo).
+
+6. **Create `tests/unit/quota/keyvDefaultConfig.test.ts`** (new file, ~60 lines).
+   - Tests AC-7, AC-8, AC-9, AC-10.
+   - Verify: `DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/unit/quota/keyvDefaultConfig.test.ts` → all pass.
+
+7. **Extend `tests/unit/quota-store-factory.test.ts`** (new tests appended, ~80 lines).
+   - Tests AC-1, AC-2, AC-3, AC-4, AC-16.
+   - Verify: `DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/quota-store-factory.test.ts` → all pass.
+
+8. **Extend `tests/e2e/quota-store.e2e.ts`** (new test, ~20 lines).
+   - Tests AC-20 (sqlite-fallback scenario).
+   - Verify: `DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/e2e/quota-store.e2e.ts` → all pass.
+
+9. **Create `tests/integration/quota-store-migration.test.ts`** (new file, ~80 lines).
+   - Tests AC-13, AC-14. Sets up a sqlite store with known state, runs the migration script (dry-run + apply), verifies keyv state matches.
+   - Verify: `DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/integration/quota-store-migration.test.ts` → all pass.
+
+10. **Run full acceptance-criteria sweep** (AC-1 through AC-20).
+    - Use the verification commands in §8.3.
+    - All 20 ACs must pass.
+
+11. **Commit + push + open PR** (per §11).
+
+**Estimated diff size:** ~250 lines added (350 spec lines → 250 code lines including tests). Within the 800-line review-friendly default per `code-review-change-size` policy.
+
+
+---
+
+## 7. Risks
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|------|-----------|--------|------------|
+| R-1 | **Existing data not automatically migrated.** Users who have been on sqlite for months with critical counter state will see "0 counters" after upgrading if they were relying on default driver. | High | High | The default change in `storeFactory.ts:79` flips, but a user's `QUOTA_STORE_DRIVER=sqlite` env-pin (or `quotaStore.driver=sqlite` DB setting) keeps them on sqlite. Document in CHANGELOG + release notes. The migration script (§4.3.3) is provided for opt-in data migration. |
+| R-2 | **Memory backend = data lost on restart.** Users setting `QUOTA_KEYV_BACKEND=memory` (e.g. serverless) will lose counter state on every cold start. | Medium | Medium (acceptable for ephemeral counters) | Document this explicitly in the env variable documentation. Counter data is rolling-window; loss on restart means the next request starts at 0. For most quota-sharing workloads this is fine. For compliance data (audit trails, billing), use sqlite backend. |
+| R-3 | **Lockfile conflicts if multiple processes share a keyv+sqlite file.** Two processes opening `keyv://sqlite:/shared/quota.db` will race on the underlying SQLite file (no advisory locks in the upstream `keyv` SQLite adapter). Last-write-wins. | Medium | High (silently corrupted counters) | Document explicitly: "Keyv driver is single-process. For multi-process coordination, use Redis or a shared-sqlite layer with explicit locking." Out of scope for this PR (§10). |
+| R-4 | **`QUOTA_STORE_KEYV_URL` precedence inversion.** The default change from `memory://` to `keyv://sqlite:...` may surprise existing keyv users who relied on `memory://` by default. | Low | Low | Their counters were already ephemeral on `memory://` — they had no persistence. The new default gives them persistence for free. Document in CHANGELOG. |
+| R-5 | **Default sqlite path resolution.** `.agileplus/quota/quota.db` is relative to `process.cwd()`. If the user's `cwd` changes between restarts (e.g. systemd service vs. interactive shell), the keyv sqlite file lands in different locations. | Low | Medium | Use an absolute path resolution helper that anchors to `DATA_DIR` (same pattern as `localDb`). See `src/lib/db/core.ts` for the existing helper. The migration script in §4.3.3 reads `DATA_DIR` from env. |
+| R-6 | **Type drift re-emergence.** The contract test from PR #505 covers the 3 driver implementations of `QuotaStore`, but does not cover the `seed()` method added in this PR (§4.4). If a future PR adds another method without updating the test, drift can re-emerge. | Low | Low | Document the contract test's scope in the test file's header comment. Add a `seed()` reachability test to `tests/unit/quota/keyvQuotaStore.test.ts` (separate from the contract test). |
+| R-7 | **Contract test over-coupling.** If the contract test uses `expectTypeOf` to strictly assert all 6 interface methods, an unrelated method addition (e.g. `getPoolStatus`) on the interface would force all 3 drivers to implement it. | Low | Medium | The contract test asserts interface conformance, not method existence. Adding a method to the interface is a deliberate API change; the test should follow. |
+| R-8 | **Sliding-window divergence.** Keyv's `buckets` map uses a single TTL per `(apiKeyId, dim)`; SqliteQuotaStore uses 2-bucket sliding-window counter. The math differs at window boundaries. | Medium | Medium (counter drift between drivers) | Document the divergence explicitly in `keyvQuotaStore.ts` header. Add a benchmark test that compares the two stores on a synthetic workload; results may differ. The Keyv store is a feature-complete alternative; not a replacement. |
+| R-9 | **Migration script data loss.** If `seed()` is called with the wrong `(apiKeyId, dim)` tuple, the migration script overwrites the target bucket with `0` instead of the source value. | Low | High | Use `seed()` only after reading the source value via `peek()`. Add an invariant check: `if (sourceValue !== undefined) await target.seed(apiKeyId, dim, sourceValue)`. Test in AC-13. |
+| R-10 | **`.env.example` default-order trap.** A user copies `.env.example` to `.env`, sees `QUOTA_STORE_DRIVER=keyv`, and accidentally loses their sqlite data. | Low | Medium | The env file is opt-in (`.env.example` is not auto-loaded). The factory still uses the explicit env var. Document the migration in the CHANGELOG. |
+
+
+---
+
+## 8. Test plan
+
+### 8.1 New tests
+
+| Test file | Coverage | ACs |
+|-----------|----------|-----|
+| `tests/unit/quota/keyvDefaultConfig.test.ts` | Env validation, zod schema, default resolution | AC-7, AC-8, AC-9, AC-10 |
+| `tests/unit/quota-store-factory.test.ts` (extended) | New driver-selection tests, log-line assertion | AC-1, AC-2, AC-3, AC-4, AC-16 |
+| `tests/e2e/quota-store.e2e.ts` (extended) | sqlite-fallback scenario for bogus keyv URI | AC-20 |
+| `tests/integration/quota-store-migration.test.ts` | Migration script dry-run + apply + idempotency | AC-13, AC-14 |
+| `tests/unit/quota/keyvQuotaStore.test.ts` (extended) | `seed()` method reachability + correctness | AC-17 |
+
+### 8.2 Existing tests (must continue to pass)
+
+The following tests are unchanged but must be re-verified after the factory default flips:
+
+- `tests/unit/quota-store-factory.test.ts` (6 tests — singleton, reset, redis fallback, unknown driver).
+- `tests/unit/quota/keyvQuotaStore.test.ts` (6 tests — consume/peek/clear/isolation/dispose).
+- `tests/unit/quota/keyvQuotaStoreExtras.test.ts` (5 tests — dead-code methods relocated by PR #505).
+- `tests/unit/quota/quotaStore.contract.test.ts` (PR #505 contract test — 3 driver implementations satisfy `QuotaStore` interface).
+- `tests/e2e/quota-store.e2e.ts` (8 tests — basic KeyvQuotaStore e2e).
+- `tests/integration/quota-store-settings.test.ts` (DB-backed driver config).
+- `tests/integration/quota-pools-usage.test.ts` (pool usage route).
+- `tests/integration/quota-pool-usage-provider-resolution.test.ts` (provider resolution).
+- `tests/unit/quota-enforce.test.ts` (enforce.ts w/ mocked store).
+- `tests/unit/quota-redis-store.test.ts` (Redis driver unit tests if present).
+
+### 8.3 Verification commands
+
+```bash
+cd /Users/kooshapari/CodeProjects/Phenotype/repos/OmniRoute/.worktrees/governance-cleanup-20260806
+export PATH="/opt/homebrew/bin:$PATH"
+
+# AC-12: typecheck
+node node_modules/typescript/bin/tsc --pretty false -p tsconfig.typecheck-core.json 2>&1 | grep "error TS" | grep -v regional | wc -l  # → 0
+
+# AC-11: contract test (PR #505)
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/unit/quota/quotaStore.contract.test.ts
+
+# AC-6, AC-7, AC-8, AC-9, AC-10: keyvDefaultConfig
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/unit/quota/keyvDefaultConfig.test.ts
+
+# AC-1, AC-2, AC-3, AC-4, AC-16, AC-18, AC-19: factory tests (existing + new)
+DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/quota-store-factory.test.ts
+
+# AC-17, AC-18, AC-19 (PR #505): keyv unit + extras
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/unit/quota/keyvQuotaStore.test.ts tests/unit/quota/keyvQuotaStoreExtras.test.ts
+
+# AC-20: e2e
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/e2e/quota-store.e2e.ts
+
+# AC-13, AC-14: migration
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/integration/quota-store-migration.test.ts
+
+# AC-5: smoke (full suite)
+DISABLE_SQLITE_AUTO_BACKUP=true node node_modules/.bin/vitest run tests/unit/quota tests/integration/quota-store-settings.test.ts tests/integration/quota-pools-usage.test.ts
+```
+
+### 8.4 Smoke test invocation
+
+```bash
+# Manual: confirm factory picks keyv on a clean install
+cd /Users/kooshapari/CodeProjects/Phenotype/repos/OmniRoute/.worktrees/governance-cleanup-20260806
+unset QUOTA_STORE_DRIVER QUOTA_STORE_KEYV_URL QUOTA_KEYV_BACKEND
+DISABLE_SQLITE_AUTO_BACKUP=true node -e '
+  import("./src/lib/quota/storeFactory.ts").then(async (m) => {
+    m.resetQuotaStoreSingleton();
+    const store = await m.getQuotaStore();
+    console.log("store class:", store.constructor.name);
+    console.log("has consume:", typeof store.consume === "function");
+    console.log("has peek:", typeof store.peek === "function");
+  });
+' 2>&1
+```
+
+Expected output: `store class: KeyvQuotaStore` (proves the default flip worked).
+
+
+---
+
+## 9. Open questions (for user resolution)
+
+These questions are flagged for the user before implementation begins. Each has a recommendation; the user may override.
+
+### Q1. Auto-migrate existing sqlite data?
+
+**Recommendation: No.** Users opt-in via the migration script. Silent data movement is hard to audit; the script is idempotent and small.
+
+### Q2. Default backend for keyv?
+
+**Recommendation: `sqlite`** (durable single-process). Quota counters are durable state; ephemeral defaults are hostile to first-run users. `QUOTA_KEYV_BACKEND=memory` is for explicit serverless use.
+
+### Q3. Deprecate the sqlite driver?
+
+**Recommendation: No.** The sqlite driver is feature-correct, supports shared-disk multi-process, and is the reference implementation for the `QuotaStore` interface contract.
+
+### Q4. Bundle migration script in the published package?
+
+**Recommendation: Yes.** Ship as `omniroute migrate-quota-storage` via a `package.json` bin entry. Discoverable; otherwise users hit the script by reading `scripts/`.
+
+### Q5. "Automatic rollback" if keyv default fails to start?
+
+**Recommendation: No.** The current `try/catch` at `storeFactory.ts:103-112` is a separate concern (silent-degradation governance, tracked in PR #505 §10). This PR does NOT change the fallback; it only changes the default driver. If keyv default fails, the existing try/catch falls back to sqlite with a `pino.warn`.
+
+### Q6. Should `QUOTA_STORE_KEYV_URL` default flip from `memory://` to `keyv://sqlite:...` silently?
+
+**Recommendation: Yes.** The default backend is `sqlite`; the default URI should match. Users wanting memory set `QUOTA_KEYV_BACKEND=memory` explicitly. Document in CHANGELOG.
+
+### Q7. Migrate pool / plan metadata in the migration script?
+
+**Recommendation: No.** Only counter state. Pool / plan metadata is rarely large and easy to re-enter via the admin UI. Add a `--migrate-pools` flag in a future PR if demand emerges.
+
+
+---
+
+## 10. Out of scope (deferred)
+
+These items are flagged for follow-up but explicitly NOT in this PR:
+
+- **Silent fallback in `storeFactory.ts:103-112`.** Per PR #505 §10, the try/catch around the keyv driver hides TypeScript compile errors. Should be replaced with a fail-fast at startup. Separate PR (governance cleanup).
+- **Cross-process locking for the keyv+sqlite backend.** Per R-3, two processes sharing the same keyv+sqlite file race. Solutions: file advisory locks (`proper-lockfile`), named semaphores, or a separate shared-sqlite layer. Separate PR.
+- **Redis cluster support.** The redis driver is single-instance today. Cluster support requires `@keyv/redis` or a connection-pool layer. Separate PR.
+- **Auth / billing migration.** Storage persistence concerns are siloed. Quota data uses the `QuotaStore` interface; auth and billing use their own storage. No coordination in this PR.
+- **BucketValue / fromUri / member-set design.** Per `FORGE_WRAPUP.md:97-105`, a previous agent wrote a 363-line breaking rewrite using these primitives. Out of scope; would require data migration.
+- **Performance benchmark suite.** A head-to-head benchmark of `SqliteQuotaStore` vs `KeyvQuotaStore` (memory) vs `KeyvQuotaStore` (sqlite) is deferred. The `benches/` directory exists for this.
+- **Production runtime smoke test.** The Keyv driver is exercised in unit/e2e tests but not in a staging canary. Separate PR for staging canary.
+- **Pool / plan metadata migration.** Q7 §9. Future PR.
+- **Deprecation of `better-sqlite3` dependency.** Even if Keyv becomes the default, `localDb` still uses `better-sqlite3` for other tables (settings, pools, plans). Removing `better-sqlite3` requires a separate migration of those tables to a different backend. Separate PR.
+- **Multi-region failover.** The Redis driver is single-instance. A future PR can add Redis Sentinel / Cluster failover.
+
+---
+
+## 11. Commit + delivery
+
+### 11.1 Commit message
+
+```
+feat(quota): promote Keyv to embedded default driver (PR-G)
+
+Closes the PR-G comment deferred from PR #505. Makes Keyv the
+default QuotaStore driver when QUOTA_STORE_DRIVER is unset; the
+sqlite driver remains an opt-in for users with existing data.
+
+- Add src/lib/quota/keyvDefaultConfig.ts: zod-validated env reader
+  for QUOTA_STORE_DRIVER + QUOTA_KEYV_BACKEND + QUOTA_STORE_KEYV_URL.
+  Defaults to driver=keyv, backend=sqlite, URI=keyv://sqlite:.agileplus/quota/quota.db.
+- Edit src/lib/quota/storeFactory.ts: default driver flips from
+  "sqlite" to "keyv"; default URI flips from "memory://" to a
+  durable sqlite-backed URI; structured pino.info log line at startup.
+- Add seed() method to src/lib/quota/keyvQuotaStore.ts: bypass the
+  additive consume() for one-time migration use; NOT part of the
+  QuotaStore interface contract.
+- Add scripts/migrate-quota-storage.ts: opt-in, idempotent,
+  dry-run-by-default migration script for existing sqlite users.
+- Edit .env.example: document QUOTA_KEYV_BACKEND and the new default
+  for QUOTA_STORE_DRIVER.
+- Tests:
+  - Add tests/unit/quota/keyvDefaultConfig.test.ts (env validation)
+  - Extend tests/unit/quota-store-factory.test.ts (defaults)
+  - Extend tests/e2e/quota-store.e2e.ts (sqlite-fallback scenario)
+  - Add tests/integration/quota-store-migration.test.ts (migration)
+  - Extend tests/unit/quota/keyvQuotaStore.test.ts (seed() reachability)
+
+The contract test from PR #505 (tests/unit/quota/quotaStore.contract.test.ts)
+continues to enforce that all 3 driver implementations satisfy the
+QuotaStore interface — preventing type drift between Sqlite, Keyv,
+and Redis drivers.
+
+Verification:
+- tsc -p tsconfig.typecheck-core.json → 0 errors
+- vitest quotaStore.contract.test.ts → pass
+- vitest keyvDefaultConfig.test.ts → pass
+- node --test quota-store-factory.test.ts → all pass (existing 6 + new 5)
+- vitest keyvQuotaStore.test.ts → 6 existing + 1 new seed() test pass
+- vitest quota-store.e2e.ts → 8 existing + 1 new fallback test pass
+- vitest quota-store-migration.test.ts → dry-run + apply + idempotency pass
+
+Refs: PR #505, PR-G comment, FORGE_WRAPUP.md Tier-5 task 20.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+### 11.2 PR target
+
+- **Source branch:** `feat/keyv-as-embedded-default-20260806`
+- **Target branch:** `origin/agent/migration-version-collision-fix` (current canonical branch, per the task brief)
+- **Worktree:** `repos/OmniRoute/.worktrees/governance-cleanup-20260806`
+
+### 11.3 Delivery sequence
+
+1. **Implement** the spec in the worktree (per §6).
+2. **Run all verification commands** (§8.3). All 20 ACs must pass.
+3. **Commit** as a single feature commit (§11.1).
+4. **Open PR** against `origin/agent/migration-version-collision-fix`. Note: GitHub Actions CI will fail with the billing error (per `AGENTS.md`); do not block on CI green. Verify quality locally.
+5. **Merge via `gh pr merge --admin`** after code review, since CI cannot gate.
+6. **AgilePlus registration** (per the task brief):
+   - `agileplus specify --feature keyv-as-embedded-default --from-file plans/keyv-as-embedded-default-spec.md`
+   - This registers the spec in the AgilePlus DB and creates a feature record.
+7. **Cleanup** the worktree branch after merge (canonical folder returns to `main`).
+
+### 11.4 Review checklist
+
+Before requesting review, verify:
+
+- [ ] All 20 ACs pass.
+- [ ] No `better-sqlite3` import added to keyv code paths.
+- [ ] `seed()` method is documented as NOT part of the `QuotaStore` interface.
+- [ ] Migration script is idempotent (re-running does not double-count).
+- [ ] `.env.example` documents new defaults.
+- [ ] CHANGELOG.md updated with the driver-default flip + migration instructions.
+- [ ] ADR.md updated (or a new ADR added) recording the default-driver decision.
+- [ ] No silent data movement on upgrade (R-1 mitigation).
+
+---
+
+## 12. Cross-project reuse
+
+Per the `PHENOTYPE_SHARED_REUSE_PROTOCOL`, this PR deliberately does NOT extract quota-store logic to a shared package. The driver implementations are tightly coupled to OmniRoute's `localDb` + `better-sqlite3` + `keyv` runtime, and the `QuotaStore` interface is OmniRoute-specific. The keyv quota store pattern is unusual (most apps use Keyv for cache, not authoritative state); reuse would be premature.
+
+Future PRs that may benefit from Phenotype-wide reuse: a generic `ZodEnvConfig<T>` helper in `phenotype-shared/` that consumes the pattern in `keyvDefaultConfig.ts` (env validation + default resolution — duplicated across many config readers in OmniRoute today), and a generic `DriverFactory<P, D, R>` type that the `storeFactory.ts` pattern could be parameterised over. Both out of scope for this PR.
+
+---
+
+## 13. References
+
+- `plans/quota-keystore-type-drift-spec.md` — sibling spec from PR #505.
+- `src/lib/quota/storeFactory.ts:79,89-92,99-110` — current driver-selection logic + PR-G comment.
+- `src/lib/quota/keyvQuotaStore.ts` — Keyv driver (unchanged except for `seed()` add).
+- `src/lib/quota/keyvQuotaStoreExtras.ts` — extension class (PR #505; unchanged).
+- `src/lib/quota/types.ts` — `QuotaStore` interface (SSOT).
+- `src/lib/quota/sqliteQuotaStore.ts` — sqlite driver (unchanged).
+- `src/lib/quota/redisQuotaStore.ts` — redis driver (unchanged).
+- `src/lib/quota/dimensions.ts` — `DimensionKey`, `WINDOW_MS`, `PoolAllocation`, `ProviderPlan`.
+- `tests/unit/quota/quotaStore.contract.test.ts` — contract test (PR #505).
+- `tests/unit/quota-store-factory.test.ts` — factory tests (existing).
+- `tests/unit/quota/keyvQuotaStore.test.ts` — keyv unit tests.
+- `tests/e2e/quota-store.e2e.ts` — keyv e2e tests.
+- `.env.example` — env var documentation.
+- `AGENTS.md` — billing constraint (CI will fail; verify locally).
+- `FORGE_WRAPUP.md` — Tier-5 task 20 (this PR is the home for that task).
+


### PR DESCRIPTION
## **User description**
docs(plans): track 2 governance specs for future implementation

Two deferred-implementation specs are now tracked in version control so the work product is preserved and discoverable.

## Plans added

1. **plans/encryption-failclosed-spec.md** (883 lines) — Hardening `src/lib/db/encryption.ts:144-148` (the silent plaintext fallback when `STORAGE_ENCRYPTION_KEY` is set but crypto fails). Compares 3 design options (throw, mark-broken, startup canary) with detailed tradeoffs. Recommended: **C+A** (startup canary + runtime throw). Registered as AgilePlus feature `encryption-failclosed`.

2. **plans/keyv-as-embedded-default-spec.md** (698 lines) — Promote Keyv from optional driver to embedded default for fresh installs. Includes backwards-compat plan, config migration, and rollout sequence. Registered as AgilePlus feature `keyv-as-embedded-default`.

## Why these are docs-only

These specs intentionally do NOT include code changes. They gate on answering the open questions (spec section 9 for each) before implementation begins:

- **encryption-failclosed:** Q1 (which option A/B/C), Q2 (should silent passthrough be removed entirely), Q6 (does chosen option need a feature flag)
- **keyv-as-embedded-default:** Q1 (auto-migrate existing sqlite data?), Q2 (default backend for the new keyv default?), Q3 (deprecate sqlite driver?)

## Related PRs

- PR #505 (quota keystore type-drift) — referenced by keyv spec
- PR #509 (crypto catches) — referenced by encryption spec
- PR #510 (encryption.ts pino migration) — related to encryption spec

## Style

These match the existing sibling spec (plans/quota-keystore-type-drift-spec.md, ~326 lines from PR #505) in tone and structure: problem statement -> goals -> non-goals -> design -> AC -> implementation steps -> risks -> test plan -> open questions -> out of scope -> commit + delivery.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Track governance specs for encryption hardening and the Keyv quota-store default

### What Changed
- Added a draft specification for preventing plaintext writes when configured encryption fails, while preserving intentional no-key passthrough behavior
- Added a draft specification for making Keyv the default quota-store driver for fresh installs, with durable SQLite-backed storage by default and explicit options for memory, SQLite, and Redis
- Documented migration plans, compatibility expectations, acceptance criteria, risks, tests, and unresolved decisions before implementation begins

### Impact
`✅ Discoverable encryption fail-closed plan`
`✅ Documented quota-store default migration`
`✅ Clearer implementation and rollout decisions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
