### PR TITLE
fix(build): expose local FFI workspace to release installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
-        "open-sse"
+        "open-sse",
+        "packages/omniroute-ffi"
       ],
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -115,7 +116,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/better-sqlite3": "^7.6.13",
-        "@types/bun": "*",
+        "@types/bun": "latest",
         "@types/node": "^26.0.0",
         "@types/opossum": "^8.1.9",
         "@types/react": "^19.2.15",
@@ -5911,6 +5912,10 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/@omniroute/ffi": {
+      "resolved": "packages/omniroute-ffi",
+      "link": true
     },
     "node_modules/@omniroute/open-sse": {
       "resolved": "open-sse",
@@ -31083,6 +31088,21 @@
         "@opentelemetry/api": "^1.9.0",
         "@toon-format/toon": "^2.3.0",
         "safe-regex": "^2.1.1"
+      }
+    },
+    "packages/omniroute-ffi": {
+      "name": "@omniroute/ffi",
+      "version": "3.8.43",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0 <23 || >=24.0.0 <27"
+      },
+      "optionalDependencies": {
+        "@omniroute/ffi-darwin-arm64": "3.8.43",
+        "@omniroute/ffi-darwin-x64": "3.8.43",
+        "@omniroute/ffi-linux-arm64-gnu": "3.8.43",
+        "@omniroute/ffi-linux-x64-gnu": "3.8.43",
+        "@omniroute/ffi-win32-x64": "3.8.43"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "src/shared/utils/nodeRuntimeSupport.ts"
   ],
   "workspaces": [
-    "open-sse"
+    "open-sse",
+    "packages/omniroute-ffi"
   ],
   "engines": {
     "node": ">=22.0.0 <23 || >=24.0.0 <27"

--- a/tests/unit/build/ffi-workspace-package.test.ts
+++ b/tests/unit/build/ffi-workspace-package.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+test("root workspace exposes the local FFI package to clean release installs", async () => {
+  const manifestUrl = new URL("../../../package.json", import.meta.url);
+  const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
+  const workspaces = Array.isArray(manifest.workspaces) ? manifest.workspaces : manifest.workspaces?.packages;
+
+  assert.ok(
+    workspaces?.includes("packages/omniroute-ffi"),
+    "@omniroute/ffi is imported by the release build and must be in the root workspace graph"
+  );
+});


### PR DESCRIPTION
## **User description**
## Summary

- exposes the existing `@omniroute/ffi` workspace to clean root installs
- regenerates the lockfile without removing the existing `open-sse` workspace
- adds a regression test for the root workspace contract

## Validation

- RED: `node --test tests/unit/build/ffi-workspace-package.test.mjs` failed before the workspace declaration
- GREEN: the same assertion passed after the declaration and lock regeneration
- TypeScript loader: `node --import .../tsx/dist/loader.mjs --test tests/unit/build/ffi-workspace-package.test.ts` passed
- lock invariants: both `node_modules/@omniroute/open-sse` and `node_modules/@omniroute/ffi` are workspace links

## Scope

This intentionally addresses only the unresolved `@omniroute/ffi` release-build import. Device-code import, schema export, native SQLite, and Actions-policy failures remain separate tracked lanes.


___

## **CodeAnt-AI Description**
Expose the local FFI package to clean release installs

### What Changed
- Release installs now resolve `@omniroute/ffi` from the repository workspace instead of treating it as an unavailable external package
- The lockfile records the FFI workspace and its platform-specific optional packages
- Added a regression test to ensure the root workspace continues to include the FFI package

### Impact
`✅ Fewer release-build import failures`
`✅ Reliable local FFI package linking`
`✅ Protected workspace configuration`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the local FFI package to the project’s npm workspace configuration, enabling it to be included in clean installations and releases.

* **Tests**
  * Added coverage to verify the FFI package remains registered in the workspace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->