### PR TITLE
fix(runtime): break logger data-path initialization cycle

### DIFF
--- a/src/lib/dataPaths.ts
+++ b/src/lib/dataPaths.ts
@@ -1,10 +1,6 @@
 import path from "path";
 import os from "os";
 import fs from "fs";
-import { createLogger } from "@/shared/utils/logger";
-
-const log = createLogger("lib:data-paths");
-
 export const APP_NAME = "omniroute";
 
 function fallbackHomeDir() {
@@ -103,10 +99,11 @@ export function resolveWritableDataDir({ isCloud = false }: { isCloud?: boolean 
     const code = (err as NodeJS.ErrnoException | null)?.code;
     if (code === "EACCES" || code === "EPERM") {
       const fallback = getDefaultDataDir();
-      log.warn(
-        { resolved, fallback, code },
-        "data-paths: configured DATA_DIR is not writable — falling back to default"
-      );
+      console.warn("data-paths: configured DATA_DIR is not writable; falling back to default", {
+        resolved,
+        fallback,
+        code,
+      });
       return fallback;
     }
     throw err;

--- a/tests/unit/data-paths-import-cycle.test.ts
+++ b/tests/unit/data-paths-import-cycle.test.ts
@@ -1,0 +1,8 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("data paths imports without initializing the logger cycle", async () => {
+  const module = await import("../../src/lib/dataPaths.ts");
+
+  assert.equal(module.APP_NAME, "omniroute");
+});


### PR DESCRIPTION
Carries the previously validated data-paths cycle repair onto the current CI recovery chain. `dataPaths` is imported while logger initialization resolves its storage path, so it must not call `createLogger` at module scope.\n\nAdds a regression import test and uses a direct warning only on the existing fallback path. Syntax, Prettier, and ESM compilation pass. Hosted qgate remains authoritative.