### PR TITLE
fix(models): resolve catalog cache conflict against main

### DIFF
--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -5,6 +5,7 @@ import {
   getCombos,
   getAllCustomModels,
   getSettings,
+  getDatabaseSettings,
   getProviderNodes,
   getModelIsHidden,
   getModelAliases,

--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -74,12 +74,9 @@ import {
 import { getVisionCapabilityFields, getCustomVisionCapabilityFields } from "./catalogVision";
 import { FALLBACK_ALIAS_TO_PROVIDER, buildAliasMaps } from "./catalogProviderMaps";
 import { getModelCatalogAuthRejection, isCodexModelCatalogClient } from "./catalogRequest";
-<<<<<<< HEAD
-=======
 import { isFreeModel, providerHasFreeModels } from "@/shared/utils/freeModels";
 import { isCodexDiscoveryModelExcluded } from "@/shared/services/codexDiscoveryPolicy";
 import { buildErrorBody } from "@omniroute/open-sse/utils/error";
->>>>>>> 6706d5ff7 (fix(api): serve /v1/models stale-first and sanitize its error bodies (#8703))
 
 // Public API of this module is preserved after the catalog helper extraction:
 // `isVisionModelId` (vision-detection-consistency.test.ts) and
@@ -88,8 +85,6 @@ import { buildErrorBody } from "@omniroute/open-sse/utils/error";
 export { isVisionModelId } from "@/shared/constants/visionModels";
 export { getCustomVisionCapabilityFields };
 
-<<<<<<< HEAD
-=======
 // The response cache (coalescing, short-TTL memoization and stale-while-revalidate)
 // lives in ./catalogCache. Re-exported here because the existing tests import the
 // hooks from this module, and CATALOG_STALE_WHILE_REVALIDATE_MS is part of the
@@ -107,7 +102,6 @@ export {
 } from "./catalogCache";
 export type { CachedCatalog } from "./catalogCache";
 
->>>>>>> 6706d5ff7 (fix(api): serve /v1/models stale-first and sanitize its error bodies (#8703))
 /**
  * Build unified OpenAI-compatible model catalog response.
  * Reused by `/api/v1/models` and `/api/v1` to avoid semantic drift (T09).
@@ -117,8 +111,6 @@ export async function getUnifiedModelsResponse(
   corsHeaders: Record<string, string> = {}
 ) {
   const diagnosticHeaders = getCatalogDiagnosticsHeaders({ request });
-<<<<<<< HEAD
-=======
 
   // #6408 fast path: reject unauthorized callers first (auth state is per-request
   // and MUST NOT be cached), then coalesce identical concurrent requests + short-
@@ -187,7 +179,6 @@ async function buildUnifiedModelsResponseCore(
   corsHeaders: Record<string, string> = {}
 ) {
   const diagnosticHeaders = getCatalogDiagnosticsHeaders({ request });
->>>>>>> 6706d5ff7 (fix(api): serve /v1/models stale-first and sanitize its error bodies (#8703))
   try {
     let settings: Record<string, any> = {};
     try {

--- a/src/lib/db/readCache.ts
+++ b/src/lib/db/readCache.ts
@@ -154,6 +154,15 @@ export async function setCachedLKGP(
 // one and treat a mismatch as a cache miss — so combo edits take effect
 // immediately instead of after the 10s window (#3147).
 let combosCacheVersion = 0;
+let modelCatalogCacheVersion = 0;
+
+/**
+ * Monotonic invalidation version consumed by the model-catalog response cache.
+ * Any settings, pricing, provider, or combo write invalidates catalog output.
+ */
+export function getModelCatalogCacheVersion(): number {
+  return modelCatalogCacheVersion;
+}
 
 /**
  * Current combo-cache version. Cache layers snapshot this when they populate
@@ -171,6 +180,7 @@ export function getCombosCacheVersion(): number {
 export function invalidateDbCache(
   scope?: "settings" | "pricing" | "connections" | "combos"
 ): void {
+  modelCatalogCacheVersion++;
   if (!scope || scope === "settings") settingsCache.invalidate();
   if (!scope || scope === "pricing") pricingCache.invalidate();
   if (!scope || scope === "connections") connectionsCache.invalidate();

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -270,6 +270,7 @@ function validateProviderSpecificData(
 // Helpers + oauthPasteCredentialsSchema re-exports (webpack barrel truncation).
 export { validateBody, isValidationFailure } from "./helpers";
 export { oauthPasteCredentialsSchema } from "./schemas/auth";
+export { cliMultiModelConfigSchema } from "./schemas/cli";
 // ──── Provider Schemas ────
 
 export const createProviderSchema = z


### PR DESCRIPTION
## **User description**
Forward resolution of PR #559 conflicts against main 9922f6a.

- Preserve main catalog registry/provider behavior.
- Restore PR cache extraction, stale-while-revalidate, and sanitized error handling.
- Retain main read-cache version export/invalidation and cli schema export.

Validation: targeted tsc emitted no diagnostics for catalog.ts/readCache.ts; full lint/typecheck is blocked by absent node_modules in isolated checkout.


___

## **CodeAnt-AI Description**
Improve model catalog caching and error responses

### What Changed
- Concurrent requests for the same model catalog now share one build, while recent results are reused briefly to reduce repeated catalog work
- Expired catalog results can be served while a background refresh updates them, keeping responses available during refreshes
- Catalog cache entries are refreshed after settings, pricing, connection, or combo changes so results reflect current configuration
- Catalog failures now preserve the correct HTTP 500 status and use the standard error response format
- The CLI multi-model configuration schema is available through the shared validation exports

### Impact
`✅ Faster model-list responses during request bursts`
`✅ Fewer delays while the catalog refreshes`
`✅ Clearer and correctly classified catalog errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved catalog response caching and request handling to reduce redundant work and support more consistent response delivery.
  - Added configurable catalog cache lifetimes to keep results current while improving repeat-request performance.

- **Reliability**
  - Improved error response handling for catalog requests, providing more consistent behavior when failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->