### PR TITLE
fix(ci): allow BlueOak license for Keyv SQLite transition

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,7 +21,10 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: true
-          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, Unlicense, 0BSD, CC0-1.0
+          # @keyv/sqlite@4 pulls sqlite3@6, whose node-gyp toolchain includes
+          # isexe@4 under BlueOak-1.0.0. Permit this transitive license while
+          # retaining the deny-by-default policy for all other unlisted licenses.
+          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, Unlicense, 0BSD, CC0-1.0, BlueOak-1.0.0
           # Sonar's pinned GitHub Action is LGPL-3.0. Exempt only this immutable
           # action dependency; LGPL remains denied for every package and action.
           allow-dependencies-licenses: pkg:githubactions/SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f


### PR DESCRIPTION
## **User description**
## Summary
- allow the BlueOak-1.0.0 license introduced transitively by @keyv/sqlite@4 / sqlite3@6
- retain deny-by-default license policy for all other unlisted licenses

## Evidence
- PR #524 dependency review found no high-or-higher vulnerabilities
- failure was solely `isexe@4.0.0` (BlueOak-1.0.0)
- YAML parse and `git diff --check` pass

This is a one-file CI policy change on current main after #524 merged; no Keyv source or lockfile changes.


___

## **CodeAnt-AI Description**
Allow the Keyv SQLite dependency chain to pass CI license validation

### What Changed
- Dependency review now permits the BlueOak-1.0.0 license used by a transitive SQLite toolchain dependency
- All other unlisted licenses remain blocked by the deny-by-default policy

### Impact
`✅ Keyv SQLite dependency updates pass license checks`
`✅ Fewer CI failures from approved transitive dependencies`
`✅ Unapproved licenses remain blocked`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
