### PR TITLE
fix(runtime): break logger data-path initialization cycle

### DIFF
--- a/src/lib/dataPaths.ts
+++ b/src/lib/dataPaths.ts
@@ -1,10 +1,6 @@
 import path from "path";
 import os from "os";
 import fs from "fs";
-import { createLogger } from "@/shared/utils/logger";
-
-const log = createLogger("lib:data-paths");
-
 export const APP_NAME = "omniroute";
 
 function fallbackHomeDir() {
@@ -103,10 +99,11 @@ export function resolveWritableDataDir({ isCloud = false }: { isCloud?: boolean 
     const code = (err as NodeJS.ErrnoException | null)?.code;
     if (code === "EACCES" || code === "EPERM") {
       const fallback = getDefaultDataDir();
-      log.warn(
-        { resolved, fallback, code },
-        "data-paths: configured DATA_DIR is not writable — falling back to default"
-      );
+      console.warn("data-paths: configured DATA_DIR is not writable; falling back to default", {
+        resolved,
+        fallback,
+        code,
+      });
       return fallback;
     }
     throw err;

--- a/tests/unit/data-paths-import-cycle.test.ts
+++ b/tests/unit/data-paths-import-cycle.test.ts
@@ -1,0 +1,8 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("data paths imports without initializing the logger cycle", async () => {
+  const module = await import("../../src/lib/dataPaths.ts");
+
+  assert.equal(module.APP_NAME, "omniroute");
+});


### PR DESCRIPTION
## Summary

Break the `logger -> logEnv -> dataPaths -> logger` initialization cycle by keeping `dataPaths` independent of the structured logger.

## Verification

- RED: `node --import tsx --test tests/unit/data-paths-import-cycle.test.ts` failed with `Cannot access APP_NAME before initialization`.
- GREEN: the new regression plus `data-dir-writable-fallback` and `logenv-datadir-path-6197` passed (9 tests).
- ESLint and Prettier passed on the two changed files.

This is source/test evidence only; it does not claim a merge, release, signing, or installed-artifact dogfood result.