### PR TITLE
fix(antigravity): complete SSE collector extraction

### DIFF
--- a/open-sse/executors/antigravity.ts
+++ b/open-sse/executors/antigravity.ts
@@ -40,8 +40,6 @@ import {
   processAntigravitySSEText,
   flushAntigravitySSEText,
 } from "./antigravity/sseCollect.ts";
-// processAntigravitySSEPayload re-exported for external importers (tests).
-export { processAntigravitySSEPayload } from "./antigravity/sseCollect.ts";
 import {
   type AntigravityCollectedStream,
   processAntigravitySSEText,
@@ -281,89 +279,6 @@ export function markConnectionQuotaExhausted(connectionId: string, retryAfterMs:
   } catch {
     // DB write failure must never crash the request path
   }
-}
-
-/**
- * Accumulate one Antigravity SSE `data:` payload into `collected`. Exported for unit
- * tests (the markdown / candidate-parts extraction branches). @internal
- */
-export function processAntigravitySSEPayload(
-  payload: string,
-  collected: AntigravityCollectedStream,
-  log?: { debug?: (scope: string, message: string) => void }
-) {
-  if (!payload || payload === "[DONE]") return;
-  try {
-    const parsed = JSON.parse(payload);
-    const markdown =
-      typeof parsed?.markdown === "string"
-        ? parsed.markdown
-        : typeof parsed?.response?.markdown === "string"
-          ? parsed.response.markdown
-          : null;
-    if (markdown) {
-      collected.textContent += markdown;
-    }
-    const candidate = parsed?.response?.candidates?.[0];
-    if (candidate?.content?.parts) {
-      for (const part of candidate.content.parts) {
-        if (typeof part.text === "string" && !part.thought && !part.thoughtSignature) {
-          const textualToolCall = parseAntigravityTextualToolCall(part.text);
-          if (textualToolCall) {
-            addAntigravityTextualToolCall(collected, textualToolCall);
-          } else {
-            collected.textContent += part.text;
-          }
-        }
-      }
-    }
-    if (candidate?.finishReason) {
-      collected.finishReason = normalizeOpenAICompatibleFinishReasonString(
-        String(candidate.finishReason).toLowerCase()
-      );
-    }
-    if (parsed?.response?.usageMetadata) {
-      const um = parsed.response.usageMetadata;
-      collected.usage = {
-        prompt_tokens: um.promptTokenCount || 0,
-        completion_tokens: um.candidatesTokenCount || 0,
-        total_tokens: um.totalTokenCount || 0,
-      };
-    }
-    if (Array.isArray(parsed?.remainingCredits)) {
-      collected.remainingCredits = parsed.remainingCredits;
-    }
-  } catch {
-    log?.debug?.("SSE_PARSE", `Skipping malformed SSE line: ${payload.slice(0, 80)}`);
-  }
-}
-
-function processAntigravitySSEText(
-  text: string,
-  partialLine: { value: string },
-  collected: AntigravityCollectedStream,
-  log?: { debug?: (scope: string, message: string) => void }
-) {
-  partialLine.value += text;
-  const lines = partialLine.value.split("\n");
-  partialLine.value = lines.pop() || "";
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed.startsWith("data:")) continue;
-    processAntigravitySSEPayload(trimmed.slice(5).trim(), collected, log);
-  }
-}
-
-function flushAntigravitySSEText(
-  partialLine: { value: string },
-  collected: AntigravityCollectedStream,
-  log?: { debug?: (scope: string, message: string) => void }
-) {
-  const trimmed = partialLine.value.trim();
-  partialLine.value = "";
-  if (!trimmed.startsWith("data:")) return;
-  processAntigravitySSEPayload(trimmed.slice(5).trim(), collected, log);
 }
 
 /**
@@ -747,7 +662,9 @@ export class AntigravityExecutor extends BaseExecutor {
     };
 
     const transformedRequest = isClaude
-      ? stripTrailingAntigravityAssistantTurn(sanitizeAntigravityGeminiRequest(rawTransformedRequest))
+      ? stripTrailingAntigravityAssistantTurn(
+          sanitizeAntigravityGeminiRequest(rawTransformedRequest)
+        )
       : rawTransformedRequest;
 
     applyAntigravityGenerationDefaults(transformedRequest);


### PR DESCRIPTION
Completes the Antigravity SSE collector extraction: retain one host import/re-export from `sseCollect.ts` and remove the stale duplicate host collector implementation. The extracted module preserves textual tool-call parsing, usage, credits, and finish reasons.\n\nValidation: syntax check, Prettier, ESM compile, and exact one-reexport/no-local-collector assertion pass. Hosted tests remain authoritative.