### PR TITLE
fix(security): remove duplicate outbound URL guard export

### DIFF
--- a/src/shared/network/outboundUrlGuard.ts
+++ b/src/shared/network/outboundUrlGuard.ts
@@ -172,27 +172,6 @@ export function parseAndValidateNonMetadataUrl(input: string | URL) {
   return url;
 }
 
-/**
- * Webhook variant of {@link parseAndValidatePublicUrl}. Webhooks legitimately point at
- * internal services (n8n, Home Assistant, a LAN box) in Docker/self-hosted deployments,
- * so the private-host block is gated behind the same explicit opt-in used for private
- * provider URLs (`OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS`, default OFF). Protocol and
- * embedded-credential checks in {@link parseOutboundUrl} remain unconditional. (#3269)
- */
-export function parseAndValidateNonMetadataUrl(input: string | URL) {
-  const url = parseOutboundUrl(input);
-
-  if (isCloudMetadataHost(url.hostname)) {
-    throw new OutboundUrlGuardError(CLOUD_METADATA_BLOCKED_MESSAGE, {
-      code: "OUTBOUND_URL_GUARD_BLOCKED",
-      url: url.toString(),
-      hostname: url.hostname || null,
-    });
-  }
-
-  return url;
-}
-
 function isTrueValue(raw: unknown): boolean {
   if (typeof raw !== "string") return false;
   return TRUE_ENV_VALUES.has(raw.trim().toLowerCase());


### PR DESCRIPTION
Removes the duplicate `parseAndValidateNonMetadataUrl` declaration while retaining the current security behavior: HTTP(S) protocol and embedded-credential validation plus unconditional cloud metadata blocking.\n\nValidation: syntax check, Prettier, ESM compilation, and a single-export assertion pass. This dependent recovery PR requires hosted validation.