### PR TITLE
fix(providers): restore OpenAI registry factory export

### DIFF
--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -150,6 +150,23 @@ export interface RegistryEntry {
   forceStream?: boolean;
 }
 
+/**
+ * Build a standard OpenAI-compatible provider registry entry.
+ * Eliminates the repeated format, executor, and API-key auth boilerplate.
+ */
+export function buildOpenAiCompatibleRegistryEntry(
+  overrides: Pick<RegistryEntry, "id"> &
+    Partial<Omit<RegistryEntry, "id" | "format" | "executor" | "authType" | "authHeader">>
+): RegistryEntry {
+  return {
+    format: "openai",
+    executor: "default",
+    authType: "apikey",
+    authHeader: "bearer",
+    ...overrides,
+  } as RegistryEntry;
+}
+
 export interface LegacyProvider {
   format: string;
   baseUrl?: string;


### PR DESCRIPTION
Restores `buildOpenAiCompatibleRegistryEntry` in the shared provider registry module. Multiple registry providers already import this factory; its absence produced a named-export module-load failure before their tests could run.\n\nValidation: Prettier, node syntax check, ESM compilation with external packages, and a one-factory-export assertion pass. This is a dependent CI-recovery PR; hosted validation remains authoritative.