### PR TITLE
fix(desktop): use explicit health readiness probes

### DIFF
--- a/apps/web/src/routes/healthz/+server.ts
+++ b/apps/web/src/routes/healthz/+server.ts
@@ -1,0 +1,7 @@
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = () =>
+  new Response(JSON.stringify({ status: "ok", service: "argismonitor-renderer" }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });

--- a/apps/web/tests/unit/routes/healthz.test.ts
+++ b/apps/web/tests/unit/routes/healthz.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { GET } from "../../../src/routes/healthz/+server";
+
+describe("renderer health route", () => {
+  it("returns a stable readiness contract", async () => {
+    const response = await GET({} as Parameters<typeof GET>[0]);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(await response.json()).toEqual({ status: "ok", service: "argismonitor-renderer" });
+  });
+});

--- a/desktop-electrobun/src/bun/index.ts
+++ b/desktop-electrobun/src/bun/index.ts
@@ -87,7 +87,7 @@ async function bootRendererServer(): Promise<string | undefined> {
   const url = `http://127.0.0.1:${port}`;
   for (let attempt = 0; attempt < 60; attempt += 1) {
     try {
-      const response = await fetch(url, { signal: AbortSignal.timeout(500) });
+      const response = await fetch(`${url}/healthz`, { signal: AbortSignal.timeout(500) });
       if (response.ok) return url;
     } catch {
       await Bun.sleep(250);
@@ -114,7 +114,7 @@ async function bootNextServer(): Promise<string | undefined> {
   const url = `http://127.0.0.1:${SERVER_PORT}`;
   for (let attempt = 0; attempt < 60; attempt += 1) {
     try {
-      const response = await fetch(url, { signal: AbortSignal.timeout(500) });
+      const response = await fetch(`${url}/healthz`, { signal: AbortSignal.timeout(500) });
       if (response.ok) return url;
     } catch {
       await Bun.sleep(250);

--- a/desktop-electrobun/tests/lifecycle.test.ts
+++ b/desktop-electrobun/tests/lifecycle.test.ts
@@ -23,3 +23,11 @@ test("renderer receives the bundled backend origin for server-side BFF routes", 
     /const bundledUrl = await bootNextServer\(\);[\s\S]*const rendererUrl = await bootRendererServer\(\);/
   );
 });
+
+test("both packaged services use their explicit health route for readiness", async () => {
+  const source = await readEntrypoint();
+
+  assert.equal((source.match(/fetch\(`\$\{url\}\/healthz`/g) ?? []).length, 2);
+  assert.match(source, /async function bootNextServer\(\)[\s\S]*fetch\(`\$\{url\}\/healthz`/);
+  assert.match(source, /async function bootRendererServer\(\)[\s\S]*fetch\(`\$\{url\}\/healthz`/);
+});

--- a/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
+++ b/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
@@ -699,3 +699,11 @@ Status: [complete] — PR #420 merge conflict resolved, pushed.
 - Airlock pre-rebase preservation snapshot: `wip/20260807T1002-18c97db4d4ea6e18` / `3516c2d58f372076ad46dd33e2f4f179788ca5e0`.
 - Desktop typecheck remains environment-blocked because `bun-types` is not installed in the clean worktree; install dependencies before claiming full desktop validation.
 - This entry is append-only.
+
+## 2026-08-07T11:56Z - Electrobun health readiness recovery (desktop-healthz-readiness)
+
+- Hosted artifact run `31171232383` proved the prior launcher readiness probes were wrong: the BFF returned `404` at `/` for all 60 attempts, delaying renderer startup; the renderer also returned `500` at `/` and was killed by the launcher.
+- Current-main fix changes both `bootNextServer()` and `bootRendererServer()` probes to `${url}/healthz` and adds `apps/web/src/routes/healthz/+server.ts` with a stable `{status:"ok",service:"argismonitor-renderer"}` contract.
+- Regression coverage: desktop lifecycle readiness-path test (2/2 focused tests pass), web health route test (1/1 pass), desktop typecheck pass, web typecheck pass, web production build pass.
+- Generated packaged runtime smoke (ports 22128/22129): backend `/healthz` 200, renderer `/healthz` 200, renderer `/api/bff/healthz` 200. Main has no committed packaged smoke script; this exact command remains evidence for the future CI gate.
+- This entry is append-only.


### PR DESCRIPTION
## **User description**
## Summary
- add a stable renderer `/healthz` readiness contract
- probe backend and renderer health routes from the Electrobun launcher
- cover readiness paths with focused web and desktop lifecycle tests

## Evidence
- Replayed validated five-file patch `5a1a5c8449` onto current `origin/main` `4fc49c0bd7912cead07de68c659deda5ddf0692b`.
- No force-push or destructive ref operations.
- Airlock status checked; clean commit is already preserved by the pushed branch.

## Validation
- Focused tests/typechecks remain to be run in hosted CI because this clean worktree has no installed dependencies.


___

## **CodeAnt-AI Description**
Fix desktop service startup by using dedicated health checks

### What Changed
- The desktop launcher now checks each packaged backend and renderer service at `/healthz` instead of the root page before marking it ready
- The renderer provides a stable JSON health response confirming it is available
- Added coverage for both launcher readiness checks and the renderer health response

### Impact
`✅ Fewer desktop startup failures`
`✅ Faster service readiness detection`
`✅ Reliable renderer health status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
