### PR TITLE
fix(reasoning): restore single max-token buffer policy

### DIFF
--- a/open-sse/services/reasoningTokenBuffer.ts
+++ b/open-sse/services/reasoningTokenBuffer.ts
@@ -12,15 +12,6 @@ import {
  */
 export const REASONING_BUFFER_MIN_TRIGGER = 256;
 
-/**
- * Below this caller-supplied `max_tokens`, the request is treated as a probe
- * (e.g. Claude Code's `/model` capability check sends `max_tokens: 1`) rather
- * than a genuine reasoning budget, so no headroom is added. Keeping it a named
- * constant makes the threshold easy to tune. See issue #6274 (probe inflated to
- * 1001 upstream) vs. issue #3587 (headroom for real reasoning budgets).
- */
-export const REASONING_BUFFER_MIN_TRIGGER = 256;
-
 export function toPositiveInteger(value: unknown): number | null {
   const numericValue =
     typeof value === "number"
@@ -54,10 +45,12 @@ export function resolveReasoningBufferedMaxTokens(
   // request. Respect it verbatim instead of inflating (e.g. 1 -> 1001).
   if (current < REASONING_BUFFER_MIN_TRIGGER) return current;
 
-  // Issue #6274: a tiny explicit budget is a capability probe, not a reasoning
-  // request. Respect it verbatim instead of inflating (e.g. 1 -> 1001).
-  if (current < REASONING_BUFFER_MIN_TRIGGER) return current;
-
-  const buffered = Math.max(current + 1000, Math.ceil(current * 1.5));
-  return buffered > maxOutputTokens ? current : buffered;
+  // Issue #9507: never enlarge a client's explicit max_tokens. The #3587
+  // headroom heuristic (Math.ceil(current * 1.5)) silently rewrote reasoning
+  // budgets upward (64000 -> 96000 on claude-opus-5), violating the #1761
+  // contract that upward adjustment must be opt-in. The over-cap clamp above
+  // (line 42) already narrows, and the model's own output cap is the only
+  // legitimate ceiling; any headroom beyond the client-declared value is a
+  // silent cost increase the client did not authorize.
+  return current;
 }


### PR DESCRIPTION
## Why
The reasoning-token buffer declared the trigger twice and retained a stale headroom path, producing a duplicate identifier and violating the explicit client-budget contract.

## Change
Keep one exported trigger and the established no-inflation policy.

## Validation
- Prettier check
- ESM transpile and Node syntax check
- Structural assertion: exactly one exported trigger

## Scope
One source file. Draft link in the recovery chain; not release evidence.