### PR TITLE
fix(chat): restore compression options extraction boundary

### DIFF
--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1302,7 +1302,8 @@ export async function handleChatCore({
       }
       // Phase 4A: unified output styles (supersedes cavemanOutputMode via the back-compat shim).
       let outputStyleResult:
-        import("../services/compression/outputStyles/apply.ts").OutputStylesResult | null = null;
+        | import("../services/compression/outputStyles/apply.ts").OutputStylesResult
+        | null = null;
       if (config.enabled) {
         try {
           const { resolveOutputStyleSelection } =
@@ -1354,8 +1355,8 @@ export async function handleChatCore({
           ? ((compressionInputBody as Record<string, unknown>).max_tokens as number)
           : null;
       let adaptiveTelemetry:
-        import("../services/compression/adaptiveCompression/types.ts").AdaptiveTelemetry | null =
-        null;
+        | import("../services/compression/adaptiveCompression/types.ts").AdaptiveTelemetry
+        | null = null;
       const compressionPlan = selectCompressionPlan(
         config,
         compressionComboKey,
@@ -1402,7 +1403,7 @@ export async function handleChatCore({
         // that selectCompressionStrategy can only partially apply via the mode string.
         const cacheCtx = { provider, targetFormat, model: effectiveModel };
         const compressionConfig = resolveCacheAwareConfig(config, compressionInputBody, cacheCtx);
-        const result = await applyCompressionAsync(compressionInputBody, mode, {
+        const compressionOptions = {
           model: effectiveModel,
           // #7237: feed the AUTHORITATIVE capability (model spec / models.dev sync / DB
           // override, with the conservative model-id fragment heuristic only as its


### PR DESCRIPTION
## Scope

Repair a partial compression-options extraction in the chat core handler. The old inline `applyCompressionAsync` call left an unmatched opening parenthesis when its options object was moved for shared direct/live-zone use.

The recovery declares one `compressionOptions` object and retains both the direct `runCompression` and live-zone wrapper paths.

## Validation

- `prettier --check open-sse/handlers/chatCore.ts`
- TypeScript-aware `esbuild` ESM compile of the full handler using repository tsconfig
- compiled-artifact `node --check`
- structural assertion: one options declaration and shared compression call boundary

## Release safety

Dependent recovery PR; hosted validation, targeted compression/live-zone tests, review, merge, release signing, and installed desktop dogfood remain required.