### PR TITLE
fix(ci): stop qgate cache from replacing checkout files

### DIFF
--- a/.github/workflows/qgate.yml
+++ b/.github/workflows/qgate.yml
@@ -41,7 +41,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4.0.0
         with:
           node-version: '24'
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Why
Hosted qgate reaches `npm ci` with no usable lockfile even though the PR merge tree contains the tracked root `package-lock.json`. The log proves `setup-node` restored a 690-byte cache directly into `$GITHUB_WORKSPACE` immediately before `npm ci`.

## Change
Remove only `setup-node` npm caching from qgate. The job retains Node 24 and immutable `npm ci`; dependency resolution is unchanged.

## Validation
- YAML parse passed
- Tracked merge-tree lockfile SHA verified
- Hosted log evidence captured: cache extraction precedes the lockfile-missing EUSAGE

## Scope
One workflow file, current-main based. Draft CI-recovery lane; no release claim.