### PR TITLE
fix(tools): restore known and effective limit contract

### DIFF
--- a/open-sse/services/toolLimitDetector.ts
+++ b/open-sse/services/toolLimitDetector.ts
@@ -18,8 +18,8 @@ if (typeof _detectedLimitsSweep === "object" && "unref" in _detectedLimitsSweep)
   (_detectedLimitsSweep as { unref?: () => void }).unref?.();
 }
 
-export function getEffectiveToolLimit(provider: string): number {
-  const proactiveLimit = PROVIDER_TOOL_LIMITS[provider];
+export function getKnownToolLimit(provider: string | null | undefined): number | null {
+  const proactiveLimit = provider ? PROVIDER_TOOL_LIMITS[provider] : undefined;
   if (proactiveLimit !== undefined) {
     return proactiveLimit;
   }


### PR DESCRIPTION
## Scope

Repair the partial extraction that declared `getEffectiveToolLimit` twice. The known limit may return `null`; the effective limit wraps it with the configured default, matching upstream and existing tests.

## Validation

- `prettier --check open-sse/services/toolLimitDetector.ts`
- TypeScript-aware `esbuild` ESM compile
- compiled-artifact `node --check`
- structural assertion: one known limit and one effective default API

## Release safety

Dependent recovery PR; hosted validation, review, merge, release signing, and installed desktop dogfood remain required.