### PR TITLE
fix(sidebar): remove duplicate icon accent helpers

### DIFF
--- a/src/shared/constants/sidebarVisibility.ts
+++ b/src/shared/constants/sidebarVisibility.ts
@@ -77,52 +77,6 @@ export const SIDEBAR_ICON_ACCENTS: Partial<Record<HideableSidebarItemId, string>
   changelog: "#F59E0B",
 };
 
-export const SIDEBAR_SUBITEM_ICON_ACCENTS: Record<string, string> = {};
-
-function getDeterministicIconAccent(id: string): string {
-  let hash = 0;
-  for (let index = 0; index < id.length; index += 1) {
-    hash = (hash * 31 + id.charCodeAt(index)) >>> 0;
-  }
-  const hue = hash % 360;
-  const saturation = 72;
-  const lightness = 56;
-  const chroma = (1 - Math.abs((2 * lightness) / 100 - 1)) * (saturation / 100);
-  const huePrime = hue / 60;
-  const x = chroma * (1 - Math.abs((huePrime % 2) - 1));
-  const match = lightness / 100 - chroma / 2;
-  const [red, green, blue] =
-    huePrime < 1
-      ? [chroma, x, 0]
-      : huePrime < 2
-        ? [x, chroma, 0]
-        : huePrime < 3
-          ? [0, chroma, x]
-          : huePrime < 4
-            ? [0, x, chroma]
-            : huePrime < 5
-              ? [x, 0, chroma]
-              : [chroma, 0, x];
-
-  return [red, green, blue]
-    .map((channel) =>
-      Math.round((channel + match) * 255)
-        .toString(16)
-        .padStart(2, "0")
-        .toUpperCase()
-    )
-    .join("")
-    .replace(/^/, "#");
-}
-
-export function getSidebarIconAccent(id: string): string {
-  return (
-    SIDEBAR_ICON_ACCENTS[id as HideableSidebarItemId] ||
-    SIDEBAR_SUBITEM_ICON_ACCENTS[id] ||
-    getDeterministicIconAccent(id)
-  );
-}
-
 export type SidebarSectionId =
   | "home"
   | "omni-proxy"


### PR DESCRIPTION
## Scope

Remove only the stale duplicate sidebar icon-accent implementation left by a partial extraction. The retained implementation is the current typed `SidebarItemId` variant.

## Validation

- `prettier --check src/shared/constants/sidebarVisibility.ts`
- `esbuild` TypeScript parse/bundle with external packages
- structural assertion: one definition each for the accent map and helpers

## Release safety

Dependent recovery PR; no merge, release, desktop, or dogfood claim.