### PR TITLE
fix(version): remove duplicate GitHub version export

### DIFF
--- a/src/lib/system/versionCheck.ts
+++ b/src/lib/system/versionCheck.ts
@@ -156,32 +156,6 @@ export async function getLatestVersionFromGitHub(
  * warning — instead of silently degrading to "no update available" — when ALL sources fail.
  * Thunks are injectable for tests.
  */
-export async function getLatestVersionFromGitHub(
-  fetchImpl: typeof fetch = fetch
-): Promise<string | null> {
-  try {
-    const res = await fetchImpl(GITHUB_RELEASES_LATEST_URL, {
-      signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
-      headers: {
-        // GitHub's API rejects requests without a User-Agent.
-        "User-Agent": "omniroute-version-check",
-        Accept: "application/vnd.github+json",
-      },
-    });
-    if (!res.ok) return null;
-    const data = (await readBoundedJson(res)) as { tag_name?: unknown };
-    return typeof data?.tag_name === "string" && data.tag_name ? data.tag_name : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Resolve the latest published version. Tries the `npm` CLI first (fast on source installs),
- * then the registry HTTP API, then the GitHub releases API — both npm-binary-free. Logs a
- * warning — instead of silently degrading to "no update available" — when ALL sources fail.
- * Thunks are injectable for tests.
- */
 export function clearLatestVersionCache(): void {
   latestVersionCache = null;
   latestVersionCacheGeneration += 1;


### PR DESCRIPTION
## Summary

Remove the duplicated `getLatestVersionFromGitHub` declaration that blocks module transformation.

## Verification

- RED: `version-compare-client-safe.test.ts` failed because `versionCheck.ts` had duplicate exports.
- GREEN: 4/4 compatibility tests pass after one definition remains.
- ESLint and Prettier pass for `versionCheck.ts`.

Depends on #571 because that branch makes the logger/data-path import path loadable. This is not a release or installed-artifact claim.