### PR TITLE
fix(web): remove duplicate provider helper exports

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
+++ b/src/app/(dashboard)/dashboard/providers/[id]/providerPageHelpers.ts
@@ -16,10 +16,7 @@ import {
   type CodexServiceTier,
 } from "@/lib/providers/requestDefaults";
 import { type CodexGlobalServiceMode } from "@/lib/providers/codexFastTier";
-import { type WebSessionCredentialRequirement } from "./webSessionCredentials";
 import { CC_COMPATIBLE_DEFAULT_CHAT_PATH } from "./providerDetailConstants";
-import { getRegistryEntry } from "@omniroute/open-sse/config/providerRegistry";
-import type { AlternateFormat } from "@omniroute/open-sse/config/providers/alternateFormats";
 import {
   type ProviderMessageTranslator,
   providerText,
@@ -45,13 +42,6 @@ export {
 // Types shared between page + modals
 // ---------------------------------------------------------------------------
 
-export type ProviderMessageTranslator = ((
-  key: string,
-  values?: Record<string, unknown>
-) => string) & {
-  has?: (key: string) => boolean;
-};
-
 export type LocalProviderMetadata = {
   name?: string;
   localDefault?: string;
@@ -60,7 +50,14 @@ export type LocalProviderMetadata = {
 
 export type CommandCodeAuthFlowState = {
   phase:
-    "idle" | "starting" | "polling" | "received" | "applying" | "applied" | "expired" | "error";
+    | "idle"
+    | "starting"
+    | "polling"
+    | "received"
+    | "applying"
+    | "applied"
+    | "expired"
+    | "error";
   state: string;
   authUrl: string;
   callbackUrl: string;
@@ -118,28 +115,6 @@ const TARGET_FORMAT_BADGE_I18N_KEYS: Record<string, string> = {
 
 export function targetFormatBadgeI18nKey(value: string): string | null {
   return TARGET_FORMAT_BADGE_I18N_KEYS[value] ?? null;
-}
-
-// ---------------------------------------------------------------------------
-// Utility — message translation with fallback
-// ---------------------------------------------------------------------------
-
-export function providerText(
-  t: ProviderMessageTranslator,
-  key: string,
-  fallback: string,
-  values?: Record<string, unknown>
-): string {
-  if (typeof t.has === "function" && t.has(key)) {
-    return t(key, values);
-  }
-  if (values) {
-    return Object.entries(values).reduce(
-      (acc, [name, value]) => acc.replaceAll(`{${name}}`, String(value)),
-      fallback
-    );
-  }
-  return fallback;
 }
 
 /**
@@ -411,108 +386,6 @@ export function formatExcludedModelsInput(value: unknown): string {
       (pattern): pattern is string => typeof pattern === "string" && pattern.trim().length > 0
     )
     .join(", ");
-}
-
-// ---------------------------------------------------------------------------
-// Web-session credential label / hint helpers (Phase 2b)
-// ---------------------------------------------------------------------------
-
-export function getWebSessionCredentialLabel(
-  t: ProviderMessageTranslator,
-  requirement: WebSessionCredentialRequirement,
-  optional: boolean
-): string {
-  if (requirement.kind === "none") {
-    return providerText(t, "webNoAuthCredentialLabel", "No credential required");
-  }
-  const baseLabel =
-    requirement.kind === "token"
-      ? providerText(t, "webTokenCredentialLabel", "Web session token")
-      : t("sessionCookieLabel");
-  return optional ? `${baseLabel} (${t("optional").toLowerCase()})` : baseLabel;
-}
-
-export function getWebSessionCredentialHint(
-  t: ProviderMessageTranslator,
-  requirement: WebSessionCredentialRequirement,
-  providerName: string,
-  editing: boolean
-): string | undefined {
-  if (requirement.kind === "none") return undefined;
-
-  const values = { provider: providerName, credential: requirement.credentialName };
-  if (editing) {
-    return requirement.kind === "token"
-      ? providerText(
-          t,
-          "webTokenEditHint",
-          "Leave blank to keep the current web session token. Credential: {credential}.",
-          values
-        )
-      : providerText(
-          t,
-          "webCookieEditHint",
-          "Leave blank to keep the current session cookie. Required cookie: {credential}.",
-          values
-        );
-  }
-
-  // #5465 — a provider-specific hint (e.g. t3.chat's step-by-step DevTools copy)
-  // replaces the generic one-line cookie/token template when that template is
-  // unclear for the provider (t3.chat needs a localStorage value AND the Cookie
-  // header, so "Required cookie: convex-session-id + Cookie header…" reads
-  // circular). The override key ships translated in every locale.
-  if (requirement.hintKey) {
-    return providerText(
-      t,
-      requirement.hintKey,
-      "Open the provider's web session in DevTools, copy the required credential(s), and paste them in the fields below.",
-      values
-    );
-  }
-
-  return requirement.kind === "token"
-    ? providerText(
-        t,
-        "webTokenCredentialHint",
-        "Credential: {credential}. Paste the token value from your own signed-in {provider} web session, or a DevTools HAR export if the provider supports it.",
-        values
-      )
-    : providerText(
-        t,
-        "webCookieCredentialHint",
-        "Required cookie: {credential}. Paste the Cookie header value from your own signed-in {provider} web session. Do not include the Cookie: prefix.",
-        values
-      );
-}
-
-export function getWebSessionCredentialCheckLabel(
-  t: ProviderMessageTranslator,
-  requirement: WebSessionCredentialRequirement
-): string {
-  if (requirement.kind === "token") return providerText(t, "checkWebToken", "Check token");
-  return providerText(t, "checkCookie", "Check cookie");
-}
-
-export function getAddCredentialModalTitle(
-  t: ProviderMessageTranslator,
-  providerName: string,
-  requirement: WebSessionCredentialRequirement | null
-): string {
-  if (!requirement) return t("addProviderApiKeyTitle", { provider: providerName });
-  if (requirement.kind === "none") {
-    return providerText(t, "addProviderConnectionTitle", "Add {provider} connection", {
-      provider: providerName,
-    });
-  }
-  if (requirement.kind === "token") {
-    return providerText(t, "addProviderWebTokenTitle", "Add {provider} web token", {
-      provider: providerName,
-    });
-  }
-  return providerText(t, "addProviderSessionCookieTitle", "Add {provider} session cookie", {
-    provider: providerName,
-  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why
The provider detail helper re-exported credential helpers from `providerCredentialText` while also defining them locally, producing duplicate exports and blocking browser builds.

## Change
Keep the canonical extracted credential-text module and remove the overlapping local definitions and now-unused imports.

## Validation
- Prettier check
- Browser ESM transpile and Node syntax check
- Structural assertions: no local duplicate credential helper definitions

## Test environment note
The focused helper tests could not start because the recovery archive has no installed `zod` package (`Cannot find package zod`), before test execution. This is not represented as a passing test.

## Scope
One source file, current-main based. Draft recovery lane; no release claim.