### PR TITLE
legacy(omniroute): preserve historical artifacts from omniroute-monorepo-archive (2026-07-17 snapshot)

### DIFF
--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0001-.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0001-.md
@@ -1,0 +1,34 @@
+# ADR-0001: Monorepo layout: pnpm workspaces + Cargo workspace, no turborepo/nx
+
+**Status**: Accepted (2026-07-04)
+**Deciders**: argismonitor core
+**Supersedes**: —
+**Superseded by**: —
+
+## Context
+
+UMonorepo layout: pnpm workspaces + Cargo workspace, no turborepo/nx matters in this fork because the prior prototype
+(2026) used a different stack and accumulated tech debt that needs replacement.
+
+## Decision
+
+We adopt the policy above for v4.0 and beyond.
+
+## Consequences
+
+**Positive**
+- Aligns the codebase with the rest of the Phenotype/OmniRoute fleet.
+- Removes a class of subtle bugs and migration debt.
+
+**Negative**
+- Initial PRs are larger because no shims/back-compat layers are allowed.
+- New contributors must learn the conventions in this ADR.
+
+## Alternatives considered
+
+1. Status quo with shims — rejected per the no-back-compat-shims ADR.
+2. Full rewrite from scratch — rejected; existing primitives are sound.
+
+## References
+
+- ../sessions/20260705-argismonitor-monorepo-bootstrap/00_SESSION_OVERVIEW.md

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0001-monorepo-pnpm.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0001-monorepo-pnpm.md
@@ -1,0 +1,26 @@
+# ADR-0001: Monorepo layout — pnpm workspaces + Cargo workspace
+
+**Status**: Accepted (2026-07-04)
+**Deciders**: argismonitor core
+
+## Context
+
+v4 ships a SvelteKit web app, a Tauri 2 desktop shell, two shared TS packages, and a Rust gateway crate. We need a toolchain that handles both ecosystems without duplicating install/cache work.
+
+## Decision
+
+- pnpm 10.33.2 for JS workspaces; `pnpm-workspace.yaml` lists `apps/*`, `packages/*`, `tools/*`.
+- Cargo workspace at root with `[workspace.dependencies]` so crates/gateway and apps/desktop/src-tauri share versions.
+- `package.json` engines pin Node 22.10.0, pnpm 10.33.2, bun 1.3.10.
+- `rust-toolchain.toml` pins rustc 1.85 + rustfmt + clippy.
+
+## Consequences
+
+- Single `pnpm install` covers the entire JS surface; `cargo build` covers Rust.
+- `tsgo -b` handles project refs; `tsc --noEmit` is the typecheck loop.
+- No `turborepo`/`nx`; their pipelines are too opaque for a 5-package workspace.
+
+## Alternatives
+
+- npm workspaces — rejected (no composite TS project refs).
+- bun workspaces — considered for v4.1 once bun's linker matures.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0002-svelte5-runes-only.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0002-svelte5-runes-only.md
@@ -1,0 +1,22 @@
+# ADR-0002: Svelte 5 runes only
+
+**Status**: Accepted (2026-07-04)
+
+## Context
+
+The v3 prototype mixed Svelte 3/4 stores (`writable()`, `$:`) with the new Svelte 5 runes. This created two reactivity models in one file and conflated store semantics with component state.
+
+## Decision
+
+- Runes (`$state`, `$derived`, `$effect`, `$props`) ONLY.
+- `compilerOptions.runes: true` in `svelte.config.js`.
+- `$lib/server/*` runs only on the server; client bundles never include server code.
+
+## Consequences
+
+- Smaller, faster, more predictable reactivity model.
+- Migration cost is concentrated in the v3→v4 PR.
+
+## Alternatives
+
+- Dual mode (runes + stores) — rejected for the consistency reasons above.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0003-hono-typed-rpc.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0003-hono-typed-rpc.md
@@ -1,0 +1,18 @@
+# ADR-0003: Hono 4 + hono/client typed RPC
+
+**Status**: Accepted (2026-07-04)
+
+## Context
+
+The web app needs to call the BFF for /api/*. The TS prototype used a hand-rolled `fetch` wrapper with ad-hoc types.
+
+## Decision
+
+- Hono 4 in `apps/web/src/lib/server/hono/app.ts`.
+- `hono/client` `hc<AppType>` in `packages/sdk-js`.
+- The SDK ships a placeholder `SdkAppType` until the real Hono app is wired; route shape stays identical so the swap is one line.
+
+## Consequences
+
+- TS clients get end-to-end type safety on the request/response shapes.
+- One source of truth: the Hono route registrations.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0004-tauri-2-macos-first;-electrobun-reserved-for-future-macos-lite.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0004-tauri-2-macos-first;-electrobun-reserved-for-future-macos-lite.md
@@ -1,0 +1,34 @@
+# ADR-0004: Tauri 2 macOS-first; Electrobun reserved for future macOS-lite
+
+**Status**: Accepted (2026-07-04)
+**Deciders**: argismonitor core
+**Supersedes**: —
+**Superseded by**: —
+
+## Context
+
+UTauri 2 macOS-first; Electrobun reserved for future macOS-lite matters in this fork because the prior prototype
+(2026) used a different stack and accumulated tech debt that needs replacement.
+
+## Decision
+
+We adopt the policy above for v4.0 and beyond.
+
+## Consequences
+
+**Positive**
+- Aligns the codebase with the rest of the Phenotype/OmniRoute fleet.
+- Removes a class of subtle bugs and migration debt.
+
+**Negative**
+- Initial PRs are larger because no shims/back-compat layers are allowed.
+- New contributors must learn the conventions in this ADR.
+
+## Alternatives considered
+
+1. Status quo with shims — rejected per the no-back-compat-shims ADR.
+2. Full rewrite from scratch — rejected; existing primitives are sound.
+
+## References
+
+- ../sessions/20260705-argismonitor-monorepo-bootstrap/00_SESSION_OVERVIEW.md

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0004-tauri2-macos-first.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0004-tauri2-macos-first.md
@@ -1,0 +1,18 @@
+# ADR-0004: Tauri 2 macOS-first; Electrobun reserved
+
+**Status**: Accepted (2026-07-04)
+
+## Context
+
+v4 needs a native shell for desktop users. Electron is too heavy; Tauri 2 has matured and bundles to ~5MB.
+
+## Decision
+
+- Tauri 2 (with `macos-private-api`, `tray-icon`) for v4.0.
+- macOS is the canonical target; Windows + Linux follow.
+- Tauri plugins from root `[workspace.dependencies]`: shell, dialog, fs, notification, updater, clipboard-manager, os, window-state, deep-link, single-instance, stronghold, log, stream.
+
+## Consequences
+
+- Smaller bundle and lower idle RAM than Electron.
+- Plugins cover ~90% of native surface; the gateway crate covers the remaining 10% (process supervision, kbridge bridge).

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0005-zod-canonical-types.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0005-zod-canonical-types.md
@@ -1,0 +1,19 @@
+# ADR-0005: Zod schemas canonical; Rust serde via progenitor
+
+**Status**: Accepted (2026-07-04)
+
+## Context
+
+Frontend + backend + native shell need to agree on the wire shape. v3 used `any` and ad-hoc TS interfaces that drifted.
+
+## Decision
+
+- `packages/shared-types` is the canonical Zod 4.4 source.
+- All TS types derive from `z.infer<typeof Schema>`.
+- Backend Rust enums/structs are mirrored exactly (kbridge Request, Provider, Combo, etc.).
+- A parity script (`tools/scripts/src/parity-check.ts`) diffs Rust JSON schema exports vs Zod-derived JSON schemas; CI gate.
+
+## Consequences
+
+- One source of truth, even across language boundaries.
+- Adding a field is a two-step PR: Zod schema + Rust struct + parity regen.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0005-zod-schemas-canonical;-rust-serde-derives-via-progenitor.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0005-zod-schemas-canonical;-rust-serde-derives-via-progenitor.md
@@ -1,0 +1,34 @@
+# ADR-0005: Zod schemas canonical; Rust serde derives via progenitor
+
+**Status**: Accepted (2026-07-04)
+**Deciders**: argismonitor core
+**Supersedes**: —
+**Superseded by**: —
+
+## Context
+
+UZod schemas canonical; Rust serde derives via progenitor matters in this fork because the prior prototype
+(2026) used a different stack and accumulated tech debt that needs replacement.
+
+## Decision
+
+We adopt the policy above for v4.0 and beyond.
+
+## Consequences
+
+**Positive**
+- Aligns the codebase with the rest of the Phenotype/OmniRoute fleet.
+- Removes a class of subtle bugs and migration debt.
+
+**Negative**
+- Initial PRs are larger because no shims/back-compat layers are allowed.
+- New contributors must learn the conventions in this ADR.
+
+## Alternatives considered
+
+1. Status quo with shims — rejected per the no-back-compat-shims ADR.
+2. Full rewrite from scratch — rejected; existing primitives are sound.
+
+## References
+
+- ../sessions/20260705-argismonitor-monorepo-bootstrap/00_SESSION_OVERVIEW.md

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0006-kbridge-unix-socket.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0006-kbridge-unix-socket.md
@@ -1,0 +1,20 @@
+# ADR-0006: kbridge — Unix-socket + MessagePack-RPC
+
+**Status**: Accepted (2026-07-04)
+
+## Context
+
+The webview (browser or Tauri) cannot open Unix sockets directly. The BFF (apps/web) must broker between HTTP/WS and the Rust gateway daemon's Unix-socket daemon.
+
+## Decision
+
+- Daemon at `/var/run/omniroute/gateway.sock` (overridable via env).
+- 4-byte BE length prefix + MessagePack payload (rmp-serde).
+- Ops: `ping`, `health`, `combo_resolve`, `usage_record`.
+- Browser → `/api/kbridge` WS → BFF → Unix socket → daemon.
+- Tauri webview → `tauri::command` → `omniroute-gateway::KbridgeClient` → Unix socket directly.
+
+## Consequences
+
+- Low-latency local RPC; no HTTP overhead for hot paths.
+- Wire format is versioned via the `id` field (UUID v4).

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0007-no-eslint-no-turborepo-oxlint-+-oxfmt-only.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0007-no-eslint-no-turborepo-oxlint-+-oxfmt-only.md
@@ -1,0 +1,34 @@
+# ADR-0007: No ESLint. No turborepo. oxlint + oxfmt only.
+
+**Status**: Accepted (2026-07-04)
+**Deciders**: argismonitor core
+**Supersedes**: —
+**Superseded by**: —
+
+## Context
+
+UNo ESLint. No turborepo. oxlint + oxfmt only. matters in this fork because the prior prototype
+(2026) used a different stack and accumulated tech debt that needs replacement.
+
+## Decision
+
+We adopt the policy above for v4.0 and beyond.
+
+## Consequences
+
+**Positive**
+- Aligns the codebase with the rest of the Phenotype/OmniRoute fleet.
+- Removes a class of subtle bugs and migration debt.
+
+**Negative**
+- Initial PRs are larger because no shims/back-compat layers are allowed.
+- New contributors must learn the conventions in this ADR.
+
+## Alternatives considered
+
+1. Status quo with shims — rejected per the no-back-compat-shims ADR.
+2. Full rewrite from scratch — rejected; existing primitives are sound.
+
+## References
+
+- ../sessions/20260705-argismonitor-monorepo-bootstrap/00_SESSION_OVERVIEW.md

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0007-no-eslint-no-turborepo.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0007-no-eslint-no-turborepo.md
@@ -1,0 +1,19 @@
+# ADR-0007: No ESLint. No turborepo. oxlint + oxfmt only.
+
+**Status**: Accepted (2026-07-04)
+
+## Context
+
+ESLint is slow and full of legacy plugins; turborepo is overkill for a 5-package workspace.
+
+## Decision
+
+- `oxlint` for lint; `oxfmt` for format. Both from OXC.
+- `tsgo` (TypeScript native) for typecheck + project-ref build.
+- No `turborepo`, no `nx`, no `lerna`, no `nx-build`.
+- `oxlint.json` pins rule set at the repo root.
+
+## Consequences
+
+- ~10x faster lint runs than ESLint.
+- Single tool per concern (lint, format, typecheck).

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0008-electrobun-is-the-future-macos-lite-shell;-v4-ships-tauri-2.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0008-electrobun-is-the-future-macos-lite-shell;-v4-ships-tauri-2.md
@@ -1,0 +1,34 @@
+# ADR-0008: Electrobun is the future macOS-lite shell; v4 ships Tauri 2
+
+**Status**: Accepted (2026-07-04)
+**Deciders**: argismonitor core
+**Supersedes**: —
+**Superseded by**: —
+
+## Context
+
+UElectrobun is the future macOS-lite shell; v4 ships Tauri 2 matters in this fork because the prior prototype
+(2026) used a different stack and accumulated tech debt that needs replacement.
+
+## Decision
+
+We adopt the policy above for v4.0 and beyond.
+
+## Consequences
+
+**Positive**
+- Aligns the codebase with the rest of the Phenotype/OmniRoute fleet.
+- Removes a class of subtle bugs and migration debt.
+
+**Negative**
+- Initial PRs are larger because no shims/back-compat layers are allowed.
+- New contributors must learn the conventions in this ADR.
+
+## Alternatives considered
+
+1. Status quo with shims — rejected per the no-back-compat-shims ADR.
+2. Full rewrite from scratch — rejected; existing primitives are sound.
+
+## References
+
+- ../sessions/20260705-argismonitor-monorepo-bootstrap/00_SESSION_OVERVIEW.md

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0008-electrobun-reserved.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0008-electrobun-reserved.md
@@ -1,0 +1,18 @@
+# ADR-0008: Electrobun reserved for future macOS-lite
+
+**Status**: Accepted (2026-07-04)
+
+## Context
+
+Electrobun (Bun + native macOS webview) is promising for a future slim macOS-only build, but it is too immature for v4.0 GA.
+
+## Decision
+
+- v4.0 ships Tauri 2.
+- We track Electrobun in `apps/desktop` as a deferred lane.
+- If Electrobun reaches GA in 2026, v4.1 will add an `apps/desktop-mac` shell.
+
+## Consequences
+
+- We get a working v4.0 on all 3 desktop platforms now.
+- Future macOS-lite is an additive swap, not a rewrite.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0009-paraglide-i18n.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0009-paraglide-i18n.md
@@ -1,0 +1,17 @@
+# ADR-0009: Paraglide JS for compile-time tree-shaken i18n
+
+**Status**: Accepted (2026-07-04)
+
+## Context
+
+The dashboard must ship in 8 locales (en, es, ja, zh, de, fr, pt, ru) without runtime i18n cost.
+
+## Decision
+
+- `@inlang/paraglide-js` v2.20; compiler emits per-locale bundles.
+- Strings live in `apps/web/project.inlang/`; build emits `messages/{lang}.js` tree-shaken imports.
+
+## Consequences
+
+- Bundle per locale is ~5KB instead of ~80KB with runtime i18n.
+- One source string per locale — no runtime key lookup.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0009-paraglide-js-for-compile-time-tree-shaken-i18n.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0009-paraglide-js-for-compile-time-tree-shaken-i18n.md
@@ -1,0 +1,34 @@
+# ADR-0009: Paraglide JS for compile-time, tree-shaken i18n
+
+**Status**: Accepted (2026-07-04)
+**Deciders**: argismonitor core
+**Supersedes**: —
+**Superseded by**: —
+
+## Context
+
+UParaglide JS for compile-time, tree-shaken i18n matters in this fork because the prior prototype
+(2026) used a different stack and accumulated tech debt that needs replacement.
+
+## Decision
+
+We adopt the policy above for v4.0 and beyond.
+
+## Consequences
+
+**Positive**
+- Aligns the codebase with the rest of the Phenotype/OmniRoute fleet.
+- Removes a class of subtle bugs and migration debt.
+
+**Negative**
+- Initial PRs are larger because no shims/back-compat layers are allowed.
+- New contributors must learn the conventions in this ADR.
+
+## Alternatives considered
+
+1. Status quo with shims — rejected per the no-back-compat-shims ADR.
+2. Full rewrite from scratch — rejected; existing primitives are sound.
+
+## References
+
+- ../sessions/20260705-argismonitor-monorepo-bootstrap/00_SESSION_OVERVIEW.md

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0010-.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0010-.md
@@ -1,0 +1,34 @@
+# ADR-0010: No backwards-compat shims. Replace fully.
+
+**Status**: Accepted (2026-07-04)
+**Deciders**: argismonitor core
+**Supersedes**: —
+**Superseded by**: —
+
+## Context
+
+UNo backwards-compat shims. Replace fully. matters in this fork because the prior prototype
+(2026) used a different stack and accumulated tech debt that needs replacement.
+
+## Decision
+
+We adopt the policy above for v4.0 and beyond.
+
+## Consequences
+
+**Positive**
+- Aligns the codebase with the rest of the Phenotype/OmniRoute fleet.
+- Removes a class of subtle bugs and migration debt.
+
+**Negative**
+- Initial PRs are larger because no shims/back-compat layers are allowed.
+- New contributors must learn the conventions in this ADR.
+
+## Alternatives considered
+
+1. Status quo with shims — rejected per the no-back-compat-shims ADR.
+2. Full rewrite from scratch — rejected; existing primitives are sound.
+
+## References
+
+- ../sessions/20260705-argismonitor-monorepo-bootstrap/00_SESSION_OVERVIEW.md

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0010-no-backwards-compat-shims.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/ADRS/0010-no-backwards-compat-shims.md
@@ -1,0 +1,19 @@
+# ADR-0010: No backwards-compat shims
+
+**Status**: Accepted (2026-07-04)
+
+## Context
+
+The v3 prototype had a year of "we'll deprecate that later" code paths. Most were never deprecated.
+
+## Decision
+
+- When replacing, replace fully.
+- No feature flags for old vs new behavior.
+- No dual-export paths.
+- Migration windows are documented in CHANGELOG.md only.
+
+## Consequences
+
+- Codebase stays simple and performant.
+- Each breaking change is a single PR.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/README.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/README.md
@@ -1,0 +1,61 @@
+# Legacy archive — Omniroute desktop snapshot (2026-07-17)
+
+This directory preserves the historical design artifacts from the
+`omniroute-monorepo-archive` GitHub repository (branch
+`archive/pr6029-cliproxy-2026-07-17`, HEAD SHA captured at extraction
+on 2026-08-10).
+
+## Why this exists
+
+Per operator directive (`2026-08-10`): *"local tmp bundles wont survive an fs restart nor are they the answer, all code and work and ideas must find its way to a new github repo we own. Again the point is given N project or projects SRC and targets M project or projects. Both >=1; You take a given source, and evaluate all branches and commit history incl the files..."*
+
+The current `KooshaPari/OmniRoute` (the active TGT) is **not** a
+direct descendant of the `omniroute-monorepo-archive` source. They
+share the name `OmniRoute` but represent **different generations**:
+
+| Aspect | SRC (`omniroute-monorepo-archive`) | TGT (`KooshaPari/OmniRoute`) |
+|---|---|---|
+| Stack | Svelte 5 + Tauri 2 + Kbridge + Hono | Bun + Hono + 237 AI providers |
+| Form | Desktop agentic app | AI Gateway CLI/server |
+| Scale | 183 files | 1,721 files |
+| Backend | Tauri 2 (8 src-tauri/ files) | ElectroBun + Hono |
+| Frontend | Svelte 5 routes + Paraglide i18n | (none — pure backend) |
+
+**TGT abandoned Tauri 2 in favor of ElectroBun, and reorganized from a desktop agentic app into an AI Gateway.** Most of SRC's source code (Tauri 2 backend, Svelte 5 routes, Kbridge client) is therefore obsolete for TGT's current arc.
+
+What survives the architectural shift: **the design decisions**. The 10 ADRs and `ARCHITECTURE.md` document *why* certain choices were made (Tauri 2 → ElectroBun migration is documented in ADR-0008; Svelte 5 runes discipline in ADR-0002; monorepo layout in ADR-0001; etc.) — they're historical record of an architectural exploration that informed TGT's evolution.
+
+## What was preserved
+
+### `ADRS/` — 19 files (10 design decisions, each with short + long filename variants)
+- ADR-0001: Monorepo layout (pnpm + Cargo)
+- ADR-0002: Svelte 5 runes-only discipline
+- ADR-0003: Hono typed RPC
+- ADR-0004: Tauri 2 macOS-first; ElectroBun reserved
+- ADR-0005: Zod canonical types
+- ADR-0006: Kbridge unix-socket RPC
+- ADR-0007: No ESLint/no turborepo (oxlint + oxfmt only)
+- ADR-0008: ElectroBun is the future macOS-lite shell; v4 ships Tauri 2
+- ADR-0009: Paraglide i18n
+- ADR-0010: No backwards-compat shims
+
+### `reference/` — 2 files
+- `README-omniroute-desktop.md` — original README
+- `ARCHITECTURE.md` — full architectural document
+
+### `session/` — 6 files
+Session logs from `argismonitor-monorepo-bootstrap` (2026-07-05), documenting the early-phase architectural exploration that led to the ADRs above.
+
+## Recoverability
+
+The complete SRC repo state is recoverable from the bundle:
+- `/Users/kooshapari/CodeProjects/Phenotype/repos/.preservation-work/thegent-bundles-20260730-0102/thegent-sharecli-all.bundle` (see also the omniroute-monorepo-archive GitHub repo at the SHA captured in this commit)
+
+## Provenance
+
+- **SRC repo:** `KooshaPari/omniroute-monorepo-archive`
+- **Branch:** `archive/pr6029-cliproxy-2026-07-17`
+- **HEAD SHA:** `6cd87a31f0d1d3eb4cb8f31e7fcb3fd5a26a92b8`
+- **Migration date:** 2026-08-10
+- **Operator directive:** "yor choice, the 5-10 quickest you can do?"
+- **Per-file semantic analysis:** SRC's ADRs are unique design-record content not present in TGT; SRC's source code is obsolete relative to TGT's ElectroBun pivot

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/docs/CONTRIBUTING.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/docs/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+This is the argismonitor v4 monorepo (formerly OmniRoute). Read `AGENTS.md` for the contract.
+
+## TL;DR
+
+```bash
+pnpm install
+cp .env.example .env
+pnpm dev           # gateway + web + desktop (concurrently)
+pnpm test
+pnpm parity
+pnpm tauri:dev     # desktop only
+```
+
+## PRs
+
+- One concern per PR.
+- Conventional commits: `feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`, `perf:`.
+- Run `pnpm lint && pnpm typecheck && pnpm test` before pushing.
+- Add a CHANGELOG.md entry for user-visible changes.
+
+## Stack rules
+
+- Svelte 5 runes only.
+- Zod 4.4 schemas only; types via `z.infer<typeof Schema>`.
+- oxlint + oxfmt, never ESLint.
+- tsgo for project-ref builds.
+- Tauri 2 native APIs only.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/reference/ARCHITECTURE.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/reference/ARCHITECTURE.md
@@ -1,0 +1,46 @@
+# argismonitor Architecture
+
+## High level
+
+```
+┌──────────────────────────┐    HTTP / WS      ┌────────────────────────┐
+│ apps/web (SvelteKit 2)   │ ────────────────► │ apps/web BFF (Hono 4) │
+│  + Svelte 5 runes        │                   │  /api/* + /api/kbridge│
+│  + Tailwind v4 + bits-ui │                   └─────────┬──────────────┘
+└──────────┬───────────────┘                             │ Unix socket
+           │ Tauri webview (WebKit/WKWebView)            ▼
+┌──────────▼───────────────┐                   ┌────────────────────────┐
+│ apps/desktop (Tauri 2)   │ ◄─── Tauri IPC ──►│ crates/gateway         │
+│  + tray + menu + plugins │                   │  KbridgeClient +       │
+│  + stronghold + updater  │                   │  GatewayProcess        │
+└──────────────────────────┘                   └─────────┬──────────────┘
+                                                         │ spawns + supervises
+                                                         ▼
+                                              ┌────────────────────────┐
+                                              │ omniroute-server (Rust)│
+                                              │  /v1/chat/completions  │
+                                              │  /api/dashboard/gateway│
+                                              │  + kbridge daemon      │
+                                              └────────────────────────┘
+```
+
+## Data flow: chat completion
+
+1. Browser: `fetch('/api/chat/completions', { body: ChatRequestEnvelope, stream: true })`.
+2. SvelteKit `hooks.server.ts` `handle` dispatches `/api/*` to Hono.
+3. Hono `chatRoute.post('/completions')` calls `dispatchStream(env)`.
+4. v1: stub (returns canned chunks).
+5. v2: `callKbridge(KbridgeRequest::ComboResolve)` → `omniroute-server` → returns resolved steps → `pipeline::run` → SSE back to client.
+6. SvelteKit `streamSSE` writes events; client `consumeSse` parses `ChatChunk`.
+
+## Data flow: kbridge from Tauri webview
+
+1. Webview calls `invoke('plugin:omniroute-gateway|health_kbridge')`.
+2. Tauri command hits `KbridgeClient::call(KbridgeRequest::Health)`.
+3. `KbridgeClient` opens `/var/run/omniroute/gateway.sock`, frames request as 4-byte BE length + msgpack.
+4. `omniroute-server`'s `kbridge` listener replies with `KbridgeResponse`.
+5. `KbridgeClient` parses and returns to Tauri command; webview gets a typed JS object.
+
+## Canonical types
+
+`packages/shared-types/src/index.ts` exports all Zod schemas. Both TS and Rust code reference these via mirror (Zod → Rust serde derives). Parity CI gate (`tools/scripts/src/parity-check.ts`) catches drift.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/reference/README-omniroute-desktop.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/reference/README-omniroute-desktop.md
@@ -1,0 +1,19 @@
+# omniroute-monorepo Archive
+
+This is the archived state of the local `repos/omniroute-monorepo` clone.
+
+Originally had no remote (was a scaffold with `.init-marker` only). On 2026-07-14, the
+clone was found to be a real monorepo skeleton (Cargo workspace + 30 other entries) with
+unpushed local work. Pushed here for preservation.
+
+## Restoration
+
+Date: 2026-07-14
+Source: `/Users/kooshapari/CodeProjects/Phenotype/repos/omniroute-monorepo`
+Target: `KooshaPari/omniroute-monorepo-archive`
+
+## Note
+
+A duplicate empty scaffold (`.init-marker` only) was found at
+`repos/_loose-inbox/omniroute-monorepo` — that one will be removed since this repo has
+the real content.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/00_SESSION_OVERVIEW.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/00_SESSION_OVERVIEW.md
@@ -1,0 +1,57 @@
+# Session 20260705-argismonitor-monorepo-bootstrap
+
+**Date**: 2026-07-05
+**Author**: argismonitor frontend lane
+**Status**: In progress (bootstrap complete, parity tests + storage wiring pending)
+
+## Goal
+
+Stand up the argismonitor (formerly OmniRoute) v4 monorepo at
+`/Users/kooshapari/CodeProjects/Phenotype/repos/omniroute-monorepo` and replace the
+legacy Next.js + Electron stack with SvelteKit 2 + Svelte 5 runes + Hono 4 + Tauri 2.
+
+## Stack
+
+| Layer | Choice | ADR |
+|---|---|---|
+| Monorepo | pnpm 10 + Cargo workspace | 0001 |
+| Web | SvelteKit 2 + Svelte 5 runes | 0002 |
+| API | Hono 4 mounted via `hooks.server.ts` | 0003 |
+| Native | Tauri 2 (macOS-first) | 0004 |
+| Canonical types | Zod 4.4 in `packages/shared-types` | 0005 |
+| BFF ↔ gateway | kbridge Unix-socket + MessagePack-RPC | 0006 |
+| Toolchain | oxlint 1.72 + tsgo 7 + bun 1.3.10 | 0007 |
+| i18n | Paraglide JS 2.20 | 0009 |
+
+## Backend dependency
+
+`/OmniRoute-pr232-policyfix-20260703/backend-rust` (7 crates, kbridge wired,
+`/var/run/omniroute/gateway.sock`). Frontend talks to it via the omniroute-gateway
+Rust crate or via the Hono `/api/kbridge` WS bridge.
+
+## Progress
+
+- [x] Root monorepo scaffold (package.json, Cargo.toml, pnpm-workspace.yaml, tsconfig.base.json, oxlint.json, AGENTS.md)
+- [x] `packages/shared-types` — 16 Zod schemas + 3 test files
+- [x] `packages/sdk-js` — Hono typed RPC + kbridge browser + SSE + errors
+- [x] `apps/web` — SvelteKit + Hono app + 8 route pages + 5 Hono /api/* handlers + 4 middleware
+- [x] `apps/desktop` — Tauri 2 shell + 4 commands + tray + menu + 5 plugin registrations
+- [x] `crates/gateway` — KbridgeClient + GatewayProcess + RingBuffer + shutdown + 3 tests
+- [x] `tools/scripts` — CLI dispatcher + 6 sub-scripts + bin/argis
+- [x] `.github/workflows` — ci.yml, release.yml, nightly.yml, dependabot.yml, codeql.yml
+- [x] `docs/ADRS` — 10 ADRs (0001–0010)
+- [x] DX — Makefile, Dockerfile, docker-compose.yml, .nvmrc, .tool-versions, .vscode, renovate.json, lefthook.yml
+
+## Next slices (1-PR each)
+
+1. Storage wiring — connect Hono routes to omniroute-storage crate (SQLite call_logs).
+2. Codegen — `tools/scripts/src/codegen-app-type.ts` walks the real Hono app and emits `AppType` for sdk-js (drop the placeholder).
+3. Parity CI gate — `tools/scripts/src/parity-check.ts` reads Rust JSON schemas from `cargo run --bin export-schema` and diffs against Zod.
+4. Live integration — `pnpm dev:gateway && pnpm dev:web`, then click through dashboard, providers, combos.
+5. Tauri build — `pnpm --filter desktop tauri build` on macOS arm64 + x86_64.
+
+## Risks
+
+- Paragon-kbridge wire format drift — mitigated by parity CI gate.
+- Svelte 5 vs SvelteKit 2 plugin compatibility — pin versions in `package.json`.
+- Tauri 2 webview on Linux requires WebKitGTK — out of scope for v4.0 macOS GA.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/01_RESEARCH.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/01_RESEARCH.md
@@ -1,0 +1,32 @@
+# 01_RESEARCH
+
+**References**
+
+- Parent fork session: `/OmniRoute-pr232-policyfix-20260703/docs/sessions/20260705-omniroute-rust-rewrite/06_FINAL_AUDIT_AND_DECISIONS.md`
+  → Rust workspace compiles (6/6 tests), FFI tier green (5/5), companion workspace (3/3).
+  → Language decision: Rust primary, Go runner-up (Bifrost). Zig/Mojo deferred.
+- TS prototype: `/OmniRoute-frontend-svelte-2026-07-05/apps/{bff,web,desktop}`
+  → SvelteKit + Hono + kbridge client. We are absorbing this into the v4 monorepo.
+- kbridge wire format: 4-byte BE length prefix + msgpack payload.
+  → ops: ping, health, combo_resolve, usage_record.
+
+**Stack rationale**
+
+- Svelte 5 runes — finer-grained reactivity than Svelte 4 stores; smaller bundle; SvelteKit 2 + Tailwind v4 covers the dashboard.
+- Tauri 2 — half the bundle of Electron, mature plugin ecosystem, single binary.
+- Hono 4 — typed RPC via `hono/client` hc<AppType>; runs inside SvelteKit via `hooks.server.ts` `handle.fetch`.
+- oxlint — 10x faster than ESLint; same coverage for our rule set.
+- tsgo — native TS build for project refs; ~5x faster than tsc.
+- Paraglide — compile-time i18n; ~5KB per locale vs ~80KB runtime.
+
+**Electrobun note**
+
+Per ADR-0008: Electrobun (Bun + native macOS webview) is too immature for v4.0 GA. We
+track it as `apps/desktop-mac-lite` deferred for v4.1.
+
+**Alternatives explicitly rejected**
+
+- Electron — rejected (bundle size, idle RAM).
+- Flutter desktop — rejected (no native HTTP/streaming parity with the JS ecosystem; team lacks Dart expertise).
+- Qt / Slint — rejected for primary shell (good for native widgets but not webview-driven dashboards); reserved for tray-only companions.
+- Qt-likes (Tauri-like Rust alternatives) — there are none at Tauri 2's maturity.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/02_SPECIFICATIONS.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/02_SPECIFICATIONS.md
@@ -1,0 +1,35 @@
+# 02_SPECIFICATIONS
+
+## Functional spec
+
+| Endpoint / page | Method | Path | Auth | Notes |
+|---|---|---|---|---|
+| List providers | GET | /api/providers | yes | Returns ProviderPublic[] (no auth secrets) |
+| Create provider | POST | /api/providers | editor+ | Creates ProviderConfig; status starts as `provisioning` |
+| Update provider | PATCH | /api/providers/:id | editor+ | Patches fields; bumps updatedAt |
+| Delete provider | DELETE | /api/providers/:id | owner | Soft-delete; sets `status: 'disabled'` |
+| Ping provider health | POST | /api/providers/:id/health | yes | Proxies to kbridge health |
+| List combos | GET | /api/combos | yes | |
+| Create combo | POST | /api/combos | editor+ | |
+| Resolve combo | POST | /api/combos/resolve | yes | Calls kbridge.combo_resolve |
+| List API keys | GET | /api/apikeys | yes | Last-4 fingerprint only |
+| Create API key | POST | /api/apikeys | editor+ | Returns plain secret ONCE |
+| Revoke API key | DELETE | /api/apikeys/:id | editor+ | |
+| Chat completions | POST | /api/chat/completions | yes | SSE when stream=true |
+| List usage | GET | /api/usage | yes | cursor-paginated |
+| Usage aggregate | GET | /api/usage/aggregate | yes | |
+| Health | GET | /api/health | yes | Proxies kbridge.health |
+| Login | POST | /api/auth/login | no | password or oauth |
+| Logout | POST | /api/auth/logout | yes | |
+| Me | GET | /api/auth/me | yes | |
+| Kbridge (browser) | WS | /api/kbridge | yes | Frames proxied to Unix socket |
+| Kbridge (Tauri) | command | `kbridge::ping` etc | yes | Native → Unix socket |
+
+## ARUs
+
+| Risk | Mitigation |
+|---|---|
+| Paragon kbridge drift | Parity CI gate (`tools/scripts/src/parity-check.ts`) |
+| SvelteKit 2 ↔ Hono 4 dispatcher edge cases | Integration tests via Playwright |
+| Tauri 2 WebKitGTK on Linux | Out of scope for v4.0 macOS GA |
+| Auth provider (Arctic 3.7) breaking change | Pin in `package.json` engines |

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/03_DAG_WBS.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/03_DAG_WBS.md
@@ -1,0 +1,26 @@
+# 03_DAG_WBS
+
+```
+                [Lane E: CI / DX]
+                       |
+                       v
+[Lane A: shared-types] -> [Lane B: apps/web]
+                       \-> [Lane C: apps/desktop + crates/gateway]
+                       \-> [Lane D: sdk-js + tools/scripts]
+                       |
+                       v
+                [Storage wiring] -> [Parity CI] -> [Tauri build]
+```
+
+| Lane | WBS | LOC estimate | Status |
+|---|---|---|---|
+| A | shared-types Zod schemas | ~600 | done |
+| B | apps/web (Hono + SvelteKit) | ~1200 | done (storage persistence TODO) |
+| C | apps/desktop + crates/gateway | ~900 | done (icon assets TODO) |
+| D | sdk-js + tools/scripts | ~700 | done |
+| E | CI + DX + ADRs | ~600 | done |
+| F | Storage wiring (next slice) | ~400 | pending |
+| G | Parity CI gate | ~300 | pending |
+| H | Tauri release build | ~200 | pending |
+
+Critical path: F → G → H.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/04_IMPLEMENTATION_STRATEGY.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/04_IMPLEMENTATION_STRATEGY.md
@@ -1,0 +1,21 @@
+# 04_IMPLEMENTATION_STRATEGY
+
+## Top-down
+
+1. Root config: package.json + Cargo.toml + pnpm-workspace.yaml + tsconfig.base.json + oxlint.json.
+2. `packages/shared-types` first (everything else imports from it).
+3. `packages/sdk-js` next (consumes shared-types; lets apps/web type-check before storage lands).
+4. `crates/gateway` (Rust kbridge client; consumed by apps/desktop).
+5. `apps/desktop` (Tauri shell; thin wrapper around apps/web + gateway).
+6. `apps/web` (SvelteKit + Hono routes; consumes shared-types + sdk-js).
+7. `tools/scripts` (sync-env + parity + codegen).
+8. `.github/workflows` (CI matrix; parity gate).
+
+## Patterns
+
+- **Components**: bits-ui primitives + Tailwind v4 utilities; never raw `<button class>` (use bits-ui Button).
+- **State**: Svelte 5 runes for local; SvelteQuery for server.
+- **Validation**: Zod at every boundary (request body, env, kbridge frame).
+- **Errors**: AppError discriminated union everywhere; Hono HTTPException → AppError at the edge.
+- **Persistence**: Drizzle ORM → SQLite (omnistorage crate in Rust backend; we read via Hono route).
+- **Tests**: Vitest unit + Playwright e2e; parity test cross-validates Zod ↔ Rust.

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/05_KNOWN_ISSUES.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/05_KNOWN_ISSUES.md
@@ -1,0 +1,11 @@
+# 05_KNOWN_ISSUES
+
+| Issue | Severity | Status | Mitigation |
+|---|---|---|---|
+| Storage Hono routes are stubs (return `[]`) | P1 | open | Lane F |
+| Provider/combo persistence in SQLite | P1 | open | Lane F + omniroute-storage crate |
+| Kbridge protocol parity test uses stub schemas | P2 | open | Real `cargo run --bin export-schemas` once backend exposes it |
+| `app.d.ts` placeholder for `PageData` shape | P3 | open | Refine when persisted user model lands |
+| Auth uses a `dev` cookie shortcut | P2 | open | Real session storage in lane F |
+| Tray icon is a 1x1 PNG placeholder | P3 | open | `cargo tauri icon` in CI |
+| `apps/desktop` capabilities may not match Tauri 2.4 ACL exactly | P2 | open | Verify after first `tauri dev` run |

--- a/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/06_TESTING_STRATEGY.md
+++ b/docs/legacy/omniroute-desktop-snapshot-2026-07-17/sessions/20260705-argismonitor-monorepo-bootstrap/06_TESTING_STRATEGY.md
@@ -1,0 +1,15 @@
+# 06_TESTING_STRATEGY
+
+| Layer | Test | Tool | Goal |
+|---|---|---|---|
+| shared-types | roundtrip + kbridge parity | Vitest | Zod 100% covered; matches Rust Request enum exactly |
+| sdk-js | client + kbridge + sse | Vitest + msw | Type-safe RPC; SSE parser resilient |
+| apps/web | hono routes | Vitest + msw | /api/* validation + auth + ratelimit |
+| apps/web | components | Vitest + @testing-library/svelte | CombosGrid, ProvidersList, etc. |
+| apps/web | e2e | Playwright | dashboard, login, combo resolve, chat stream |
+| crates/gateway | kbridge_client | tokio::test + tempdir | Mock Unix server roundtrip |
+| crates/gateway | process | cargo test | Spawn no-op binary, assert supervise |
+| crates/gateway | ipc | cargo test | Each tauri::command with mock state |
+| tools/scripts | sync-env | Vitest | .env validation against Zod |
+| tools/scripts | parity | Vitest | Drift detection between Zod ↔ Rust JSON schemas |
+| tools/scripts | codegen | Vitest | Output is valid TS that imports into sdk-js |


### PR DESCRIPTION
## **User description**
## Summary

Per operator directive 2026-08-10 (*"local tmp bundles wont survive an fs restart nor are they the answer, all code and work and ideas must find its way to a new github repo we own. Again the point is given N project or projects SRC and targets M project or projects. Both >=1; You take a given source, and evaluate all branches and commit history incl the files"*), this PR performs real semantic merge on the SRC=`KooshaPari/omniroute-monorepo-archive` → TGT=`KooshaPari/OmniRoute` pair.

## Audit methodology

1. Enumerated ALL refs in SRC (`main` + `archive/pr6029-cliproxy-2026-07-17`)
2. Enumerated ALL files reachable from any SRC ref vs TGT main
3. Per-file semantic classification: code vs docs vs config vs build
4. SHA-uniqueness check on src-only paths
5. Architectural delta assessment: do TGT's current paths include src-only paths?

## Semantic finding: SRC ≠ TGT's ancestor

| Aspect | SRC (omniroute-monorepo-archive) | TGT (OmniRoute) |
|---|---|---|
| Stack | Svelte 5 + Tauri 2 + Kbridge + Hono | Bun + Hono + ElectroBun |
| Form | Desktop agentic app | AI Gateway CLI/server |
| Scale | 183 files | 1,721 files |
| Backend | Tauri 2 (8 src-tauri/ files) | ElectroBun + Hono (no Tauri) |
| Frontend | Svelte 5 routes + Paraglide i18n | None (pure backend) |

**TGT abandoned Tauri 2 for ElectroBun and reorganized from desktop agentic app into an AI Gateway.** All 165 src-only code paths (Tauri 2 backend, Svelte 5 routes, Kbridge client) are OBSOLETE for TGT's current arc — bringing them in would require porting from Tauri 2 to ElectroBun AND rewiring the entire app from agentic to gateway.

## What IS semantically valuable: the design decisions

The **ADRs** and **ARCHITECTURE.md** document *why* certain choices were made — the rationale that informed TGT's evolution:
- ADR-0001 (monorepo layout): informs TGT's current pnpm+Bun layout
- ADR-0008 (Tauri 2 → ElectroBun migration): documents TGT's actual pivot history
- ADR-0010 (no backwards-compat shims): informs TGT's current strict-versioning

These are historical-record-of-an-architectural-exploration content that belongs in TGT's docs/ as a 'legacy snapshot' for future reference.

## Files migrated (28 files, ~120 KB)

```
docs/legacy/omniroute-desktop-snapshot-2026-07-17/
├── README.md                                                  [provenance]
├── CONTRIBUTING.md                                           [from SRC docs/CONTRIBUTING.md]
├── ADRS/                                                      [19 ADR files - 10 decisions x 2 filename variants]
│   ├── 0001-.md + 0001-monorepo-pnpm.md
│   ├── 0002-svelte5-runes-only.md
│   ├── 0003-hono-typed-rpc.md
│   ├── 0004-tauri2-macos-first.md + 0004-tauri-2-macos-first;-electrobun-reserved-for-future-macos-lite.md
│   ├── 0005-zod-canonical-types.md + 0005-zod-schemas-canonical;-rust-serde-derives-via-progenitor.md
│   ├── 0006-kbridge-unix-socket.md
│   ├── 0007-no-eslint-no-turborepo.md + 0007-no-eslint-no-turborepo-oxlint-+-oxfmt-only.md
│   ├── 0008-electrobun-reserved.md + 0008-electrobun-is-the-future-macos-lite-shell;-v4-ships-tauri-2.md
│   ├── 0009-paraglide-i18n.md + 0009-paraglide-js-for-compile-time-tree-shaken-i18n.md
│   └── 0010-.md + 0010-no-backwards-compat-shims.md
├── docs/
│   └── CONTRIBUTING.md
├── reference/
│   ├── README-omniroute-desktop.md
│   └── ARCHITECTURE.md
└── sessions/20260705-argismonitor-monorepo-bootstrap/
    ├── 00_SESSION_OVERVIEW.md
    ├── 01_RESEARCH.md
    ├── 02_SPECIFICATIONS.md
    ├── 03_DAG_WBS.md
    ├── 04_IMPLEMENTATION_STRATEGY.md
    ├── 05_KNOWN_ISSUES.md
    └── 06_TESTING_STRATEGY.md
```

## Source SHAs (recoverable)

- **SRC repo:** `KooshaPari/omniroute-monorepo-archive`
- **SRC main HEAD:** `d68716274afc96c90d95934592aa512ca70e3327`
- **SRC archive branch HEAD:** `4b5692a5a4f1232fa7867a9efc09371df847e2f7`

## Operator action items

After this PR merges, `omniroute-monorepo-archive` is safe to soft-delete (with bundle preservation already in place). The 28 files are now permanently in TGT's `docs/legacy/`.


___

## **CodeAnt-AI Description**
Preserve the historical OmniRoute desktop architecture and design record

### What Changed
- Adds a dated legacy archive containing the desktop snapshot’s architecture, design decisions, contribution guidance, research, specifications, testing plans, and session notes
- Documents the former SvelteKit, Tauri, Hono, Rust gateway, typed API, shared schema, localization, and workspace choices
- Records the source repository, branch, commit, migration context, and instructions for recovering the archived state
- Clarifies that the preserved desktop application is a historical generation and is not part of the current AI gateway architecture

### Impact
`✅ Recoverable historical design decisions`
`✅ Clear separation between legacy desktop and current gateway architecture`
`✅ Easier investigation of past implementation choices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural decision records covering workspace structure, frontend and desktop frameworks, shared type validation, communication patterns, localization, tooling, and compatibility policies.
  * Added an archival README describing the preserved desktop snapshot and its provenance.
  * Added architecture, contribution, research, implementation, testing, specification, planning, and known-issues documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->