### PR TITLE
fix(responses): remove duplicate normalized input declaration

### DIFF
--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -207,7 +207,6 @@ export function openaiResponsesToOpenAIRequest(
   // Upstream providers reject messages:[] with "400: at least one message is required".
   // When the client sends input:[] (empty), inject a placeholder user message — mirrors
   // upstream 9router#419 (and the existing empty-string handling elsewhere in this file).
-  const rawInputItems = normalizeResponsesInputForChat(root.input);
   const inputItems: unknown[] =
     rawInputItems.length === 0
       ? [{ type: "message", role: "user", content: [{ type: "input_text", text: "..." }] }]


### PR DESCRIPTION
Removes the second `rawInputItems` declaration in the OpenAI Responses request translator. The normalized input remains computed once and is reused by both tool collection and empty-input handling.\n\nValidation: syntax check, Prettier, esbuild ESM compile, and exact declaration-count assertion pass. This is a dependent release-recovery PR; hosted gates remain authoritative.