### PR TITLE
fix(combo): remove stale request-scoped predicate copy

### DIFF
--- a/open-sse/services/combo/comboPredicates.ts
+++ b/open-sse/services/combo/comboPredicates.ts
@@ -64,7 +64,9 @@ export function isRequestScopedUpstreamFailure(error?: {
 }): boolean {
   const code = typeof error?.code === "string" ? error.code.toLowerCase() : "";
   const type = typeof error?.type === "string" ? error.type.toLowerCase() : "";
-  return REQUEST_SCOPED_UPSTREAM_ERROR_CODES.has(code) || REQUEST_SCOPED_UPSTREAM_ERROR_CODES.has(type);
+  return (
+    REQUEST_SCOPED_UPSTREAM_ERROR_CODES.has(code) || REQUEST_SCOPED_UPSTREAM_ERROR_CODES.has(type)
+  );
 }
 
 /**
@@ -199,22 +201,6 @@ export function shouldRecordProviderBreakerFailure(args: {
     !args.requestScopedFailure &&
     !isLocalStreamLifecycleError(args.error)
   );
-}
-
-const REQUEST_SCOPED_UPSTREAM_ERROR_CODES = new Set([
-  "context_length_exceeded",
-  "upstream_empty_response",
-  "upstream_response_failed",
-]);
-
-/** Request/model-specific failures must not poison provider-wide resilience state. */
-export function isRequestScopedUpstreamFailure(error?: {
-  code?: string | null;
-  type?: string | null;
-}): boolean {
-  const code = typeof error?.code === "string" ? error.code.toLowerCase() : "";
-  const type = typeof error?.type === "string" ? error.type.toLowerCase() : "";
-  return REQUEST_SCOPED_UPSTREAM_ERROR_CODES.has(code) || type === "context_length_exceeded";
 }
 
 /** Request-scoped classification that also has access to the HTTP body. */


### PR DESCRIPTION
Removes the older duplicate request-scoped upstream failure predicate while retaining the newer broader policy, including combo-target and stream timeout cases. qgate previously failed module transformation before combo tests could load.\n\nValidation: syntax check, Prettier, ESM compilation, and single declaration/export assertions pass. This dependent recovery PR requires hosted validation.