### PR TITLE
fix(test): avoid Next code-frame Unicode panic

### DIFF
--- a/tests/unit/ui/fleetAggregation.test.ts
+++ b/tests/unit/ui/fleetAggregation.test.ts
@@ -11,7 +11,7 @@ import assert from "node:assert/strict";
 import { aggregateComboEventsToSets } from "../../../src/app/(dashboard)/dashboard/combos/live/fleetAggregation.ts";
 import type { ComboEventInput } from "../../../src/app/(dashboard)/dashboard/combos/live/comboFlowModel.ts";
 
-// ── helpers ───────────────────────────────────────────────────────────────
+// Helpers
 
 const WINDOW_MS = 10_000; // 10 seconds
 const NOW = 1_000_000; // fixed "now" for deterministic tests


### PR DESCRIPTION
## Why
DAST reaches the build but Next 16.2.12 Turbopack crashes while rendering an error code frame containing a box-drawing test comment: `end byte index ... is inside ─`. This is a framework diagnostic panic, not application behavior.

## Scope
Replace the exact helper separator in `fleetAggregation.test.ts` with its ASCII equivalent. No production code or test assertion changes.

## Evidence
- Hosted DAST run 31692230008 points to `...── helpers ...`.
- Prettier and Node ESM transpilation pass; the edited helper separator is ASCII.
- Hosted DAST remains the authoritative build validation.