### PR TITLE
refactor: migrate 4 console.* callsites to pino in lib/catalog + oauth/services/kiro + a2a

### DIFF
--- a/src/lib/a2a/routingLogger.ts
+++ b/src/lib/a2a/routingLogger.ts
@@ -4,6 +4,9 @@
 
 import { saveRoutingDecision } from "@/lib/db/routingDecisions";
 import { getActiveSpanContext } from "./otelContext";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("a2a:routing-logger");
 
 export interface RoutingDecision {
   taskType: string;
@@ -25,9 +28,9 @@ export interface RoutingDecision {
 }
 
 export function logRoutingDecision(decision: RoutingDecision): void {
-  // Log to console in development
+  // Log at debug level in development (low-volume, dev-only)
   if (process.env.NODE_ENV === "development") {
-    console.log("[A2A ROUTING]", JSON.stringify(decision, null, 2));
+    log.debug({ decision }, "a2a.routingLogger: routing decision");
   }
 
   // Hydrate OTel trace context when the caller didn't supply it

--- a/src/lib/catalog/openrouterCatalog.ts
+++ b/src/lib/catalog/openrouterCatalog.ts
@@ -9,6 +9,9 @@
 
 import fs from "fs";
 import path from "path";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("lib:catalog:openrouter");
 
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/models";
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -80,7 +83,10 @@ function writeCache(data: CatalogEntry[]): void {
   try {
     fs.writeFileSync(filePath, JSON.stringify(cache, null, 2), "utf8");
   } catch (err) {
-    console.warn("[OpenRouterCatalog] Failed to write cache:", err);
+    log.warn(
+      { err: (err as Error)?.message },
+      "lib.catalog.openrouterCatalog: failed to write cache file",
+    );
   }
 }
 
@@ -140,7 +146,10 @@ export async function getOpenRouterCatalog(): Promise<{
     writeCache(data);
     return { data, stale: false, cachedAt: null, fromCache: false };
   } catch (err) {
-    console.warn("[OpenRouterCatalog] Fetch failed, using stale cache:", err);
+    log.warn(
+      { err: (err as Error)?.message },
+      "lib.catalog.openrouterCatalog: fetch failed, using stale cache",
+    );
 
     // Stale-if-error: return old cache if available
     if (cache) {

--- a/src/lib/oauth/services/kiro.ts
+++ b/src/lib/oauth/services/kiro.ts
@@ -1,4 +1,7 @@
 import { KIRO_CONFIG, assertValidAwsRegion } from "../constants/oauth";
+import { createLogger } from "@/shared/utils/logger";
+
+const log = createLogger("oauth:services:kiro");
 
 /**
  * Kiro OAuth Service
@@ -211,7 +214,10 @@ export class KiroService {
       if (!response.ok) {
         // Client credentials may be expired or invalid (DB import, TTL, browser conflict).
         // Re-register a fresh OIDC client and retry once before giving up (#2524).
-        console.warn("[kiro refresh] OIDC refresh failed, attempting client re-registration...");
+        log.warn(
+          { status: response.status },
+          "oauth.services.kiro: OIDC refresh failed, attempting client re-registration",
+        );
         try {
           const newReg = await this.registerClient(resolvedRegion);
           const retryRes = await fetch(endpoint, {


### PR DESCRIPTION
## **User description**
Phase 2 of the console.* migration followup to PR #525. Replaces high-value console.* callsites in src/lib/ with structured pino logging via `createLogger('domain:subsystem')`.

**Migrated**:
- `src/lib/catalog/openrouterCatalog.ts:83, 143` — cache write failure + fetch failure (was `console.warn`)
- `src/lib/oauth/services/kiro.ts:214` — OIDC refresh failure (was `console.warn`)
- `src/lib/a2a/routingLogger.ts:30` — dev-only routing debug log (was `console.log`)

**Intentionally NOT migrated** (documented in src/lib/db/core.ts:1498-1500):
- `src/lib/db/core.ts:1500` — `console.error` preserved because `tests/unit/db-core-migration.test.ts` asserts on it (corrupted db.json surfaces a `console.error` so failure is visible in CI logs without depending on pino transport).
- `src/lib/middleware/registry.ts:190, 192, 194` — intentional fallback when the caller-supplied logger is missing (`logger.warn ?? console.warn`).
- `src/lib/gamification/streaks.ts:96, 125` — JSDoc examples (in comments, not actual code).

Per the audit doc, ~245 console.* callsites were migrated in PRs #522 and #525. This PR migrates 4 more in high-value paths. Remaining ~245 findings are mostly in CLI/dev tooling paths where console.* is the appropriate output mechanism.

TSC: 0 errors baseline unchanged.


___

## **CodeAnt-AI Description**
Standardize application logging across catalog, OAuth, and routing flows

### What Changed
- Catalog cache write and fetch failures now use structured warning logs while preserving stale-cache fallback behavior
- Kiro OAuth refresh failures now record the response status and continue retrying client registration
- Development-only A2A routing decisions now use structured debug logs

### Impact
`✅ Clearer cache and OAuth failure diagnostics`
`✅ Consistent routing logs in development`
`✅ Stale catalog results remain available when refreshes fail`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
