### PR TITLE
refactor(db): migrate console.* to pino in src/lib/db/

### DIFF
--- a/src/lib/db/adapters/driverFactory.ts
+++ b/src/lib/db/adapters/driverFactory.ts
@@ -5,6 +5,9 @@ import {
   type NodeSqliteDatabaseLike,
 } from "./nodeSqliteShared";
 import type { SqliteAdapter } from "./types";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("db:driver-factory");
 
 const _require = createRequire(import.meta.url);
 
@@ -87,12 +90,12 @@ export async function openDatabaseAsync(
 ): Promise<SqliteAdapter> {
   const sync = tryOpenSync(filePath, options);
   if (sync) {
-    console.log(`[DB] Driver: ${sync.driver} | file: ${filePath}`);
+    log.info({ driver: sync.driver, filePath }, "Opened SQLite database");
     return sync;
   }
 
-  console.warn("[DB] Synchronous drivers unavailable — falling back to sql.js (WASM)");
+  log.warn("Synchronous drivers unavailable — falling back to sql.js (WASM)");
   const adapter = await preInitSqlJs(filePath);
-  console.log(`[DB] Driver: sql.js | file: ${filePath}`);
+  log.info({ driver: "sql.js", filePath }, "Opened SQLite database");
   return adapter;
 }

--- a/src/lib/db/adapters/sqljsAdapter.ts
+++ b/src/lib/db/adapters/sqljsAdapter.ts
@@ -78,7 +78,7 @@ export async function createSqlJsAdapter(filePath: string): Promise<SqliteAdapte
         try {
           persist();
         } catch (e) {
-          console.error("[sqljsAdapter] save failed:", e);
+          log.error({ err: e }, "save failed");
         }
       }
     }, SAVE_DEBOUNCE_MS);

--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -16,6 +16,7 @@ import {
 } from "./apiKeyUsageLimitFields";
 import { setNoLog } from "../compliance/noLog";
 import { resolveModelAlias } from "@omniroute/open-sse/services/modelDeprecation.ts";
+import { createLogger } from "@/shared/utils/logger";
 import { getSyncedAvailableModelsByConnection, getCustomModels, getModelIsHidden } from "./models";
 import {
   CLAUDE_CODE_PROVIDER_PREFIXES,
@@ -45,6 +46,8 @@ import {
   parseStreamDefaultMode,
 } from "./apiKeys/rowParsers";
 import type { AccessSchedule, RateLimitRule } from "./apiKeys/types";
+
+const log = createLogger("db:api-keys");
 
 // ──────────────── Performance Optimizations ────────────────
 
@@ -349,7 +352,7 @@ function ensureApiKeyColumn(
 ): void {
   if (columnNames.has(column.name)) return;
   db.exec(`ALTER TABLE api_keys ADD COLUMN ${column.definition}`);
-  console.log(`[DB] Added api_keys.${column.name} column`);
+  log.info({ column: column.name }, "Added api_keys column");
 }
 
 // Ensure api_keys extension columns exist (memoized)
@@ -365,7 +368,7 @@ function ensureApiKeysColumns(db: ApiKeysDbLike) {
     _schemaChecked = true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn("[DB] Failed to verify api_keys schema:", message);
+    log.warn({ err: message }, "Failed to verify api_keys schema");
   }
 }
 

--- a/src/lib/db/backup.ts
+++ b/src/lib/db/backup.ts
@@ -13,9 +13,12 @@ import {
   DB_BACKUPS_DIR,
   DATA_DIR,
 } from "./core";
+import { createLogger } from "@/shared/utils/logger";
 import { resetAllDbModuleState } from "./stateReset";
 
 type CountRow = { cnt?: number };
+
+const log = createLogger("db:backup");
 
 // ──────────────── Backup Config ────────────────
 
@@ -364,7 +367,7 @@ export function backupDbFile(reason = "auto") {
 
     const stat = fs.statSync(SQLITE_FILE);
     if (stat.size < 4096) {
-      console.warn(`[DB] Backup SKIPPED — DB too small (${stat.size}B)`);
+      log.warn({ sizeBytes: stat.size }, "Backup SKIPPED — DB too small");
       return null;
     }
 
@@ -388,7 +391,10 @@ export function backupDbFile(reason = "auto") {
         const latestBackup = existingBackups[existingBackups.length - 1];
         const latestStat = fs.statSync(path.join(backupDir, latestBackup));
         if (latestStat.size > 4096 && stat.size < latestStat.size * 0.5) {
-          console.warn(`[DB] Backup SKIPPED — DB shrank from ${latestStat.size}B to ${stat.size}B`);
+          log.warn(
+            { previousSizeBytes: latestStat.size, currentSizeBytes: stat.size },
+            "Backup SKIPPED — DB shrank"
+          );
           return null;
         }
       }
@@ -401,18 +407,18 @@ export function backupDbFile(reason = "auto") {
     const db = getDbInstance();
     db.backup(backupFile)
       .then(() => {
-        console.log(`[DB] Backup created: ${backupFile} (${stat.size} bytes)`);
+        log.info({ backupFile, sizeBytes: stat.size }, "Backup created");
         cleanupDbBackups();
       })
       .catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
-        console.error("[DB] Backup failed:", message);
+        log.error({ err: message }, "Backup failed");
       });
 
     return { filename: path.basename(backupFile), size: stat.size };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error("[DB] Backup failed:", message);
+    log.error({ err: message }, "Backup failed");
     return null;
   }
 }
@@ -580,7 +586,7 @@ export async function restoreDbBackup(backupId: string) {
   const keyCount =
     (db.prepare("SELECT COUNT(*) as cnt FROM api_keys").get() as CountRow | undefined)?.cnt || 0;
 
-  console.log(`[DB] Restored backup: ${backupId} (${connCount} connections)`);
+  log.info({ backupId, connCount }, "Restored backup");
 
   return {
     restored: true,

--- a/src/lib/db/cleanup.ts
+++ b/src/lib/db/cleanup.ts
@@ -8,6 +8,9 @@ import { getDbInstance } from "./core";
 import { getUserDatabaseSettings } from "./databaseSettings";
 import { rollupUsageHistoryBeforeDate } from "@/lib/usage/aggregateHistory";
 import { purgeCallLogArtifactDirectory } from "@/lib/usage/callLogArtifacts";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("db:cleanup");
 
 interface CleanupResult {
   deleted: number;
@@ -38,11 +41,12 @@ export async function cleanupQuotaSnapshots(): Promise<CleanupResult> {
     const runResult = stmt.run(cutoffISO);
     result.deleted = runResult.changes;
 
-    console.log(
-      `[Cleanup] Deleted ${result.deleted} quota_snapshots older than ${retentionDays} days`
+    log.info(
+      { deleted: result.deleted, retentionDays, table: "quota_snapshots" },
+      "Deleted quota_snapshots older than retention period"
     );
   } catch (err: unknown) {
-    console.error("[Cleanup] Error cleaning quota_snapshots:", err);
+    log.error({ err }, "Error cleaning quota_snapshots");
     result.errors++;
   }
 
@@ -68,9 +72,12 @@ export async function cleanupCallLogs(): Promise<CleanupResult> {
     const runResult = stmt.run(cutoffISO);
     result.deleted = runResult.changes;
 
-    console.log(`[Cleanup] Deleted ${result.deleted} call_logs older than ${retentionDays} days`);
+    log.info(
+      { deleted: result.deleted, retentionDays, table: "call_logs" },
+      "Deleted call_logs older than retention period"
+    );
   } catch (err: unknown) {
-    console.error("[Cleanup] Error cleaning call_logs:", err);
+    log.error({ err }, "Error cleaning call_logs");
     result.errors++;
   }
 
@@ -103,8 +110,9 @@ export async function cleanupUsageHistory(): Promise<CleanupResult> {
   // that was never aggregated.
   const rollupResult = await rollupUsageHistoryBeforeDate(cutoffDateStr);
   if (rollupResult.errors > 0) {
-    console.error(
-      "[Cleanup] Aborting usage_history deletion because the pre-delete rollup failed."
+    log.error(
+      { rollupErrors: rollupResult.errors },
+      "Aborting usage_history deletion because the pre-delete rollup failed"
     );
     result.errors += rollupResult.errors;
     return result;
@@ -115,11 +123,12 @@ export async function cleanupUsageHistory(): Promise<CleanupResult> {
     const runResult = stmt.run(cutoffDateStr);
     result.deleted = runResult.changes;
 
-    console.log(
-      `[Cleanup] Deleted ${result.deleted} usage_history older than ${retentionDays} days`
+    log.info(
+      { deleted: result.deleted, retentionDays, table: "usage_history" },
+      "Deleted usage_history older than retention period"
     );
   } catch (err: unknown) {
-    console.error("[Cleanup] Error cleaning usage_history:", err);
+    log.error({ err }, "Error cleaning usage_history");
     result.errors++;
   }
 
@@ -145,11 +154,12 @@ export async function cleanupCompressionAnalytics(): Promise<CleanupResult> {
     const runResult = stmt.run(cutoffISO);
     result.deleted = runResult.changes;
 
-    console.log(
-      `[Cleanup] Deleted ${result.deleted} compression_analytics older than ${retentionDays} days`
+    log.info(
+      { deleted: result.deleted, retentionDays, table: "compression_analytics" },
+      "Deleted compression_analytics older than retention period"
     );
   } catch (err: unknown) {
-    console.error("[Cleanup] Error cleaning compression_analytics:", err);
+    log.error({ err }, "Error cleaning compression_analytics");
     result.errors++;
   }
 
@@ -175,11 +185,12 @@ export async function cleanupMcpAudit(): Promise<CleanupResult> {
     const runResult = stmt.run(cutoffISO);
     result.deleted = runResult.changes;
 
-    console.log(
-      `[Cleanup] Deleted ${result.deleted} mcp_audit_log older than ${retentionDays} days`
+    log.info(
+      { deleted: result.deleted, retentionDays, table: "mcp_audit_log" },
+      "Deleted mcp_audit_log older than retention period"
     );
   } catch (err: unknown) {
-    console.error("[Cleanup] Error cleaning mcp_audit_log:", err);
+    log.error({ err }, "Error cleaning mcp_audit_log");
     result.errors++;
   }
 
@@ -205,9 +216,12 @@ export async function cleanupA2aEvents(): Promise<CleanupResult> {
     const runResult = stmt.run(cutoffISO);
     result.deleted = runResult.changes;
 
-    console.log(`[Cleanup] Deleted ${result.deleted} a2a_events older than ${retentionDays} days`);
+    log.info(
+      { deleted: result.deleted, retentionDays, table: "a2a_events" },
+      "Deleted a2a_events older than retention period"
+    );
   } catch (err: unknown) {
-    console.error("[Cleanup] Error cleaning a2a_events:", err);
+    log.error({ err }, "Error cleaning a2a_events");
     result.errors++;
   }
 
@@ -233,11 +247,12 @@ export async function cleanupMemoryEntries(): Promise<CleanupResult> {
     const runResult = stmt.run(cutoffISO);
     result.deleted = runResult.changes;
 
-    console.log(
-      `[Cleanup] Deleted ${result.deleted} memory_entries older than ${retentionDays} days`
+    log.info(
+      { deleted: result.deleted, retentionDays, table: "memory_entries" },
+      "Deleted memory_entries older than retention period"
     );
   } catch (err: unknown) {
-    console.error("[Cleanup] Error cleaning memory_entries:", err);
+    log.error({ err }, "Error cleaning memory_entries");
     result.errors++;
   }
 
@@ -256,11 +271,11 @@ export async function runAutoCleanup(): Promise<{
   const autoCleanupEnabled = retention.autoCleanupEnabled;
 
   if (!autoCleanupEnabled) {
-    console.log("[Cleanup] Auto-cleanup is disabled");
+    log.info("Auto-cleanup is disabled");
     return { totalDeleted: 0, totalErrors: 0, results: {} };
   }
 
-  console.log("[Cleanup] Starting auto-cleanup...");
+  log.info("Starting auto-cleanup");
 
   const results: Record<string, CleanupResult> = {
     quotaSnapshots: await cleanupQuotaSnapshots(),
@@ -276,7 +291,10 @@ export async function runAutoCleanup(): Promise<{
   const totalDeleted = Object.values(results).reduce((sum, r) => sum + r.deleted, 0);
   const totalErrors = Object.values(results).reduce((sum, r) => sum + r.errors, 0);
 
-  console.log(`[Cleanup] Auto-cleanup complete: ${totalDeleted} deleted, ${totalErrors} errors`);
+  log.info(
+    { totalDeleted, totalErrors },
+    "Auto-cleanup complete"
+  );
 
   return { totalDeleted, totalErrors, results };
 }
@@ -293,9 +311,12 @@ export async function purgeQuotaSnapshots(): Promise<CleanupResult> {
     const runResult = stmt.run();
     result.deleted = runResult.changes;
 
-    console.log(`[Cleanup] Purged ${result.deleted} quota_snapshots`);
+    log.info(
+      { deleted: result.deleted, table: "quota_snapshots" },
+      "Purged quota_snapshots"
+    );
   } catch (err: unknown) {
-    console.error("[Cleanup] Error purging quota_snapshots:", err);
+    log.error({ err }, "Error purging quota_snapshots");
     result.errors++;
   }
 
@@ -313,9 +334,12 @@ export async function purgeCallLogs(): Promise<CleanupResult> {
     const runResult = db.prepare("DELETE FROM call_logs").run();
     result.deleted = runResult.changes;
 
-    console.log(`[Cleanup] Purged ${result.deleted} call_logs`);
+    log.info(
+      { deleted: result.deleted, table: "call_logs" },
+      "Purged call_logs"
+    );
   } catch (err: unknown) {
-    console.error("[Cleanup] Error purging call_logs:", err);
+    log.error({ err }, "Error purging call_logs");
     result.errors++;
   }
 
@@ -324,7 +348,10 @@ export async function purgeCallLogs(): Promise<CleanupResult> {
   result.errors += artifactResult.errors;
 
   if (artifactResult.errors === 0) {
-    console.log(`[Cleanup] Purged ${result.deletedArtifacts} call log artifact(s)`);
+    log.info(
+      { deletedArtifacts: result.deletedArtifacts },
+      "Purged call log artifacts"
+    );
   }
 
   return result;
@@ -342,9 +369,12 @@ export async function purgeDetailedLogs(): Promise<CleanupResult> {
     const runResult = stmt.run();
     result.deleted = runResult.changes;
 
-    console.log(`[Cleanup] Purged ${result.deleted} request_detail_logs`);
+    log.info(
+      { deleted: result.deleted, table: "request_detail_logs" },
+      "Purged request_detail_logs"
+    );
   } catch (err: unknown) {
-    console.error("[Cleanup] Error purging request_detail_logs:", err);
+    log.error({ err }, "Error purging request_detail_logs");
     result.errors++;
   }
 
@@ -371,11 +401,12 @@ export async function cleanupProxyLogs(): Promise<CleanupResult> {
     const runResult = stmt.run(cutoffISO);
     result.deleted = runResult.changes;
 
-    console.log(
-      `[Cleanup] Deleted ${result.deleted} proxy_logs older than ${retentionDays} days`
+    log.info(
+      { deleted: result.deleted, retentionDays, table: "proxy_logs" },
+      "Deleted proxy_logs older than retention period"
     );
   } catch (err: unknown) {
-    console.error("[Cleanup] Error cleaning proxy_logs:", err);
+    log.error({ err }, "Error cleaning proxy_logs");
     result.errors++;
   }
 
@@ -405,19 +436,20 @@ export function startCleanupScheduler(): void {
       const proxyResult = await cleanupProxyLogs();
       const totalDeleted = result.totalDeleted + proxyResult.deleted;
       if (totalDeleted > 0) {
-        console.log(
-          `[Cleanup] Startup cleanup freed ${totalDeleted} rows. Running VACUUM...`
+        log.info(
+          { totalDeleted },
+          "Startup cleanup freed rows. Running VACUUM"
         );
         try {
           const db = getDbInstance();
           db.exec("VACUUM");
-          console.log("[Cleanup] VACUUM completed after startup cleanup.");
+          log.info("VACUUM completed after startup cleanup");
         } catch (vacErr) {
-          console.error("[Cleanup] VACUUM after cleanup failed:", vacErr);
+          log.error({ err: vacErr }, "VACUUM after cleanup failed");
         }
       }
     } catch (err) {
-      console.error("[Cleanup] Startup cleanup failed:", err);
+      log.error({ err }, "Startup cleanup failed");
     }
   }, 30_000);
 
@@ -428,19 +460,20 @@ export function startCleanupScheduler(): void {
       const proxyResult = await cleanupProxyLogs();
       const totalDeleted = result.totalDeleted + proxyResult.deleted;
       if (totalDeleted > 0) {
-        console.log(
-          `[Cleanup] Periodic cleanup freed ${totalDeleted} rows. Running VACUUM...`
+        log.info(
+          { totalDeleted },
+          "Periodic cleanup freed rows. Running VACUUM"
         );
         try {
           const db = getDbInstance();
           db.exec("VACUUM");
-          console.log("[Cleanup] VACUUM completed after periodic cleanup.");
+          log.info("VACUUM completed after periodic cleanup");
         } catch (vacErr) {
-          console.error("[Cleanup] VACUUM after cleanup failed:", vacErr);
+          log.error({ err: vacErr }, "VACUUM after cleanup failed");
         }
       }
     } catch (err) {
-      console.error("[Cleanup] Periodic cleanup failed:", err);
+      log.error({ err }, "Periodic cleanup failed");
     }
   }, CLEANUP_INTERVAL_MS);
 
@@ -449,7 +482,10 @@ export function startCleanupScheduler(): void {
     _cleanupSchedulerTimer.unref();
   }
 
-  console.log("[Cleanup] Background cleanup scheduler started (every 6 hours).");
+  log.info(
+    { intervalMs: CLEANUP_INTERVAL_MS },
+    "Background cleanup scheduler started"
+  );
 }
 
 /**

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -14,6 +14,7 @@ import {
 import path from "path";
 import fs from "fs";
 import { resolveWritableDataDir, getLegacyDotDataDir } from "../dataPaths";
+import { createLogger } from "@/shared/utils/logger";
 import { runMigrations } from "./migrationRunner";
 import { runDbHealthCheck } from "./healthCheck";
 import { resetAllDbModuleState } from "./stateReset";
@@ -69,6 +70,8 @@ type PreservedCriticalDbState = {
   preservedTables: PreservedTableSnapshot[];
   skippedTables: SkippedTableSnapshot[];
 };
+
+const log = createLogger("db:core");
 type CriticalTableSpec = {
   table: string;
   maxRows?: number;
@@ -176,10 +179,13 @@ if (!isCloud && !fs.existsSync(DATA_DIR)) {
     fs.mkdirSync(DATA_DIR, { recursive: true });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.warn(
-      `[DB] Cannot create data directory '${DATA_DIR}': ${msg}\n` +
-        `[DB] Set the DATA_DIR environment variable to a writable path, e.g.:\n` +
-        `[DB]   DATA_DIR=/path/to/writable/dir omniroute`
+    log.warn(
+      {
+        dataDir: DATA_DIR,
+        err: msg,
+        hint: "Set the DATA_DIR environment variable to a writable path, e.g.: DATA_DIR=/path/to/writable/dir omniroute",
+      },
+      "Cannot create data directory"
     );
   }
 }
@@ -766,8 +772,9 @@ function offloadLegacyCallLogDetails(db: SqliteDatabase) {
   tx();
 
   if (failed > 0) {
-    console.warn(
-      `[DB] Kept call_logs_v1_legacy after partial call log offload (${failed} failed row(s)).`
+    log.warn(
+      { failedRows: failed },
+      "Kept call_logs_v1_legacy after partial call log offload"
     );
     return;
   }
@@ -776,10 +783,13 @@ function offloadLegacyCallLogDetails(db: SqliteDatabase) {
   try {
     db.pragma("wal_checkpoint(TRUNCATE)");
     db.exec("VACUUM");
-    console.log(`[DB] Offloaded ${pendingRows.length} legacy call log detail row(s) to artifacts.`);
+    log.info(
+      { offloadedRows: pendingRows.length },
+      "Offloaded legacy call log detail rows to artifacts"
+    );
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn("[DB] Legacy call log compaction finished without VACUUM:", message);
+    log.warn({ err: message }, "Legacy call log compaction finished without VACUUM");
   }
 }
 
@@ -812,11 +822,11 @@ function createManagedDbBackup(db: SqliteDatabase, reason: string): boolean {
     const escapedBackupPath = backupPath.replace(/'/g, "''");
 
     db.exec(`VACUUM INTO '${escapedBackupPath}'`);
-    console.log(`[DB] Backup created (${reason}): ${backupPath}`);
+    log.info({ reason, backupPath }, "Backup created");
     return true;
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[DB] Failed to create ${reason} backup:`, message);
+    log.warn({ err: message, reason }, "Failed to create backup");
     return false;
   }
 }
@@ -868,7 +878,10 @@ function autoMigrateLegacyEncryptedConnections(db: SqliteDatabase): number {
 
   if (migratedCount > 0) {
     invalidateDbCache("connections");
-    console.log(`[DB] Auto-migrated ${migratedCount} connection(s) to new static-salt encryption.`);
+    log.info(
+      { migratedCount },
+      "Auto-migrated connections to new static-salt encryption"
+    );
   }
 
   return migratedCount;
@@ -912,7 +925,7 @@ function startDbHealthCheckScheduler(db: SqliteDatabase) {
       });
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      console.warn("[DB] Periodic health-check failed:", message);
+      log.warn({ err: message }, "Periodic health-check failed");
     }
   }, intervalMs);
   dbHealthCheckTimer.unref?.();
@@ -933,7 +946,7 @@ export function getDbInstance(): SqliteDatabase {
 
   if (isCloud || isBuildPhase) {
     if (isBuildPhase) {
-      console.log("[DB] Build phase detected — using in-memory SQLite (read-only)");
+      log.info("Build phase detected — using in-memory SQLite (read-only)");
     }
     const memoryDb = openSqliteDatabase(":memory:");
     memoryDb.pragma("journal_mode = WAL");
@@ -955,8 +968,9 @@ export function getDbInstance(): SqliteDatabase {
     const latestBackup = probeFailureBackups[0];
     try {
       fs.renameSync(latestBackup, sqliteFile);
-      console.log(
-        `[DB] Auto-restored preserved database from previous probe failure: ${path.basename(latestBackup)}`
+      log.info(
+        { preservedBackup: path.basename(latestBackup) },
+        "Auto-restored preserved database from previous probe failure"
       );
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -1005,8 +1019,8 @@ export function getDbInstance(): SqliteDatabase {
         probe.close();
 
         if (hasData) {
-          console.log(
-            `[DB] Old schema_migrations table found but data exists — preserving data (#146)`
+          log.info(
+            "Old schema_migrations table found but data exists — preserving data (#146)"
           );
           const fixDb = openSqliteDatabase(sqliteFile);
           try {
@@ -1014,14 +1028,15 @@ export function getDbInstance(): SqliteDatabase {
             fixDb.pragma("wal_checkpoint(TRUNCATE)");
           } catch (e: unknown) {
             const message = e instanceof Error ? e.message : String(e);
-            console.warn("[DB] Could not clean up old schema table:", message);
+            log.warn({ err: message }, "Could not clean up old schema table");
           } finally {
             fixDb.close();
           }
         } else {
           const oldPath = sqliteFile + ".old-schema";
-          console.log(
-            `[DB] Old incompatible schema detected (empty) — renaming to ${path.basename(oldPath)}`
+          log.info(
+            { renamedTo: path.basename(oldPath) },
+            "Old incompatible schema detected (empty) — renaming"
           );
           fs.renameSync(sqliteFile, oldPath);
           for (const ext of ["-wal", "-shm"]) {
@@ -1037,7 +1052,7 @@ export function getDbInstance(): SqliteDatabase {
       }
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
-      console.warn("[DB] Could not probe existing DB:", message);
+      log.warn({ err: message }, "Could not probe existing DB");
 
       // If the error is a Node module/ABI failure, throw it immediately to avoid renaming the database
       if (
@@ -1054,7 +1069,7 @@ export function getDbInstance(): SqliteDatabase {
       const failedPath = sqliteFile + `.probe-failed-${Date.now()}`;
       try {
         fs.renameSync(sqliteFile, failedPath);
-        console.warn(`[DB] Renamed corrupt DB to ${path.basename(failedPath)}`);
+        log.warn({ renamedTo: path.basename(failedPath) }, "Renamed corrupt DB");
         failedProbePath = failedPath;
         failedProbeMessage = message;
       } catch {
@@ -1121,10 +1136,9 @@ export function getDbInstance(): SqliteDatabase {
   if (failedProbePath && preservedCriticalState.preservedTables.length > 0) {
     try {
       const restoredTables = restoreCriticalDbState(db, preservedCriticalState);
-      console.log(
-        `[DB] Restored preserved critical DB state after probe failure: ${summarizePreservedTables(
-          restoredTables
-        )}`
+      log.info(
+        { restored: summarizePreservedTables(restoredTables) },
+        "Restored preserved critical DB state after probe failure"
       );
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
@@ -1150,7 +1164,7 @@ export function getDbInstance(): SqliteDatabase {
   if (shouldRunStartupDbHealthCheck()) {
     const skipIntegrityCheck = process.env.OMNIROUTE_SKIP_DB_HEALTHCHECK === "1";
     if (skipIntegrityCheck) {
-      console.log("[DB] Health check skipped (OMNIROUTE_SKIP_DB_HEALTHCHECK=1)");
+      log.info("Health check skipped (OMNIROUTE_SKIP_DB_HEALTHCHECK=1)");
     }
     runDbHealthCheck(db, {
       autoRepair: true,
@@ -1167,7 +1181,7 @@ export function getDbInstance(): SqliteDatabase {
     autoMigrateLegacyEncryptedConnections(db);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(`[DB] Legacy encryption migration failed: ${message}`);
+    log.error({ err: message }, "Legacy encryption migration failed");
   }
 
   startDbHealthCheckScheduler(db);
@@ -1175,9 +1189,12 @@ export function getDbInstance(): SqliteDatabase {
   // multi-replica / Docker volume-topology mismatch (each replica opening a
   // different on-disk DB → "phantom"/missing combos & connections) is
   // diagnosable straight from the logs. (#3147)
-  console.log(
-    `[DB] SQLite database ready: ${sqliteFile} ` +
-      `(DATA_DIR=${path.resolve(DATA_DIR)}, SQLITE_FILE=${path.resolve(sqliteFile)})`
+  log.info(
+    {
+      sqliteFile,
+      dataDir: path.resolve(DATA_DIR),
+    },
+    "SQLite database ready"
   );
   return db;
 }
@@ -1207,11 +1224,11 @@ export function closeDbInstance(options?: { checkpointMode?: CheckpointMode | nu
     if (checkpointMode) {
       try {
         if (checkpointDb(db, checkpointMode)) {
-          console.log(`[DB] SQLite WAL checkpoint completed (${checkpointMode}).`);
+          log.info({ checkpointMode }, "SQLite WAL checkpoint completed");
         }
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
-        console.warn(`[DB] WAL checkpoint failed during close (${checkpointMode}):`, message);
+        log.warn({ err: message, checkpointMode }, "WAL checkpoint failed during close");
       }
     }
   } finally {
@@ -1280,7 +1297,7 @@ export async function ensureDbInitialized(): Promise<void> {
   }
 
   // No synchronous driver available — pre-initialize sql.js (WASM, async)
-  console.warn("[DB] Pre-initializing sql.js WASM (synchronous drivers unavailable)...");
+  log.warn("Pre-initializing sql.js WASM (synchronous drivers unavailable)");
   await preInitSqlJs(SQLITE_FILE);
   // Agora getSqlJsAdapter() retornará o adapter, e getDbInstance() vai usá-lo
   getDbInstance();
@@ -1298,13 +1315,14 @@ function migrateFromJson(db: SqliteDatabase, jsonPath: string) {
     const keyCount = (data.apiKeys || []).length;
 
     if (connCount === 0 && nodeCount === 0 && keyCount === 0) {
-      console.log("[DB] db.json has no data to migrate, skipping");
+      log.info("db.json has no data to migrate, skipping");
       fs.renameSync(jsonPath, jsonPath + ".empty");
       return;
     }
 
-    console.log(
-      `[DB] Migrating db.json → SQLite (${connCount} connections, ${nodeCount} nodes, ${keyCount} keys)...`
+    log.info(
+      { connCount, nodeCount, keyCount },
+      "Migrating db.json → SQLite"
     );
 
     const migrate = db.transaction(() => {
@@ -1463,19 +1481,24 @@ function migrateFromJson(db: SqliteDatabase, jsonPath: string) {
 
     const migratedPath = jsonPath + ".migrated";
     fs.renameSync(jsonPath, migratedPath);
-    console.log(`[DB] ✓ Migration complete. Original saved as ${migratedPath}`);
+    log.info({ migratedPath }, "Migration from db.json complete");
 
     const legacyBackupDir = path.join(DATA_DIR, "db_backups");
     if (fs.existsSync(legacyBackupDir)) {
       const jsonBackups = fs.readdirSync(legacyBackupDir).filter((f) => f.endsWith(".json"));
       if (jsonBackups.length > 0) {
-        console.log(
-          `[DB] Note: ${jsonBackups.length} legacy .json backups remain in ${legacyBackupDir}`
+        log.info(
+          { legacyJsonBackups: jsonBackups.length, legacyBackupDir },
+          "Legacy .json backups remain in db_backups"
         );
       }
     }
   } catch (err) {
-    console.error("[DB] Migration from db.json failed:", err.message);
+    // Preserved console.error here: tests/unit/db-core-migration.test.ts asserts
+    // that a corrupted db.json surfaces a console.error so the failure is visible
+    // in CI logs without depending on pino transport being attached.
+    console.error("[DB] Migration from db.json failed:", (err as Error)?.message ?? String(err));
+    log.error({ err: (err as Error)?.message ?? String(err) }, "Migration from db.json failed");
   }
 }
 
@@ -1498,14 +1521,14 @@ export function runManualVacuum(): { success: boolean; duration: number; error?:
   const startTime = Date.now();
 
   try {
-    console.log("[DB] Starting manual VACUUM...");
+    log.info("Starting manual VACUUM");
     db.exec("VACUUM");
     const duration = Date.now() - startTime;
-    console.log(`[DB] Manual VACUUM completed in ${duration}ms`);
+    log.info({ durationMs: duration }, "Manual VACUUM completed");
     return { success: true, duration };
   } catch (err: unknown) {
     const duration = Date.now() - startTime;
-    console.error("[DB] Manual VACUUM failed:", err);
+    log.error({ err, durationMs: duration }, "Manual VACUUM failed");
     const message = err instanceof Error ? err.message : String(err);
     return { success: false, duration, error: message };
   }

--- a/src/lib/db/migrationRunner.ts
+++ b/src/lib/db/migrationRunner.ts
@@ -19,6 +19,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import type { SqliteAdapter } from "./adapters/types";
 import { DEFAULT_DATABASE_SETTINGS } from "@/types/databaseSettings";
+import { createLogger } from "@/shared/utils/logger";
 import {
   RENAMED_MIGRATION_COMPATIBILITY,
   LEGACY_VERSION_SLOT_MIGRATIONS,
@@ -28,19 +29,7 @@ import {
   OPTIONAL_FTS5_MIGRATION_VERSIONS,
 } from "./migrationRunner/constants";
 
-const isNodeTestRunnerChild = typeof process.env.NODE_TEST_CONTEXT === "string";
-
-const console = {
-  log: (...args: unknown[]) => {
-    if (!isNodeTestRunnerChild) globalThis.console.log(...args);
-  },
-  warn: (...args: unknown[]) => {
-    if (!isNodeTestRunnerChild) globalThis.console.warn(...args);
-  },
-  error: (...args: unknown[]) => {
-    globalThis.console.error(...args);
-  },
-};
+const log = createLogger("db:migration-runner");
 
 /**
  * Resolve the migrations directory path safely across platforms.
@@ -264,9 +253,14 @@ function filterSupersededDuplicateMigrations(
       return true;
     }
 
-    console.warn(
-      `[Migration] Ignoring superseded duplicate migration ${file.version}_${file.name}; ` +
-        `${superseded.supersededByVersion}_${superseded.supersededByName} is the canonical slot.`
+    log.warn(
+      {
+        supersededVersion: file.version,
+        supersededName: file.name,
+        canonicalVersion: superseded.supersededByVersion,
+        canonicalName: superseded.supersededByName,
+      },
+      "Ignoring superseded duplicate migration"
     );
     return false;
   });
@@ -720,9 +714,14 @@ function reconcileRenumberedMigrations(
 
     applyRepair();
     repaired = true;
-    console.warn(
-      `[Migration] Reconciled renamed migration ${compatibility.fromVersion}_${compatibility.fromName} ` +
-        `to ${compatibility.toVersion}_${compatibility.toName} to preserve pending migrations.`
+    log.warn(
+      {
+        fromVersion: compatibility.fromVersion,
+        fromName: compatibility.fromName,
+        toVersion: compatibility.toVersion,
+        toName: compatibility.toName,
+      },
+      "Reconciled renamed migration to preserve pending migrations"
     );
 
     // After the compat rewrite, verify the old version slot is now free.
@@ -734,10 +733,12 @@ function reconcileRenumberedMigrations(
       .prepare("SELECT version, name FROM _omniroute_migrations WHERE version = ?")
       .get(compatibility.fromVersion) as { version: string; name: string } | undefined;
     if (residualRow) {
-      console.warn(
-        `[Migration] ⚠️  Residual row at version ${compatibility.fromVersion} ` +
-          `(name: "${residualRow.name}") still present after compat rewrite — ` +
-          `removing to unblock new migration at this version slot.`
+      log.warn(
+        {
+          version: compatibility.fromVersion,
+          residualName: residualRow.name,
+        },
+        "Residual row at version still present after compat rewrite — removing to unblock new migration at this version slot"
       );
       db.prepare("DELETE FROM _omniroute_migrations WHERE version = ?").run(
         compatibility.fromVersion
@@ -791,9 +792,14 @@ function rehomeLegacyVersionSlotMigrations(
 
     applyRepair();
     repaired = true;
-    console.warn(
-      `[Migration] Rehomed legacy migration ${legacy.version}_${legacy.name} ` +
-        `to ${legacyVersion} so current ${legacy.version}_${diskName} can apply.`
+    log.warn(
+      {
+        version: legacy.version,
+        legacyName: legacy.name,
+        rehomedVersion: legacyVersion,
+        currentName: diskName,
+      },
+      "Rehomed legacy migration so current slot can apply"
     );
   }
 
@@ -819,11 +825,11 @@ function createPreMigrationBackup(db: SqliteAdapter): string | null {
     const escapedBackupPath = backupPath.replace(/'/g, "''");
 
     db.exec(`VACUUM INTO '${escapedBackupPath}'`);
-    console.log(`[Migration] Pre-migration backup created: ${backupPath}`);
+    log.info({ backupPath }, "Pre-migration backup created");
     return backupPath;
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.warn(`[Migration] Failed to create pre-migration backup: ${message}`);
+    log.warn({ err: message }, "Failed to create pre-migration backup");
     return null;
   }
 }
@@ -850,21 +856,15 @@ export function runMigrations(db: SqliteAdapter, options?: { isNewDb?: boolean }
   // ── Safety Check 1: Detect migration name mismatches (renumbering) ──
   const mismatches = detectNameMismatches(appliedRecords, files);
   if (mismatches.length > 0) {
-    console.error(
-      `[Migration] ⚠️  CRITICAL: ${mismatches.length} migration version(s) have been renumbered!`
+    log.error(
+      { count: mismatches.length, mismatches },
+      "CRITICAL: migration version(s) have been renumbered"
     );
-    for (const m of mismatches) {
-      console.error(
-        `  Version ${m.version}: applied as "${m.appliedName}" but disk has "${m.diskName}"`
-      );
-    }
-    console.error(
-      `[Migration] This indicates migrations were renumbered between releases, ` +
-        `which can cause the migration runner to skip or re-run migrations incorrectly.`
-    );
-    console.error(
-      `[Migration] The version-only tracking will skip these (version already applied), ` +
-        `but please report this to the OmniRoute maintainers.`
+    log.error(
+      {
+        hint: "version-only tracking will skip these (version already applied)",
+      },
+      "Please report renumbered migrations to OmniRoute maintainers"
     );
   }
 
@@ -879,10 +879,13 @@ export function runMigrations(db: SqliteAdapter, options?: { isNewDb?: boolean }
   const pending = files.filter((f) => {
     const isMissing = !applied.has(f.version);
     if (isMissing && Number(f.version) < highestApplied) {
-      console.warn(
-        `[Migration] 🔄 RECONCILIATION: Found missing intermediate migration ` +
-          `${f.version}_${f.name} (highest applied is ${highestApplied}). ` +
-          `This gap will be back-filled to ensure schema integrity.`
+      log.warn(
+        {
+          missingVersion: f.version,
+          missingName: f.name,
+          highestApplied,
+        },
+        "RECONCILIATION: Found missing intermediate migration — back-filling to ensure schema integrity"
       );
     }
     return isMissing;
@@ -902,9 +905,9 @@ export function runMigrations(db: SqliteAdapter, options?: { isNewDb?: boolean }
     const summary = deferredUnsupported
       .map((migration) => `${migration.version}_${migration.name}`)
       .join(", ");
-    console.warn(
-      `[Migration] Deferring optional FTS5 migrations on driver ${db.driver}: ${summary}. ` +
-        `Memory search will fall back until a SQLite driver with FTS5 support is available.`
+    log.warn(
+      { driver: db.driver, deferred: summary },
+      "Deferring optional FTS5 migrations on driver — memory search will fall back"
     );
   }
 
@@ -934,10 +937,13 @@ export function runMigrations(db: SqliteAdapter, options?: { isNewDb?: boolean }
       : null;
 
     if (plausiblePendingCount !== null && actionablePending.length <= plausiblePendingCount) {
-      console.warn(
-        `[Migration] Allowing ${actionablePending.length} pending migrations on an existing database ` +
-          `because the physical schema only proves ${physicalBaseline?.version} ` +
-          `(${physicalBaseline?.description}).`
+      log.warn(
+        {
+          pendingCount: actionablePending.length,
+          baselineVersion: physicalBaseline?.version,
+          baselineDescription: physicalBaseline?.description,
+        },
+        "Allowing pending migrations on existing database based on physical schema baseline"
       );
     } else {
       const schemaHint =
@@ -952,7 +958,14 @@ export function runMigrations(db: SqliteAdapter, options?: { isNewDb?: boolean }
         `This usually means the migration tracking table was accidentally wiped. ` +
         `Running all migrations from scratch will cause data loss or schema errors.` +
         schemaHint;
-      console.error(msg);
+      log.error(
+        {
+          pendingCount: actionablePending.length,
+          threshold: maxPendingMigrations,
+          physicalBaselineVersion: physicalBaseline?.version,
+        },
+        "ABORT: too many pending migrations on existing database"
+      );
       throw new Error(msg);
     }
   }
@@ -973,8 +986,9 @@ export function runMigrations(db: SqliteAdapter, options?: { isNewDb?: boolean }
 
     const applyMigration = db.transaction(() => {
       if (isSchemaAlreadyApplied(db, migration)) {
-        console.warn(
-          `[Migration] Skipped executing ${migration.version}_${migration.name} as schema changes are already present (Idempotency check).`
+        log.warn(
+          { version: migration.version, name: migration.name },
+          "Skipped executing migration as schema changes are already present (Idempotency check)"
         );
       } else if (migration.version === "032") {
         applyApiKeyLifecycleMigration(db);
@@ -995,7 +1009,10 @@ export function runMigrations(db: SqliteAdapter, options?: { isNewDb?: boolean }
     try {
       applyMigration();
       count++;
-      console.log(`[Migration] Applied: ${migration.version}_${migration.name}`);
+      log.info(
+        { version: migration.version, name: migration.name },
+        "Applied migration"
+      );
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       // "duplicate column name" means the column already exists — end state achieved, mark applied.
@@ -1007,18 +1024,22 @@ export function runMigrations(db: SqliteAdapter, options?: { isNewDb?: boolean }
         });
         applyMarkerOnly();
         count++;
-        console.log(
-          `[Migration] Applied (column pre-exists): ${migration.version}_${migration.name}`
+        log.info(
+          { version: migration.version, name: migration.name },
+          "Applied migration (column pre-exists)"
         );
       } else {
-        console.error(`[Migration] FAILED: ${migration.version}_${migration.name} — ${message}`);
+        log.error(
+          { err: message, version: migration.version, name: migration.name },
+          "Migration FAILED"
+        );
         throw err; // Re-throw to prevent DB from starting in inconsistent state
       }
     }
   }
 
   if (count > 0) {
-    console.log(`[Migration] ${count} migration(s) applied successfully.`);
+    log.info({ count }, "Migrations applied successfully");
   }
 
   // After applying all migrations, insert default settings if we just ran migration 46
@@ -1027,7 +1048,7 @@ export function runMigrations(db: SqliteAdapter, options?: { isNewDb?: boolean }
       insertDefaultDatabaseSettings(db);
     }
   } catch (error) {
-    console.error("Error inserting default database settings:", error);
+    log.error({ err: error }, "Error inserting default database settings");
   }
 
   return count;
@@ -1053,7 +1074,7 @@ function insertDefaultDatabaseSettings(db: SqliteAdapter) {
       tx();
     });
   } catch (error) {
-    console.error("Transaction error inserting default settings:", error);
+    log.error({ err: error }, "Transaction error inserting default settings");
     throw error;
   }
 }

--- a/src/lib/db/models.ts
+++ b/src/lib/db/models.ts
@@ -39,6 +39,9 @@ export {
   deleteModelAliasesForProvider,
 } from "./models/aliases";
 export { getMitmAlias, setMitmAliasAll } from "./models/mitmAlias";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("db:models");
 
 // ──────────────── Custom Models ────────────────
 
@@ -504,7 +507,7 @@ export async function removeSyncedAvailableModel(
       try {
         parsedModels = JSON.parse(value);
       } catch (error) {
-        console.warn(`[DB] Skipping malformed syncedAvailableModels entry for key ${key}:`, error);
+        log.warn({ err: error, key }, "Skipping malformed syncedAvailableModels entry");
         continue;
       }
 

--- a/src/lib/db/optimizationSettings.ts
+++ b/src/lib/db/optimizationSettings.ts
@@ -1,10 +1,13 @@
 import { DEFAULT_DATABASE_SETTINGS, type DatabaseSettings } from "@/types/databaseSettings";
 
 import type { SqliteAdapter } from "./adapters/types";
+import { createLogger } from "@/shared/utils/logger";
 
 type SqliteDatabase = SqliteAdapter;
 type DatabaseOptimizationSettings = DatabaseSettings["optimization"];
 type AutoVacuumMode = DatabaseOptimizationSettings["autoVacuumMode"];
+
+const log = createLogger("db:optimization");
 
 const AUTO_VACUUM_MODE_TO_PRAGMA: Record<AutoVacuumMode, number> = {
   NONE: 0,
@@ -139,7 +142,7 @@ function readDatabaseOptimizationSettings(db: SqliteDatabase): DatabaseOptimizat
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[DB] Failed to read database optimization settings; using defaults: ${message}`);
+    log.warn({ err: message }, "Failed to read database optimization settings; using defaults");
   }
 
   return settings;
@@ -151,12 +154,16 @@ export function setCacheSizeForDb(db: SqliteDatabase, cacheSizeKb: number): void
   const targetCacheSize = -normalizedCacheSizeKb;
 
   if (currentCacheSize === targetCacheSize) {
-    console.log(`[DB] cache_size already set to ${normalizedCacheSizeKb}KB`);
+    log.info({ cacheSizeKb: normalizedCacheSizeKb }, "cache_size already set");
     return;
   }
 
-  console.log(
-    `[DB] Changing cache_size from ${Math.abs(currentCacheSize)}KB to ${normalizedCacheSizeKb}KB`
+  log.info(
+    {
+      fromKb: Math.abs(currentCacheSize),
+      toKb: normalizedCacheSizeKb,
+    },
+    "Changing cache_size"
   );
   db.pragma(`cache_size = ${targetCacheSize}`);
 
@@ -166,7 +173,7 @@ export function setCacheSizeForDb(db: SqliteDatabase, cacheSizeKb: number): void
       `cache_size change did not take effect (expected ${targetCacheSize}, got ${newCacheSize})`
     );
   }
-  console.log(`[DB] cache_size changed to ${Math.abs(newCacheSize)}KB`);
+  log.info({ cacheSizeKb: Math.abs(newCacheSize) }, "cache_size changed");
 }
 
 function applyPersistentOptimizationPragmas(
@@ -188,10 +195,12 @@ function applyPersistentOptimizationPragmas(
   ).toUpperCase();
   const shouldRestoreWal = originalJournalMode === "WAL";
 
-  console.log(
-    `[DB] Applying persistent optimization settings ` +
-      `(auto_vacuum ${currentAutoVacuum}->${targetAutoVacuum}, ` +
-      `page_size ${currentPageSize}->${targetPageSize})`
+  log.info(
+    {
+      autoVacuum: { from: currentAutoVacuum, to: targetAutoVacuum },
+      pageSize: { from: currentPageSize, to: targetPageSize },
+    },
+    "Applying persistent optimization settings"
   );
 
   try {
@@ -205,7 +214,7 @@ function applyPersistentOptimizationPragmas(
         db.pragma("journal_mode = WAL");
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        console.warn(`[DB] Failed to restore WAL mode after optimization settings: ${message}`);
+        log.warn({ err: message }, "Failed to restore WAL mode after optimization settings");
       }
     }
   }
@@ -248,7 +257,7 @@ export function setAutoVacuumForDb(db: SqliteDatabase, mode: AutoVacuumMode): vo
   const targetMode = AUTO_VACUUM_MODE_TO_PRAGMA[mode];
 
   if (currentMode === targetMode) {
-    console.log(`[DB] auto_vacuum already set to ${mode}`);
+    log.info({ mode }, "auto_vacuum already set");
     return;
   }
 
@@ -272,7 +281,7 @@ export function setPageSizeForDb(db: SqliteDatabase, pageSize: number): void {
   );
 
   if (currentPageSize === targetPageSize) {
-    console.log(`[DB] page_size already set to ${targetPageSize}`);
+    log.info({ pageSize: targetPageSize }, "page_size already set");
     return;
   }
 

--- a/src/lib/db/providers.ts
+++ b/src/lib/db/providers.ts
@@ -13,6 +13,9 @@ import {
 import { invalidateDbCache } from "./readCache";
 import { normalizeProviderSpecificData } from "@/lib/providers/requestDefaults";
 import { bumpProxyConfigGeneration } from "./settings";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("db:providers");
 import { webSessionCredentialKey, parseProviderSpecificData } from "./webSessionDedup";
 import {
   withNullableMaxConcurrent,
@@ -712,7 +715,7 @@ export function autoMigrateLegacyEncryptedConnections(): number {
   if (migratedCount > 0) {
     backupDbFile("pre-write");
     invalidateDbCache("connections");
-    console.log(`[DB] Auto-migrated ${migratedCount} connection(s) to new static-salt encryption.`);
+    log.info({ migratedCount }, "Auto-migrated connections to new static-salt encryption");
   }
 
   return migratedCount;

--- a/src/lib/db/quotaPools.ts
+++ b/src/lib/db/quotaPools.ts
@@ -9,6 +9,10 @@
  */
 
 import { getDbInstance } from "./core";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("db:quota-pools");
+
 // Phase B2: auto-mint/prune quotaShared-* combos when pool allocations change.
 // Imported lazily (dynamic import in the hook) to avoid circular-dependency
 // risk between db/ and quota/ modules. The import is fire-and-forget; combo
@@ -19,7 +23,10 @@ async function syncQuotaCombosGuarded(poolId: string): Promise<void> {
     await syncQuotaCombos(poolId);
   } catch (err) {
     // Guard: combo-sync failure must never break pool CRUD callers.
-    console.warn("[quota-pools] syncQuotaCombos failed (non-fatal):", (err as Error)?.message);
+    log.warn(
+      { err, poolId },
+      "syncQuotaCombos failed (non-fatal)"
+    );
   }
 }
 
@@ -28,9 +35,9 @@ async function removeQuotaCombosGuarded(poolId: string): Promise<void> {
     const { removeQuotaCombosForPool } = await import("@/lib/quota/quotaCombos");
     await removeQuotaCombosForPool(poolId);
   } catch (err) {
-    console.warn(
-      "[quota-pools] removeQuotaCombosForPool failed (non-fatal):",
-      (err as Error)?.message
+    log.warn(
+      { err, poolId },
+      "removeQuotaCombosForPool failed (non-fatal)"
     );
   }
 }

--- a/src/lib/db/quotaSnapshots.ts
+++ b/src/lib/db/quotaSnapshots.ts
@@ -1,5 +1,6 @@
 import { getDbInstance, rowToCamel } from "./core";
 import type { QuotaSnapshotRow, ProviderUtilizationPoint } from "@/shared/types/utilization";
+import { createLogger } from "@/shared/utils/logger";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -12,6 +13,8 @@ interface StatementLike<TRow = unknown> {
 interface DbLike {
   prepare: <TRow = unknown>(sql: string) => StatementLike<TRow>;
 }
+
+const log = createLogger("db:quota-snapshots");
 
 let lastCleanupAt = 0;
 
@@ -38,9 +41,7 @@ export function saveQuotaSnapshot(snapshot: Omit<QuotaSnapshotRow, "id" | "creat
     );
   } catch (err: any) {
     if (err?.message?.includes("no such table")) {
-      console.warn(
-        "[QuotaSnapshots] Skipping save: quota_snapshots table not found. Awaiting migration."
-      );
+      log.warn("Skipping save: quota_snapshots table not found. Awaiting migration.");
       return;
     }
     throw err;

--- a/src/lib/db/schemaColumns.ts
+++ b/src/lib/db/schemaColumns.ts
@@ -9,8 +9,11 @@
  */
 
 import type { SqliteAdapter } from "./adapters/types";
+import { createLogger } from "@/shared/utils/logger";
 
 type SqliteDatabase = SqliteAdapter;
+
+const log = createLogger("db:schema-columns");
 
 export function ensureProviderConnectionsColumns(db: SqliteDatabase) {
   try {
@@ -22,46 +25,52 @@ export function ensureProviderConnectionsColumns(db: SqliteDatabase) {
       db.exec(
         "ALTER TABLE provider_connections ADD COLUMN rate_limit_protection INTEGER DEFAULT 0"
       );
-      console.log("[DB] Added provider_connections.rate_limit_protection column");
+      log.info({ table: "provider_connections", column: "rate_limit_protection" }, "Added column");
     }
     if (!columnNames.has("last_used_at")) {
       db.exec("ALTER TABLE provider_connections ADD COLUMN last_used_at TEXT");
-      console.log("[DB] Added provider_connections.last_used_at column");
+      log.info({ table: "provider_connections", column: "last_used_at" }, "Added column");
     }
     if (!columnNames.has("group")) {
       db.exec('ALTER TABLE provider_connections ADD COLUMN "group" TEXT');
-      console.log('[DB] Added provider_connections."group" column');
+      log.info({ table: "provider_connections", column: "group" }, "Added column");
     }
     if (!columnNames.has("max_concurrent")) {
       db.exec("ALTER TABLE provider_connections ADD COLUMN max_concurrent INTEGER");
-      console.log("[DB] Added provider_connections.max_concurrent column");
+      log.info({ table: "provider_connections", column: "max_concurrent" }, "Added column");
     }
     if (!columnNames.has("proxy_enabled")) {
       db.exec(
         "ALTER TABLE provider_connections ADD COLUMN proxy_enabled INTEGER NOT NULL DEFAULT 1"
       );
-      console.log("[DB] Added provider_connections.proxy_enabled column");
+      log.info({ table: "provider_connections", column: "proxy_enabled" }, "Added column");
     }
     if (!columnNames.has("per_key_proxy_enabled")) {
       db.exec(
         "ALTER TABLE provider_connections ADD COLUMN per_key_proxy_enabled INTEGER NOT NULL DEFAULT 0"
       );
-      console.log("[DB] Added provider_connections.per_key_proxy_enabled column");
+      log.info({ table: "provider_connections", column: "per_key_proxy_enabled" }, "Added column");
     }
     if (!columnNames.has("quota_window_thresholds_json")) {
       db.exec("ALTER TABLE provider_connections ADD COLUMN quota_window_thresholds_json TEXT");
-      console.log("[DB] Added provider_connections.quota_window_thresholds_json column");
+      log.info(
+        { table: "provider_connections", column: "quota_window_thresholds_json" },
+        "Added column"
+      );
     }
     if (!columnNames.has("rate_limit_overrides_json")) {
       db.exec("ALTER TABLE provider_connections ADD COLUMN rate_limit_overrides_json TEXT");
-      console.log("[DB] Added provider_connections.rate_limit_overrides_json column");
+      log.info(
+        { table: "provider_connections", column: "rate_limit_overrides_json" },
+        "Added column"
+      );
     }
     db.exec(
       "CREATE INDEX IF NOT EXISTS idx_pc_max_concurrent ON provider_connections(provider, max_concurrent)"
     );
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn("[DB] Failed to verify provider_connections schema:", message);
+    log.warn({ err: message, table: "provider_connections" }, "Failed to verify schema");
   }
 }
 
@@ -74,33 +83,33 @@ export function ensureUsageHistoryColumns(db: SqliteDatabase) {
 
     if (!columnNames.has("success")) {
       db.exec("ALTER TABLE usage_history ADD COLUMN success INTEGER DEFAULT 1");
-      console.log("[DB] Added usage_history.success column");
+      log.info({ table: "usage_history", column: "success" }, "Added column");
     }
     if (!columnNames.has("latency_ms")) {
       db.exec("ALTER TABLE usage_history ADD COLUMN latency_ms INTEGER DEFAULT 0");
-      console.log("[DB] Added usage_history.latency_ms column");
+      log.info({ table: "usage_history", column: "latency_ms" }, "Added column");
     }
     if (!columnNames.has("ttft_ms")) {
       db.exec("ALTER TABLE usage_history ADD COLUMN ttft_ms INTEGER DEFAULT 0");
-      console.log("[DB] Added usage_history.ttft_ms column");
+      log.info({ table: "usage_history", column: "ttft_ms" }, "Added column");
     }
     if (!columnNames.has("error_code")) {
       db.exec("ALTER TABLE usage_history ADD COLUMN error_code TEXT");
-      console.log("[DB] Added usage_history.error_code column");
+      log.info({ table: "usage_history", column: "error_code" }, "Added column");
     }
     if (!columnNames.has("service_tier")) {
       db.exec("ALTER TABLE usage_history ADD COLUMN service_tier TEXT DEFAULT 'standard'");
-      console.log("[DB] Added usage_history.service_tier column");
+      log.info({ table: "usage_history", column: "service_tier" }, "Added column");
     }
     db.exec("CREATE INDEX IF NOT EXISTS idx_uh_service_tier ON usage_history(service_tier)");
     if (!columnNames.has("combo_strategy")) {
       db.exec("ALTER TABLE usage_history ADD COLUMN combo_strategy TEXT DEFAULT 'direct'");
-      console.log("[DB] Added usage_history.combo_strategy column");
+      log.info({ table: "usage_history", column: "combo_strategy" }, "Added column");
     }
     db.exec("CREATE INDEX IF NOT EXISTS idx_uh_combo_strategy ON usage_history(combo_strategy)");
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn("[DB] Failed to verify usage_history schema:", message);
+    log.warn({ err: message, table: "usage_history" }, "Failed to verify schema");
   }
 }
 
@@ -113,75 +122,75 @@ export function ensureCallLogsColumns(db: SqliteDatabase) {
 
     if (!columnNames.has("artifact_relpath")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN artifact_relpath TEXT");
-      console.log("[DB] Added call_logs.artifact_relpath column");
+      log.info({ table: "call_logs", column: "artifact_relpath" }, "Added column");
     }
     if (!columnNames.has("has_pipeline_details")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN has_pipeline_details INTEGER DEFAULT 0");
-      console.log("[DB] Added call_logs.has_pipeline_details column");
+      log.info({ table: "call_logs", column: "has_pipeline_details" }, "Added column");
     }
     if (!columnNames.has("requested_model")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN requested_model TEXT DEFAULT NULL");
-      console.log("[DB] Added call_logs.requested_model column");
+      log.info({ table: "call_logs", column: "requested_model" }, "Added column");
     }
     if (!columnNames.has("request_type")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN request_type TEXT DEFAULT NULL");
-      console.log("[DB] Added call_logs.request_type column");
+      log.info({ table: "call_logs", column: "request_type" }, "Added column");
     }
     if (!columnNames.has("tokens_cache_read")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN tokens_cache_read INTEGER DEFAULT NULL");
-      console.log("[DB] Added call_logs.tokens_cache_read column");
+      log.info({ table: "call_logs", column: "tokens_cache_read" }, "Added column");
     }
     if (!columnNames.has("tokens_cache_creation")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN tokens_cache_creation INTEGER DEFAULT NULL");
-      console.log("[DB] Added call_logs.tokens_cache_creation column");
+      log.info({ table: "call_logs", column: "tokens_cache_creation" }, "Added column");
     }
     if (!columnNames.has("tokens_reasoning")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN tokens_reasoning INTEGER DEFAULT NULL");
-      console.log("[DB] Added call_logs.tokens_reasoning column");
+      log.info({ table: "call_logs", column: "tokens_reasoning" }, "Added column");
     }
     if (!columnNames.has("cache_source")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN cache_source TEXT DEFAULT 'upstream'");
-      console.log("[DB] Added call_logs.cache_source column");
+      log.info({ table: "call_logs", column: "cache_source" }, "Added column");
     }
     if (!columnNames.has("combo_step_id")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN combo_step_id TEXT DEFAULT NULL");
-      console.log("[DB] Added call_logs.combo_step_id column");
+      log.info({ table: "call_logs", column: "combo_step_id" }, "Added column");
     }
     if (!columnNames.has("combo_execution_key")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN combo_execution_key TEXT DEFAULT NULL");
-      console.log("[DB] Added call_logs.combo_execution_key column");
+      log.info({ table: "call_logs", column: "combo_execution_key" }, "Added column");
     }
     if (!columnNames.has("error_summary")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN error_summary TEXT DEFAULT NULL");
-      console.log("[DB] Added call_logs.error_summary column");
+      log.info({ table: "call_logs", column: "error_summary" }, "Added column");
     }
     if (!columnNames.has("detail_state")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN detail_state TEXT DEFAULT 'none'");
-      console.log("[DB] Added call_logs.detail_state column");
+      log.info({ table: "call_logs", column: "detail_state" }, "Added column");
     }
     if (!columnNames.has("artifact_size_bytes")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN artifact_size_bytes INTEGER DEFAULT NULL");
-      console.log("[DB] Added call_logs.artifact_size_bytes column");
+      log.info({ table: "call_logs", column: "artifact_size_bytes" }, "Added column");
     }
     if (!columnNames.has("artifact_sha256")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN artifact_sha256 TEXT DEFAULT NULL");
-      console.log("[DB] Added call_logs.artifact_sha256 column");
+      log.info({ table: "call_logs", column: "artifact_sha256" }, "Added column");
     }
     if (!columnNames.has("has_request_body")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN has_request_body INTEGER DEFAULT 0");
-      console.log("[DB] Added call_logs.has_request_body column");
+      log.info({ table: "call_logs", column: "has_request_body" }, "Added column");
     }
     if (!columnNames.has("has_response_body")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN has_response_body INTEGER DEFAULT 0");
-      console.log("[DB] Added call_logs.has_response_body column");
+      log.info({ table: "call_logs", column: "has_response_body" }, "Added column");
     }
     if (!columnNames.has("request_summary")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN request_summary TEXT DEFAULT NULL");
-      console.log("[DB] Added call_logs.request_summary column");
+      log.info({ table: "call_logs", column: "request_summary" }, "Added column");
     }
     if (!columnNames.has("correlation_id")) {
       db.exec("ALTER TABLE call_logs ADD COLUMN correlation_id TEXT DEFAULT NULL");
-      console.log("[DB] Added call_logs.correlation_id column");
+      log.info({ table: "call_logs", column: "correlation_id" }, "Added column");
     }
 
     db.exec(
@@ -194,7 +203,7 @@ export function ensureCallLogsColumns(db: SqliteDatabase) {
     db.exec("CREATE INDEX IF NOT EXISTS idx_cl_correlation_id ON call_logs(correlation_id)");
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn("[DB] Failed to verify call_logs schema:", message);
+    log.warn({ err: message, table: "call_logs" }, "Failed to verify schema");
   }
 }
 

--- a/src/lib/db/sessionAccountAffinity.ts
+++ b/src/lib/db/sessionAccountAffinity.ts
@@ -1,6 +1,7 @@
 import { createHash } from "crypto";
 
 import { getDbInstance } from "./core";
+import { createLogger } from "@/shared/utils/logger";
 
 type SessionAccountAffinityRecord = {
   connectionId: string;
@@ -11,6 +12,8 @@ type SessionAccountAffinityRecord = {
 
 const NAMESPACE = "session_account_affinity";
 const CLEANUP_INTERVAL_MS = 5 * 60_000;
+
+const log = createLogger("db:session-account-affinity");
 
 let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -159,14 +162,14 @@ export function startSessionAccountAffinityCleanup(): void {
   try {
     cleanupStaleSessionAccountAffinities();
   } catch (error) {
-    console.warn("[SESSION_AFFINITY] Startup cleanup failed:", error);
+    log.warn({ err: error }, "Startup cleanup failed");
   }
 
   cleanupTimer = setInterval(() => {
     try {
       cleanupStaleSessionAccountAffinities();
     } catch (error) {
-      console.warn("[SESSION_AFFINITY] Periodic cleanup failed:", error);
+      log.warn({ err: error }, "Periodic cleanup failed");
     }
   }, CLEANUP_INTERVAL_MS);
   if (typeof cleanupTimer === "object" && "unref" in cleanupTimer) cleanupTimer.unref?.();

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -11,8 +11,11 @@ import { getComboModelProvider as getComboEntryProvider } from "@/lib/combos/ste
 import { requestBodyLimitMbFromEnv } from "@/shared/constants/bodySize";
 import { DEFAULT_RESPONSES_PREVIOUS_RESPONSE_ID_MODE } from "@/shared/constants/responsesPreviousResponseId";
 import { type JsonRecord, toRecord } from "./settings/shared";
+import { createLogger } from "@/shared/utils/logger";
 
 type ProxyValue = JsonRecord | string | null;
+
+const log = createLogger("db:settings");
 type ProxyResolutionResult = {
   proxy: ProxyValue;
   level: string;
@@ -196,9 +199,9 @@ export async function updateSettings(updates: Record<string, unknown>) {
     const { applyRuntimeSettings } = await import("@/lib/config/runtimeSettings");
     await applyRuntimeSettings(nextSettings, { source: "settings:update" });
   } catch (error) {
-    console.warn(
-      "[HOT_RELOAD] Failed to apply runtime settings after update:",
-      error instanceof Error ? error.message : error
+    log.warn(
+      { err: error instanceof Error ? error.message : String(error) },
+      "Failed to apply runtime settings after update"
     );
   }
 
@@ -578,7 +581,7 @@ export async function resolveProxyForConnection(connectionId: string, apiKeyId?:
       return normalizedFallback;
     }
   } catch (err) {
-    console.warn({ err, connectionId }, "Proxy fallback auto-selection failed");
+    log.warn({ err, connectionId }, "Proxy fallback auto-selection failed");
   }
 
   // Step 12: Return direct

--- a/src/lib/db/settings/cacheMetrics.ts
+++ b/src/lib/db/settings/cacheMetrics.ts
@@ -3,6 +3,9 @@
  */
 
 import { getDbInstance } from "../core";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("db:cache-metrics");
 
 export async function getCacheMetrics() {
   const db = getDbInstance();
@@ -152,7 +155,7 @@ export async function getCacheMetrics() {
       lastUpdated: new Date().toISOString(),
     };
   } catch (error) {
-    console.error("Failed to fetch cache metrics from usage_history:", error);
+    log.error({ err: error }, "Failed to fetch cache metrics from usage_history");
     return {
       totalRequests: 0,
       requestsWithCacheControl: 0,
@@ -221,15 +224,13 @@ export async function getCacheTrend(hours = 24): Promise<CacheTrendPoint[]> {
       cacheCreationTokens: r.cacheCreationTokens || 0,
     }));
   } catch (error) {
-    console.error("Failed to fetch cache trend:", error);
+    log.error({ err: error }, "Failed to fetch cache trend");
     return [];
   }
 }
 
 export async function resetCacheMetrics() {
   // No-op: cache metrics are computed from usage_history.
-  console.warn(
-    "resetCacheMetrics is deprecated - cache metrics are now computed from usage_history"
-  );
+  log.warn("resetCacheMetrics is deprecated - cache metrics are now computed from usage_history");
   return getCacheMetrics();
 }

--- a/src/lib/db/stateReset.ts
+++ b/src/lib/db/stateReset.ts
@@ -2,10 +2,12 @@
  * Central registry for DB module state resetters.
  * Used by restore flows to clear prepared statement caches without cross-module imports.
  */
+import { createLogger } from "@/shared/utils/logger";
 
 type DbStateResetter = () => void;
 
 const resetters = new Set<DbStateResetter>();
+const log = createLogger("db:state-reset");
 
 /**
  * Register a module-level state resetter.
@@ -24,7 +26,7 @@ export function resetAllDbModuleState() {
     try {
       resetter();
     } catch (error) {
-      console.warn("[DB] Failed to reset module state:", error);
+      log.warn({ err: error }, "Failed to reset module state");
     }
   }
 }


### PR DESCRIPTION
## **User description**
Follows the PR #506/#507/#509/#510 pattern of replacing console.* with
`createLogger("db:<subsystem>")` to provide structured logging across the
SQLite persistence layer.

Files modified (~155 callsites across 17 files):
- src/lib/db/adapters/driverFactory.ts
- src/lib/db/adapters/sqljsAdapter.ts
- src/lib/db/apiKeys.ts
- src/lib/db/backup.ts
- src/lib/db/cleanup.ts (~30 sites)
- src/lib/db/core.ts (~30 sites)
- src/lib/db/migrationRunner.ts (~22 sites; removed test-suppressing local
  console wrapper that bypassed logger output during node:test runs)
- src/lib/db/models.ts
- src/lib/db/optimizationSettings.ts
- src/lib/db/providers.ts
- src/lib/db/quotaPools.ts
- src/lib/db/quotaSnapshots.ts
- src/lib/db/schemaColumns.ts (~35 sites)
- src/lib/db/sessionAccountAffinity.ts
- src/lib/db/settings.ts
- src/lib/db/settings/cacheMetrics.ts
- src/lib/db/stateReset.ts

Per AGENTS.md guidance, never log SQLite encryption keys or raw secrets;
all logger calls redact sensitive material (no plaintext tokens, keys,
or connection strings are passed to logger calls).

Behavior preservation:
- All success-path behavior unchanged
- Only the logging mechanism changes
- Targeted unit tests pass

Test interactions:
- Removed the local `console` wrapper in migrationRunner.ts that suppressed
  log/warn output when `NODE_TEST_CONTEXT` was set. Tests can suppress pino
  output via APP_LOG_LEVEL=silent or by mocking the logger; the wrapper
  predated pino and was the only consumer of `globalThis.console` in this
  file.
- Preserved one `console.error` in `core.ts:migrateFromJson` because
  `tests/unit/db-core-migration.test.ts` overrides `console.error` to
  detect the failure path. Both `console.error` and `log.error` are
  emitted so the test passes and pino is the canonical sink.

TSC: 0 errors against tsconfig.typecheck-core.json on the base branch
(baseline was 0 before this PR).

Verified tests:
- tests/unit/db-core-migration.test.ts (3/3)
- tests/unit/db-migration-version-uniqueness.test.ts
- tests/unit/db-quota-migrations-idempotency.test.ts
- tests/unit/quota-groups-migration.test.ts
- tests/unit/migration-107-quota-share-strategy.test.ts
- tests/unit/db-migrationrunner-constants-split.test.ts
- tests/unit/cleanup-column-fix.test.mjs (9/9)


___

## **CodeAnt-AI Description**
Standardize database logging without changing database behavior

### What Changed
- Database, backup, migration, cleanup, schema, and optimization messages now use structured, subsystem-specific logging.
- Log entries record useful details such as affected files, tables, row counts, migration versions, and error context.
- Database failures and recovery events remain visible, including migration errors that continue to appear in test and CI output.
- Sensitive database values are excluded from log details.

### Impact
`✅ Clearer database recovery diagnostics`
`✅ Easier troubleshooting of migrations and backups`
`✅ Consistent database logs across subsystems`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
