### PR TITLE
fix(theoldllm): restore complete execution results

### DIFF
--- a/open-sse/executors/theoldllm.ts
+++ b/open-sse/executors/theoldllm.ts
@@ -406,8 +406,9 @@ export class TheOldLlmExecutor extends BaseExecutor {
 
       if (upstream.status === 200 && finalBody) {
         const payload = stream ? finalBody : buildChatCompletion(parseSseContent(finalBody), model);
-        return {
-          response: new Response(encoder.encode(payload), {
+        return this.executionResult(
+          input,
+          new Response(encoder.encode(payload), {
             status: 200,
             headers: {
               "Content-Type": stream ? "text/event-stream" : "application/json",
@@ -433,19 +434,19 @@ export class TheOldLlmExecutor extends BaseExecutor {
       const proxyUnavailable = err instanceof TheOldLlmProxyUnavailableError;
       const msg = err instanceof Error ? err.message : String(err);
       log?.error?.("THEOLDLLM", `Executor error: ${msg}`);
-      return {
-        response: new Response(
-          encoder.encode(
-            JSON.stringify({
-              error: { message: msg, type: "upstream_error", code: "EXECUTOR_ERROR" },
-            })
-          ),
-          { status: 502, headers: { "Content-Type": "application/json" } }
-        ),
-        url: API_URL,
-        headers: this.buildHeaders(input.credentials),
-        transformedBody: body,
-      };
+      const errorPayload = proxyUnavailable
+        ? buildProxyUnavailableError()
+        : JSON.stringify({
+            error: { message: msg, type: "upstream_error", code: "EXECUTOR_ERROR" },
+          });
+      return this.executionResult(
+        input,
+        new Response(encoder.encode(errorPayload), {
+          status: proxyUnavailable ? 503 : 502,
+          headers: { "Content-Type": "application/json" },
+        }),
+        body
+      );
     }
   }
 }


### PR DESCRIPTION
## Scope

Repair a truncated TheOldLLM executor success return and restore the existing `executionResult` contract for both success and error paths.

The recovery preserves the intentional proxy-unavailable 503 response, while ordinary upstream failures remain 502.

## Validation

- `prettier --check open-sse/executors/theoldllm.ts`
- TypeScript-aware `esbuild` ESM compile using repository tsconfig
- compiled-artifact `node --check`
- structural assertion: one execute method, result helper success path, 503/502 distinction

## Release safety

Dependent recovery PR; hosted validation, targeted executor tests, review, merge, release signing, and installed desktop dogfood remain required.