### PR TITLE
fix(db): retain one complete usage reset implementation

### DIFF
--- a/src/lib/db/cleanup.ts
+++ b/src/lib/db/cleanup.ts
@@ -418,10 +418,7 @@ export async function runAutoCleanup(): Promise<{
   const totalDeleted = Object.values(results).reduce((sum, r) => sum + r.deleted, 0);
   const totalErrors = Object.values(results).reduce((sum, r) => sum + r.errors, 0);
 
-  log.info(
-    { totalDeleted, totalErrors },
-    "Auto-cleanup complete"
-  );
+  log.info({ totalDeleted, totalErrors }, "Auto-cleanup complete");
 
   return { totalDeleted, totalErrors, results };
 }
@@ -438,10 +435,7 @@ export async function purgeQuotaSnapshots(): Promise<CleanupResult> {
     const runResult = stmt.run();
     result.deleted = runResult.changes;
 
-    log.info(
-      { deleted: result.deleted, table: "quota_snapshots" },
-      "Purged quota_snapshots"
-    );
+    log.info({ deleted: result.deleted, table: "quota_snapshots" }, "Purged quota_snapshots");
   } catch (err: unknown) {
     log.error({ err }, "Error purging quota_snapshots");
     result.errors++;
@@ -461,10 +455,7 @@ export async function purgeCallLogs(): Promise<CleanupResult> {
     const runResult = db.prepare("DELETE FROM call_logs").run();
     result.deleted = runResult.changes;
 
-    log.info(
-      { deleted: result.deleted, table: "call_logs" },
-      "Purged call_logs"
-    );
+    log.info({ deleted: result.deleted, table: "call_logs" }, "Purged call_logs");
   } catch (err: unknown) {
     log.error({ err }, "Error purging call_logs");
     result.errors++;
@@ -475,10 +466,7 @@ export async function purgeCallLogs(): Promise<CleanupResult> {
   result.errors += artifactResult.errors;
 
   if (artifactResult.errors === 0) {
-    log.info(
-      { deletedArtifacts: result.deletedArtifacts },
-      "Purged call log artifacts"
-    );
+    log.info({ deletedArtifacts: result.deletedArtifacts }, "Purged call log artifacts");
   }
 
   return result;
@@ -574,16 +562,56 @@ function isResetUsageHistoryPeriod(period: string): period is ResetUsageHistoryP
  */
 const RESET_TARGETS: Array<DeleteByPeriodTarget & { resultKey: keyof ResetUsageHistoryResult }> = [
   { table: "usage_history", column: "timestamp", cutoff: "iso", resultKey: "deletedUsageHistory" },
-  { table: "daily_usage_summary", column: "date", cutoff: "date", resultKey: "deletedDailySummary" },
-  { table: "hourly_usage_summary", column: "date_hour", cutoff: "dateHour", resultKey: "deletedHourlySummary" },
+  {
+    table: "daily_usage_summary",
+    column: "date",
+    cutoff: "date",
+    resultKey: "deletedDailySummary",
+  },
+  {
+    table: "hourly_usage_summary",
+    column: "date_hour",
+    cutoff: "dateHour",
+    resultKey: "deletedHourlySummary",
+  },
   { table: "call_logs", column: "timestamp", cutoff: "iso", resultKey: "deletedCallLogs" },
-  { table: "request_detail_logs", column: "timestamp", cutoff: "iso", resultKey: "deletedRequestDetailLogs" },
+  {
+    table: "request_detail_logs",
+    column: "timestamp",
+    cutoff: "iso",
+    resultKey: "deletedRequestDetailLogs",
+  },
   { table: "proxy_logs", column: "timestamp", cutoff: "iso", resultKey: "deletedProxyLogs" },
-  { table: "relay_logs", column: "created_at", cutoff: "epochSeconds", resultKey: "deletedRelayLogs" },
-  { table: "compression_analytics", column: "timestamp", cutoff: "iso", resultKey: "deletedCompressionAnalytics" },
-  { table: "compression_run_telemetry", column: "timestamp", cutoff: "epochMs", resultKey: "deletedCompressionRunTelemetry" },
-  { table: "routing_decisions", column: "created_at", cutoff: "iso", resultKey: "deletedRoutingDecisions" },
-  { table: "quota_consumption", column: "updated_at", cutoff: "epochMs", resultKey: "deletedQuotaConsumption" },
+  {
+    table: "relay_logs",
+    column: "created_at",
+    cutoff: "epochSeconds",
+    resultKey: "deletedRelayLogs",
+  },
+  {
+    table: "compression_analytics",
+    column: "timestamp",
+    cutoff: "iso",
+    resultKey: "deletedCompressionAnalytics",
+  },
+  {
+    table: "compression_run_telemetry",
+    column: "timestamp",
+    cutoff: "epochMs",
+    resultKey: "deletedCompressionRunTelemetry",
+  },
+  {
+    table: "routing_decisions",
+    column: "created_at",
+    cutoff: "iso",
+    resultKey: "deletedRoutingDecisions",
+  },
+  {
+    table: "quota_consumption",
+    column: "updated_at",
+    cutoff: "epochMs",
+    resultKey: "deletedQuotaConsumption",
+  },
   { table: "token_ledger", column: "created_at", cutoff: "iso", resultKey: "deletedTokenLedger" },
 ];
 
@@ -647,127 +675,6 @@ export async function resetUsageHistory(period: string): Promise<ResetUsageHisto
     console.log(
       `[Cleanup] Reset usage/log data (period=${period}): ${result.deleted} row(s), ` +
         `${result.deletedCallLogArtifacts} call log artifact(s)`
-    );
-  } catch (err: unknown) {
-    console.error("[Cleanup] Error resetting usage history:", err);
-    result.errors++;
-  }
-
-  return result;
-}
-
-/**
- * Whitelist of periods accepted by {@link resetUsageHistory}. `"all"` wipes
- * every row; any other value deletes rows strictly older than `now - period`.
- */
-export const RESET_USAGE_HISTORY_PERIODS = [
-  "5m",
-  "1h",
-  "3h",
-  "6h",
-  "12h",
-  "1d",
-  "7d",
-  "30d",
-  "all",
-] as const;
-
-export type ResetUsageHistoryPeriod = (typeof RESET_USAGE_HISTORY_PERIODS)[number];
-
-type TimedResetUsageHistoryPeriod = Exclude<ResetUsageHistoryPeriod, "all">;
-
-const RESET_USAGE_HISTORY_PERIOD_MS: Record<TimedResetUsageHistoryPeriod, number> = {
-  "5m": 5 * 60 * 1000,
-  "1h": 60 * 60 * 1000,
-  "3h": 3 * 60 * 60 * 1000,
-  "6h": 6 * 60 * 60 * 1000,
-  "12h": 12 * 60 * 60 * 1000,
-  "1d": 24 * 60 * 60 * 1000,
-  "7d": 7 * 24 * 60 * 60 * 1000,
-  "30d": 30 * 24 * 60 * 60 * 1000,
-};
-
-export interface ResetUsageHistoryResult extends CleanupResult {
-  deletedUsageHistory: number;
-  deletedDailySummary: number;
-  deletedHourlySummary: number;
-}
-
-function isResetUsageHistoryPeriod(period: string): period is ResetUsageHistoryPeriod {
-  return (RESET_USAGE_HISTORY_PERIODS as readonly string[]).includes(period);
-}
-
-/**
- * On-demand, period-scoped reset of usage analytics data (`usage_history`,
- * `daily_usage_summary`, `hourly_usage_summary`).
- *
- * Unlike {@link cleanupUsageHistory} (retention-based background cleanup,
- * which rolls up rows into `daily_usage_summary` before deleting them), this
- * is a destructive user-triggered reset — it intentionally does NOT roll up
- * first, since the whole point is to wipe the data the user selected.
- *
- * @param period - One of {@link RESET_USAGE_HISTORY_PERIODS}. `"all"` wipes
- *   every row in all three tables; any other value deletes rows strictly
- *   older than `now - period`. Throws on an invalid period.
- */
-export async function resetUsageHistory(period: string): Promise<ResetUsageHistoryResult> {
-  if (!isResetUsageHistoryPeriod(period)) {
-    throw new Error(`Invalid reset period: ${period}`);
-  }
-
-  const db = getDbInstance();
-  const result: ResetUsageHistoryResult = {
-    deleted: 0,
-    deletedUsageHistory: 0,
-    deletedDailySummary: 0,
-    deletedHourlySummary: 0,
-    errors: 0,
-  };
-
-  try {
-    const runReset = db.transaction(() => {
-      if (period === "all") {
-        const usageHistory = db.prepare("DELETE FROM usage_history").run();
-        const dailySummary = db.prepare("DELETE FROM daily_usage_summary").run();
-        const hourlySummary = db.prepare("DELETE FROM hourly_usage_summary").run();
-        result.deletedUsageHistory = usageHistory.changes;
-        result.deletedDailySummary = dailySummary.changes;
-        result.deletedHourlySummary = hourlySummary.changes;
-        return;
-      }
-
-      const cutoffMs = Date.now() - RESET_USAGE_HISTORY_PERIOD_MS[period];
-      const cutoffIso = new Date(cutoffMs).toISOString();
-      // usage_history.timestamp is a full ISO string; daily_usage_summary.date is
-      // "YYYY-MM-DD"; hourly_usage_summary.date_hour is "YYYY-MM-DD HH:00:00" (see
-      // src/lib/usage/aggregateHistory.ts, which derives both with SQLite's UTC-based
-      // DATE()/strftime()). Slicing the UTC ISO cutoff keeps all three comparisons
-      // consistent without re-deriving timezone-sensitive date math by hand.
-      const cutoffDate = cutoffIso.slice(0, 10);
-      const cutoffDateHour = `${cutoffIso.slice(0, 10)} ${cutoffIso.slice(11, 13)}:00:00`;
-
-      const usageHistory = db
-        .prepare("DELETE FROM usage_history WHERE timestamp < ?")
-        .run(cutoffIso);
-      const dailySummary = db
-        .prepare("DELETE FROM daily_usage_summary WHERE date < ?")
-        .run(cutoffDate);
-      const hourlySummary = db
-        .prepare("DELETE FROM hourly_usage_summary WHERE date_hour < ?")
-        .run(cutoffDateHour);
-
-      result.deletedUsageHistory = usageHistory.changes;
-      result.deletedDailySummary = dailySummary.changes;
-      result.deletedHourlySummary = hourlySummary.changes;
-    });
-
-    runReset();
-    result.deleted =
-      result.deletedUsageHistory + result.deletedDailySummary + result.deletedHourlySummary;
-
-    console.log(
-      `[Cleanup] Reset usage data (period=${period}): ${result.deletedUsageHistory} usage_history, ` +
-        `${result.deletedDailySummary} daily_usage_summary, ${result.deletedHourlySummary} hourly_usage_summary`
     );
   } catch (err: unknown) {
     console.error("[Cleanup] Error resetting usage history:", err);
@@ -869,10 +776,7 @@ export function startCleanupScheduler(): void {
     _cleanupSchedulerTimer.unref();
   }
 
-  log.info(
-    { intervalMs: CLEANUP_INTERVAL_MS },
-    "Background cleanup scheduler started"
-  );
+  log.info({ intervalMs: CLEANUP_INTERVAL_MS }, "Background cleanup scheduler started");
 }
 
 /**


### PR DESCRIPTION
## Why
`cleanup.ts` contained two overlapping `resetUsageHistory` implementations and duplicate period declarations, preventing ESM compilation.

## Change
Retain the complete reset path that handles log artifacts and all documented reset targets; remove only the stale overlapping implementation.

## Validation
- Prettier check
- Node ESM transpile and syntax check
- Structural assertions: one period list and one reset implementation

## Test environment note
The existing db cleanup test did not start because the recovery archive lacks `pino`; this is not a passing-test claim.

## Scope
One source file, current-main based. Draft recovery lane; no release claim.