### PR TITLE
fix(oauth): restore coherent Antigravity provider

### DIFF
--- a/src/lib/oauth/providers/antigravity.ts
+++ b/src/lib/oauth/providers/antigravity.ts
@@ -7,19 +7,24 @@ import {
   getAntigravityOAuthUserAgent,
 } from "@omniroute/open-sse/services/antigravityHeaders.ts";
 import { extractCodeAssistOnboardTierId } from "@omniroute/open-sse/services/codeAssistSubscription.ts";
-import { createLogger } from "@/shared/utils/logger";
 
-// Bound every Antigravity post-exchange call. Without this an unreachable/slow
-// upstream made the `/exchange` request (and therefore the whole OAuth login)
-// hang forever — the dashboard "just spins". Mirrors the AbortSignal.timeout
-// pattern already used by antigravityProjectBootstrap.ts.
 const POSTEXCHANGE_TIMEOUT_MS = 8_000;
+
+type AntigravityOAuthConfig = typeof ANTIGRAVITY_CONFIG;
+type AntigravityTokenPayload = {
+  access_token: string;
+  expires_in?: number;
+  refresh_token?: string;
+  scope?: string;
+};
+type AntigravityPostExchange = {
+  projectId: string;
+  tierId: string;
+  userInfo: { email?: string };
+};
 
 async function fetchFirstOk(endpoints: string[], init: RequestInit, timeoutMs?: number) {
   let lastError: unknown = null;
-  // One shared deadline for the WHOLE fallback list — a stalled set of endpoints
-  // must bound to a single timeout, not timeoutMs × endpoints (that re-introduced
-  // a ~40s login wait). A reachable endpoint still returns immediately.
   const signal = timeoutMs ? AbortSignal.timeout(timeoutMs) : init.signal;
   for (const endpoint of endpoints) {
     try {
@@ -33,44 +38,14 @@ async function fetchFirstOk(endpoints: string[], init: RequestInit, timeoutMs?: 
   throw lastError || new Error("No Antigravity endpoints configured");
 }
 
-export const antigravity = {
-  config: ANTIGRAVITY_CONFIG,
-  // NO PKCE. The embedded Antigravity client is a Google "Desktop/native" OAuth client;
-  // sending a PKCE code_challenge (combined with the openid scope) pushed Google into the
-  // `signin/oauth/firstparty/nativeapp` consent flow that hangs and never redirects back
-  // (operator report 2026-06-27). The working 9router flow uses a plain authorization_code
-  // grant with client_secret and no code_challenge — match it exactly. The token exchange
-  // already sends client_secret (ANTIGRAVITY_OAUTH_CLIENT_SECRET) and omits code_verifier.
-  flowType: "authorization_code",
-  buildAuthUrl: (config, redirectUri, state, codeChallenge) => {
-    const params = new URLSearchParams({
-      client_id: config.clientId,
-      response_type: "code",
-      redirect_uri: redirectUri,
-      scope: config.scopes.join(" "),
-      state: state,
-      access_type: "offline",
-      prompt: "consent",
-    });
-    if (codeChallenge) {
-      params.set("code_challenge", codeChallenge);
-      params.set("code_challenge_method", "S256");
-    }
-    return `${config.authorizeUrl}?${params.toString()}`;
-  },
-  // NOTE: no PKCE. Antigravity is a plain authorization_code grant now (see flowType
-  // above). The shared generateAuthData() still mints a codeVerifier for every flow, but
-  // we MUST NOT forward it here — the authorize URL carries no code_challenge, so sending
-  // a code_verifier makes Google reject the exchange with invalid_grant ("code_verifier
-  // provided but code_challenge was not"), surfacing as a 500 on /exchange. Ignore it and
-  // authenticate with client_secret only, exactly like the working 9router flow.
-  exchangeToken: async (config, code, redirectUri) => {
-    const bodyParams: Record<string, string> = {
-      grant_type: "authorization_code",
-      client_id: config.clientId,
-      code: code,
-      redirect_uri: redirectUri,
-    };
+function getPostExchangeHeaders(
+  profile: AntigravityClientProfile,
+  accessToken: string
+): Record<string, string> {
+  return profile === "cli"
+    ? getAntigravityContentHeaders("cli", accessToken)
+    : getAntigravityIdeNodeHeaders(accessToken);
+}
 
 function buildAntigravityAuthUrl(
   config: AntigravityOAuthConfig,
@@ -94,15 +69,34 @@ function buildAntigravityAuthUrl(
   return `${config.authorizeUrl}?${params.toString()}`;
 }
 
-    const response = await fetch(config.tokenUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Accept: "application/json",
-        "User-Agent": antigravityNativeOAuthUserAgent(),
-      },
-      body: new URLSearchParams(bodyParams),
-    });
+async function exchangeAntigravityToken(
+  config: AntigravityOAuthConfig,
+  clientProfile: AntigravityClientProfile,
+  code: string,
+  redirectUri: string
+): Promise<AntigravityTokenPayload> {
+  const bodyParams: Record<string, string> = {
+    grant_type: "authorization_code",
+    client_id: config.clientId,
+    code,
+    redirect_uri: redirectUri,
+  };
+  if (config.clientSecret) bodyParams.client_secret = config.clientSecret;
+
+  const response = await fetch(config.tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      "User-Agent": getAntigravityOAuthUserAgent(clientProfile),
+    },
+    body: new URLSearchParams(bodyParams),
+  });
+  if (!response.ok) {
+    throw new Error(`Token exchange failed: ${await response.text()}`);
+  }
+  return (await response.json()) as AntigravityTokenPayload;
+}
 
 function extractProjectId(data: Record<string, unknown>): string {
   const project = data.cloudaicompanionProject;
@@ -112,61 +106,78 @@ function extractProjectId(data: Record<string, unknown>): string {
   return typeof id === "string" ? id : "";
 }
 
-    return await response.json();
-  },
-  postExchange: async (tokens) => {
-    const headers = getAntigravityHeaders("loadCodeAssist", tokens.access_token);
-    const metadata = getAntigravityLoadCodeAssistMetadata();
-
-    // Best-effort + bounded: a slow userinfo endpoint must never hang the login.
-    const userInfoRes = await fetch(`${ANTIGRAVITY_CONFIG.userInfoUrl}?alt=json`, {
-      headers: { Authorization: `Bearer ${tokens.access_token}` },
-      signal: AbortSignal.timeout(POSTEXCHANGE_TIMEOUT_MS),
-    }).catch(() => null);
-    const userInfo = userInfoRes?.ok ? await userInfoRes.json() : {};
-
-    let projectId = "";
-    let tierId = "legacy-tier";
+async function onboardAntigravityUser(
+  config: AntigravityOAuthConfig,
+  headers: Record<string, string>,
+  tierId: string,
+  metadata: Record<string, string>
+): Promise<void> {
+  const MAX_ONBOARD_RETRIES = 3;
+  const BASE_RETRY_MS = 3000;
+  const JITTER_MS = 4000;
+  for (let i = 0; i < MAX_ONBOARD_RETRIES; i++) {
     try {
-      const loadRes = await fetchFirstOk(
-        ANTIGRAVITY_CONFIG.loadCodeAssistEndpoints,
-        { method: "POST", headers, body: JSON.stringify({ metadata }) },
+      const response = await fetchFirstOk(
+        config.onboardUserEndpoints,
+        { method: "POST", headers, body: JSON.stringify({ tier_id: tierId, metadata }) },
         POSTEXCHANGE_TIMEOUT_MS
       );
-      const data = await loadRes.json();
-      projectId = data.cloudaicompanionProject?.id || data.cloudaicompanionProject || "";
-      tierId = extractCodeAssistOnboardTierId(data);
-    } catch (e) {
-      console.log("Failed to load code assist:", e);
+      const result = (await response.json()) as { done?: boolean };
+      if (result.done === true) return;
+    } catch {
+      return;
     }
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+    await new Promise((resolve) => setTimeout(resolve, BASE_RETRY_MS + Math.random() * JITTER_MS));
   }
 }
 
-    // Fire-and-forget onboarding — it must NOT block the OAuth login response.
-    // The previous inline `await` loop (up to 10×5s, each fetch un-timed) made the
-    // `/exchange` request hang forever when an upstream was slow/unreachable, so the
-    // dashboard "just spun". Onboarding is also performed lazily at request time by
-    // antigravityProjectBootstrap.ts, so backgrounding it here is safe. Matches the
-    // 9router web flow. (#5180-followup / antigravity login hang)
-    if (projectId) {
-      const onboardInBackground = async () => {
-        for (let i = 0; i < 10; i++) {
-          try {
-            const onboardRes = await fetchFirstOk(
-              ANTIGRAVITY_CONFIG.onboardUserEndpoints,
-              { method: "POST", headers, body: JSON.stringify({ tier_id: tierId, metadata }) },
-              POSTEXCHANGE_TIMEOUT_MS
-            );
-            const result = await onboardRes.json();
-            if (result.done === true) break;
-          } catch {
-            break;
-          }
-          await new Promise((resolve) => setTimeout(resolve, 5000));
-        }
-      };
-      void onboardInBackground().catch(() => {});
+async function postExchangeAntigravity(
+  config: AntigravityOAuthConfig,
+  clientProfile: AntigravityClientProfile,
+  tokens: AntigravityTokenPayload
+): Promise<AntigravityPostExchange> {
+  const headers = getPostExchangeHeaders(clientProfile, tokens.access_token);
+  const metadata = getAntigravityLoadCodeAssistMetadata();
+  const userInfoResponse = await fetch(`${config.userInfoUrl}?alt=json`, {
+    headers: { Authorization: `Bearer ${tokens.access_token}` },
+    signal: AbortSignal.timeout(POSTEXCHANGE_TIMEOUT_MS),
+  }).catch(() => null);
+  const userInfo = userInfoResponse?.ok
+    ? ((await userInfoResponse.json()) as { email?: string })
+    : {};
+
+  let projectId = "";
+  let tierId = "legacy-tier";
+  try {
+    const response = await fetchFirstOk(
+      config.loadCodeAssistEndpoints,
+      { method: "POST", headers, body: JSON.stringify({ metadata }) },
+      POSTEXCHANGE_TIMEOUT_MS
+    );
+    const data = (await response.json()) as Record<string, unknown>;
+    projectId = extractProjectId(data);
+    tierId = extractCodeAssistOnboardTierId(data);
+  } catch (error) {
+    console.log("Failed to load code assist:", error);
+  }
+
+  if (projectId) {
+    void onboardAntigravityUser(config, headers, tierId, metadata).catch(() => {});
+  } else if (config.onboardUserEndpoints.length > 0) {
+    try {
+      await fetchFirstOk(
+        config.onboardUserEndpoints,
+        { method: "POST", headers, body: JSON.stringify({ tier_id: tierId, metadata }) },
+        POSTEXCHANGE_TIMEOUT_MS
+      );
+      const retryResponse = await fetchFirstOk(
+        config.loadCodeAssistEndpoints,
+        { method: "POST", headers, body: JSON.stringify({ metadata }) },
+        POSTEXCHANGE_TIMEOUT_MS
+      );
+      projectId = extractProjectId((await retryResponse.json()) as Record<string, unknown>);
+    } catch {
+      // Lazy request-time bootstrap retries if onboarding or discovery is unavailable.
     }
   }
   return { userInfo, projectId, tierId };


### PR DESCRIPTION
## Scope

Replace a malformed hybrid OAuth provider with the current coherent provider implementation. The hybrid interleaved an obsolete object literal with newer helper functions and could not parse.

The recovered flow uses shared client-profile headers, explicit token-exchange failure handling, bounded post-exchange calls, and bounded background/on-demand onboarding.

## Validation

- `prettier --check src/lib/oauth/providers/antigravity.ts`
- TypeScript-aware `esbuild` ESM compile using repository tsconfig
- compiled-artifact `node --check`
- structural assertion: canonical OAuth functions and one provider export

## Release safety

Dependent recovery PR; hosted validation, review, merge, OAuth integration, release signing, and installed desktop dogfood remain required.