### PR TITLE
fix(test): remove remaining Unicode code-frame separator

### DIFF
--- a/tests/unit/ui/fleetAggregation.test.ts
+++ b/tests/unit/ui/fleetAggregation.test.ts
@@ -31,7 +31,7 @@ function ev(
   };
 }
 
-// ── aggregateComboEventsToSets ────────────────────────────────────────────
+// aggregateComboEventsToSets
 
 describe("aggregateComboEventsToSets — basic categorization", () => {
   it("puts a recently failed provider in error set", () => {


### PR DESCRIPTION
## Why
After PR #614 removed the first box-drawing comment, DAST reached the next one in the same test file and Next 16.2.12 Turbopack again crashed while formatting its code frame.

## Scope
Replace the remaining test-only separator in `fleetAggregation.test.ts` with an ASCII heading. No production code or assertions change.

## Evidence
- DAST run 31693074949 identifies the remaining `aggregateComboEventsToSets` separator.
- Prettier and Node ESM transpilation pass; the file now contains no box-drawing separators.

Hosted DAST remains the authoritative validation.