### PR TITLE
fix(combo): restore fingerprint target expansion syntax

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -385,32 +385,7 @@ export async function buildAutoCandidates(
       const parsed = parseModel(t.modelStr);
       return t.provider || parsed.provider || parsed.providerAlias || "unknown";
     }
-    const connectionIds = providerConnections
-      .map((c) => (c && typeof c === "object" && typeof c.id === "string" ? c.id : null))
-      .filter((id): id is string => id !== null);
-    const allowedConnectionIds = Array.isArray(target.allowedConnectionIds)
-      ? new Set(
-          target.allowedConnectionIds.filter(
-            (connectionId): connectionId is string =>
-              typeof connectionId === "string" && connectionId.trim().length > 0
-          )
-        )
-      : null;
-    const scopedConnectionIds = allowedConnectionIds
-      ? connectionIds.filter((connectionId) => allowedConnectionIds.has(connectionId))
-      : connectionIds;
-    if (scopedConnectionIds.length === 0) {
-      expandedTargets.push(target);
-      continue;
-    }
-    for (const connectionId of scopedConnectionIds) {
-      expandedTargets.push({
-        ...target,
-        connectionId,
-        executionKey: `${target.executionKey}@${connectionId}`,
-      });
-    }
-  }
+  );
 
   const candidates = await Promise.all(
     fingerprintExpandedTargets.map(async (target) => {


### PR DESCRIPTION
Repairs the malformed fingerprint-expansion call in `open-sse/services/combo.ts` using the exact upstream implementation. The prior source failed parsing before any combo route could build.\n\nValidation: `node --check open-sse/services/combo.ts` passes; focused suite execution is deferred to hosted CI because this archive cannot install dependencies due the unrelated root DOMPurify override conflict.\n\nThis is a dependent CI-recovery PR; it does not claim release readiness.