### PR TITLE
fix(combo): remove stale strategy extraction fragments

### DIFF
--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -283,36 +283,6 @@ function quotaRemainingPercentFromQuota(quota: unknown): number {
   return 100;
 }
 
-const QUOTA_BLOCKING_CONNECTION_STATUSES = new Set([
-  "banned",
-  "credits_exhausted",
-  "deactivated",
-  "expired",
-  "rate_limited",
-]);
-
-function normalizeConnectionStatus(value: unknown): string {
-  return typeof value === "string" ? value.trim().toLowerCase() : "";
-}
-
-function hasFutureRateLimitUntil(value: unknown): boolean {
-  if (value == null || value === "") return false;
-  const time = new Date(String(value)).getTime();
-  return Number.isFinite(time) && time > Date.now();
-}
-
-export function getConnectionStatusQuotaCutoffReason(
-  connection: Record<string, unknown> | undefined
-): string | undefined {
-  if (!connection) return undefined;
-  const status = normalizeConnectionStatus(connection.testStatus);
-  if (QUOTA_BLOCKING_CONNECTION_STATUSES.has(status)) return status;
-  if (status === "unavailable" && hasFutureRateLimitUntil(connection.rateLimitedUntil)) {
-    return "rate_limited";
-  }
-  return undefined;
-}
-
 export async function buildAutoCandidates(
   targets: ResolvedComboTarget[],
   comboName: string,
@@ -1519,11 +1489,8 @@ export async function handleComboChat({
       relayOptions,
       resilienceSettings,
       log,
-      buildAutoCandidates,
-    });
-    if ("earlyResponse" in autoResult) return autoResult.earlyResponse;
-    orderedTargets = autoResult.orderedTargets;
-    autoUsedExplicitRouter = autoResult.autoUsedExplicitRouter;
+      buildAutoCandidates
+    );
   } else {
     orderedTargets = await applyStrategyOrdering(strategy, orderedTargets, {
       combo,
@@ -3104,9 +3071,7 @@ async function handleRoundRobinCombo({
   // runtime-unavailable, we must reconsider these before returning 503, instead of
   // permanently dropping a compat-rejected-but-healthy provider.
   const compatKeptSet = new Set(filteredTargets);
-  const compatRejectedTargets = evalRankedTargets.filter(
-    (target) => !compatKeptSet.has(target)
-  );
+  const compatRejectedTargets = evalRankedTargets.filter((target) => !compatKeptSet.has(target));
   const modelCount = filteredTargets.length;
   if (modelCount === 0) {
     const exhaustion = describeCapabilityFilterExhaustion(
@@ -3693,7 +3658,10 @@ async function handleRoundRobinCombo({
           resilienceSettings.providerCooldown.enabled &&
           provider &&
           provider !== "unknown" &&
-          !(result.status === 500 && hasPerModelQuota(provider, parseModel(modelStr).model || modelStr))
+          !(
+            result.status === 500 &&
+            hasPerModelQuota(provider, parseModel(modelStr).model || modelStr)
+          )
         ) {
           recordProviderCooldown(
             provider,


### PR DESCRIPTION
## Scope

Repair two partial-extraction fragments in the core combo service:

- remove an undefined `autoResult` tail mistakenly appended to the positional `reset-aware` call;
- remove stale local quota-cutoff helpers already imported/re-exported from `comboPredicates.ts`.

The defined auto-candidate flow remains unchanged and the leaf-module public API stays exported.

## Validation

- `prettier --check open-sse/services/combo.ts`
- TypeScript-aware `esbuild` ESM compile of the full combo service using repository tsconfig
- compiled-artifact `node --check`
- structural assertions for no stale auto/host helpers and retained leaf re-export

## Release safety

Dependent recovery PR; hosted validation, review, combo behavior tests, merge, release signing, and installed desktop dogfood remain required.