### PR TITLE
fix(types): v0.11 lane F4 — OmniRoute type-ignore audit (4 of 5 removed)

### DIFF
--- a/extensions/argis/pheno-llms-txt/src/pheno_llms_txt/generator.py
+++ b/extensions/argis/pheno-llms-txt/src/pheno_llms_txt/generator.py
@@ -7,11 +7,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 try:
-    import structlog
-    log = structlog.get_logger(__name__)
+    import structlog as _structlog
+    log = _structlog.get_logger(__name__)
 except ImportError:  # pragma: no cover
     import logging
-    log = logging.getLogger(__name__)  # type: ignore[assignment]
+    log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)

--- a/extensions/argis/pheno-scaffold-kit/src/pheno_scaffold_kit/scaffold.py
+++ b/extensions/argis/pheno-scaffold-kit/src/pheno_scaffold_kit/scaffold.py
@@ -12,11 +12,11 @@ from pathlib import Path
 from typing import Any
 
 try:
-    import structlog
-    log = structlog.get_logger(__name__)
+    import structlog as _structlog
+    log = _structlog.get_logger(__name__)
 except ImportError:  # pragma: no cover
     import logging
-    log = logging.getLogger(__name__)  # type: ignore[assignment]
+    log = logging.getLogger(__name__)
 
 # Path to the bundled Cookiecutter template (relative to the package root).
 TEMPLATE_DIR = Path(__file__).parent.parent.parent / "templates" / "cookiecutter"

--- a/extensions/argis/pheno-vibecoding-guard/src/pheno_vibecoding_guard/scanner.py
+++ b/extensions/argis/pheno-vibecoding-guard/src/pheno_vibecoding_guard/scanner.py
@@ -7,11 +7,11 @@ from pathlib import Path
 from typing import Callable
 
 try:
-    import structlog
-    log = structlog.get_logger(__name__)
+    import structlog as _structlog
+    log = _structlog.get_logger(__name__)
 except ImportError:  # pragma: no cover
     import logging
-    log = logging.getLogger(__name__)  # type: ignore[assignment]
+    log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)

--- a/extensions/argis/pheno-worklog-schema/src/pheno_worklog_schema/parser.py
+++ b/extensions/argis/pheno-worklog-schema/src/pheno_worklog_schema/parser.py
@@ -28,11 +28,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 try:
-    import structlog
-    log = structlog.get_logger(__name__)
+    import structlog as _structlog
+    log = _structlog.get_logger(__name__)
 except ImportError:  # pragma: no cover
     import logging
-    log = logging.getLogger(__name__)  # type: ignore[assignment]
+    log = logging.getLogger(__name__)
 
 # Cell counts (excludes the empty leading + trailing pipe tokens).
 V20_CELLS = 6   # v2.0 schema: Date | Task ID | Layer | Action | Files | Notes


### PR DESCRIPTION
## **User description**
Refs: v0.11 backlog Lane F task F4.

Type-ignore audit + selective replacement in OmniRoute. Removes
4 of 5 'type: ignore' comments where minimal mypy fixes were
sufficient. The 5th is left in place pending a deeper mypy
investigation.

Branch: chore/f4-type-ignore-audit.


___

## **CodeAnt-AI Description**
Remove unnecessary type-checking exceptions from optional logging setup

### What Changed
- Logging continues to use structlog when available and standard logging when it is not
- Four extensions now pass type checking without suppressing assignment warnings
- Runtime behavior and log output remain unchanged when either logging library is used

### Impact
`✅ Cleaner type-checking results`
`✅ Reliable fallback logging`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logging setup across several tools.
  * Preserved existing logging behavior, including fallback support when optional logging features are unavailable.
  * No user-facing functionality or exported interfaces changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->