### PR TITLE
fix(build): keep FFI platform binaries optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,7 @@
       "license": "MIT",
       "workspaces": [
         "open-sse",
-        "packages/omniroute-ffi",
-        "packages/omniroute-ffi-darwin-arm64",
-        "packages/omniroute-ffi-darwin-x64",
-        "packages/omniroute-ffi-linux-arm64-gnu",
-        "packages/omniroute-ffi-linux-x64-gnu",
-        "packages/omniroute-ffi-win32-x64"
+        "packages/omniroute-ffi"
       ],
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -121,7 +116,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/better-sqlite3": "^7.6.13",
-        "@types/bun": "*",
+        "@types/bun": "latest",
         "@types/node": "^26.0.0",
         "@types/opossum": "^8.1.9",
         "@types/react": "^19.2.15",
@@ -31123,52 +31118,98 @@
         "node": ">=22.0.0 <23 || >=24.0.0 <27"
       },
       "optionalDependencies": {
-        "@omniroute/ffi-darwin-arm64": "3.8.43",
-        "@omniroute/ffi-darwin-x64": "3.8.43",
-        "@omniroute/ffi-linux-arm64-gnu": "3.8.43",
-        "@omniroute/ffi-linux-x64-gnu": "3.8.43",
-        "@omniroute/ffi-win32-x64": "3.8.43"
+        "@omniroute/ffi-darwin-arm64": "file:../omniroute-ffi-darwin-arm64",
+        "@omniroute/ffi-darwin-x64": "file:../omniroute-ffi-darwin-x64",
+        "@omniroute/ffi-linux-arm64-gnu": "file:../omniroute-ffi-linux-arm64-gnu",
+        "@omniroute/ffi-linux-x64-gnu": "file:../omniroute-ffi-linux-x64-gnu",
+        "@omniroute/ffi-win32-x64": "file:../omniroute-ffi-win32-x64"
       }
     },
     "packages/omniroute-ffi-darwin-arm64": {
       "name": "@omniroute/ffi-darwin-arm64",
       "version": "3.8.43",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
       "license": "MIT",
-      "cpu": ["arm64"],
-      "os": ["darwin"],
-      "engines": {"node": ">=22.0.0 <23 || >=24.0.0 <27"}
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=22.0.0 <23 || >=24.0.0 <27"
+      }
     },
     "packages/omniroute-ffi-darwin-x64": {
       "name": "@omniroute/ffi-darwin-x64",
       "version": "3.8.43",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
       "license": "MIT",
-      "cpu": ["x64"],
-      "os": ["darwin"],
-      "engines": {"node": ">=22.0.0 <23 || >=24.0.0 <27"}
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=22.0.0 <23 || >=24.0.0 <27"
+      }
     },
     "packages/omniroute-ffi-linux-arm64-gnu": {
       "name": "@omniroute/ffi-linux-arm64-gnu",
       "version": "3.8.43",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
-      "cpu": ["arm64"],
-      "os": ["linux"],
-      "engines": {"node": ">=22.0.0 <23 || >=24.0.0 <27"}
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22.0.0 <23 || >=24.0.0 <27"
+      }
     },
     "packages/omniroute-ffi-linux-x64-gnu": {
       "name": "@omniroute/ffi-linux-x64-gnu",
       "version": "3.8.43",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
-      "cpu": ["x64"],
-      "os": ["linux"],
-      "engines": {"node": ">=22.0.0 <23 || >=24.0.0 <27"}
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22.0.0 <23 || >=24.0.0 <27"
+      }
     },
     "packages/omniroute-ffi-win32-x64": {
       "name": "@omniroute/ffi-win32-x64",
       "version": "3.8.43",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
       "license": "MIT",
-      "cpu": ["x64"],
-      "os": ["win32"],
-      "engines": {"node": ">=22.0.0 <23 || >=24.0.0 <27"}
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=22.0.0 <23 || >=24.0.0 <27"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,12 +61,7 @@
   ],
   "workspaces": [
     "open-sse",
-    "packages/omniroute-ffi",
-    "packages/omniroute-ffi-darwin-arm64",
-    "packages/omniroute-ffi-darwin-x64",
-    "packages/omniroute-ffi-linux-arm64-gnu",
-    "packages/omniroute-ffi-linux-x64-gnu",
-    "packages/omniroute-ffi-win32-x64"
+    "packages/omniroute-ffi"
   ],
   "engines": {
     "node": ">=22.0.0 <23 || >=24.0.0 <27"

--- a/packages/omniroute-ffi/package.json
+++ b/packages/omniroute-ffi/package.json
@@ -9,10 +9,10 @@
     "node": ">=22.0.0 <23 || >=24.0.0 <27"
   },
   "optionalDependencies": {
-    "@omniroute/ffi-darwin-arm64": "3.8.43",
-    "@omniroute/ffi-darwin-x64": "3.8.43",
-    "@omniroute/ffi-linux-x64-gnu": "3.8.43",
-    "@omniroute/ffi-linux-arm64-gnu": "3.8.43",
-    "@omniroute/ffi-win32-x64": "3.8.43"
+    "@omniroute/ffi-darwin-arm64": "file:../omniroute-ffi-darwin-arm64",
+    "@omniroute/ffi-darwin-x64": "file:../omniroute-ffi-darwin-x64",
+    "@omniroute/ffi-linux-x64-gnu": "file:../omniroute-ffi-linux-x64-gnu",
+    "@omniroute/ffi-linux-arm64-gnu": "file:../omniroute-ffi-linux-arm64-gnu",
+    "@omniroute/ffi-win32-x64": "file:../omniroute-ffi-win32-x64"
   }
 }

--- a/tests/unit/build/ffi-workspace-package.test.ts
+++ b/tests/unit/build/ffi-workspace-package.test.ts
@@ -2,14 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { test } from "node:test";
 
-const FFI_WORKSPACES = [
-  "packages/omniroute-ffi",
-  "packages/omniroute-ffi-darwin-arm64",
-  "packages/omniroute-ffi-darwin-x64",
-  "packages/omniroute-ffi-linux-arm64-gnu",
-  "packages/omniroute-ffi-linux-x64-gnu",
-  "packages/omniroute-ffi-win32-x64",
-];
+const FFI_WORKSPACE = "packages/omniroute-ffi";
 
 test("root workspace exposes the local FFI package to clean release installs", async () => {
   const manifestUrl = new URL("../../../package.json", import.meta.url);
@@ -18,16 +11,22 @@ test("root workspace exposes the local FFI package to clean release installs", a
   const lock = JSON.parse(await readFile(lockUrl, "utf8"));
   const workspaces = Array.isArray(manifest.workspaces) ? manifest.workspaces : manifest.workspaces?.packages;
 
-  assert.deepEqual(workspaces?.filter((workspace) => workspace.startsWith("packages/omniroute-ffi")), FFI_WORKSPACES);
+  assert.deepEqual(workspaces?.filter((workspace) => workspace.startsWith("packages/omniroute-ffi")), [FFI_WORKSPACE]);
 
-  for (const workspace of FFI_WORKSPACES) {
-    const packageUrl = new URL(`../../../${workspace}/package.json`, import.meta.url);
-    const packageManifest = JSON.parse(await readFile(packageUrl, "utf8"));
+  const packageUrl = new URL(`../../../${FFI_WORKSPACE}/package.json`, import.meta.url);
+  const packageManifest = JSON.parse(await readFile(packageUrl, "utf8"));
+
+  for (const [packageName, source] of Object.entries(packageManifest.optionalDependencies)) {
+    assert.equal(
+      source,
+      `file:../omniroute-${packageName.slice("@omniroute/".length)}`,
+      `${packageName} must resolve from its local platform package`,
+    );
 
     assert.equal(
-      lock.packages[`node_modules/${packageManifest.name}`]?.link,
+      lock.packages[`node_modules/${packageName}`]?.link,
       true,
-      `${packageManifest.name} must be a workspace link in package-lock.json`,
+      `${packageName} must be locked as an optional dependency of the portable FFI workspace`,
     );
   }
 });


### PR DESCRIPTION
## **User description**
Fixes the cross-platform install regression introduced by #553 without rewriting history.

- Keeps only the portable `@omniroute/ffi` facade in the root workspace graph.
- Resolves each OS-specific binary through an explicit local optional dependency.
- Locks those platform packages as links under the facade rather than root workspaces, so npm skips non-matching OS/CPU variants.
- Extends the committed TypeScript regression test for both workspace scope and optional platform lock links.

Evidence from an isolated fixture:
- RED: the regression test failed when local optional platform entries were absent from the lock.
- GREEN: the same test passes after regeneration.
- `npm ci --ignore-scripts --no-audit --no-fund` completed locally against the corrected fixture.

This PR exists because #552 and #553 were merged automatically before hosted CI completed; it is a forward-only correction.


___

## **CodeAnt-AI Description**
Keep platform-specific FFI binaries optional during installation

### What Changed
- Clean installs now include only the portable FFI package in the root workspace.
- Platform-specific FFI binaries are resolved as local optional packages, so installations skip binaries that do not match the current operating system or CPU.
- Build regression coverage now verifies the portable workspace and its optional platform links in the lockfile.

### Impact
`✅ Fewer cross-platform install failures`
`✅ Smaller installs on unsupported platforms`
`✅ Reliable clean release installs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FFI package resolution by linking platform-specific components locally.
  * Updated workspace handling to support a single portable FFI package across platforms.

* **Tests**
  * Updated validation to confirm local platform package links are correctly recorded in the lockfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->