### PR TITLE
fix(build): guard API routes against code-frame unicode panic

### DIFF
--- a/src/app/api/cli-tools/letta-settings/route.ts
+++ b/src/app/api/cli-tools/letta-settings/route.ts
@@ -13,7 +13,7 @@ import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error";
 
 const execAsync = promisify(exec);
 
-// ── Paths ──────────────────────────────────────────────────────────────
+// Paths
 const getLettaDir = () => path.join(os.homedir(), ".letta");
 const getSettingsPath = () => path.join(getLettaDir(), "settings.json");
 const getLocalBackendDir = () => path.join(getLettaDir(), "lc-local-backend");
@@ -21,14 +21,14 @@ const getProviderAuthPath = () => path.join(getLocalBackendDir(), "providers", "
 const getBackupPath = () =>
   path.join(getLocalBackendDir(), "providers", "auth.json.omniroute-backup");
 
-// ── Provider name in auth.json ─────────────────────────────────────────
+// Provider name in auth.json
 // "lmstudio" provider type has localModelDiscovery: "openai-compatible"
 // which auto-discovers models from /v1/models and shows them in /model picker
 // Models appear as "lmstudio/<model-id>" in the CLI
 const PROVIDER_NAME = "lmstudio";
 const PROVIDER_TYPE = "lmstudio_openai";
 
-// ── Check if Letta CLI is installed ────────────────────────────────────
+// Check if Letta CLI is installed
 const checkLettaInstalled = async () => {
   try {
     const isWindows = os.platform() === "win32";
@@ -49,7 +49,7 @@ const checkLettaInstalled = async () => {
   }
 };
 
-// ── Read settings.json ─────────────────────────────────────────────────
+// Read settings.json
 const readSettings = async () => {
   try {
     const content = await fs.readFile(getSettingsPath(), "utf-8");
@@ -60,7 +60,7 @@ const readSettings = async () => {
   }
 };
 
-// ── Read auth.json ──────────────────────────────────────────────────────
+// Read auth.json
 const readAuthFile = async () => {
   try {
     const content = await fs.readFile(getProviderAuthPath(), "utf-8");
@@ -71,13 +71,13 @@ const readAuthFile = async () => {
   }
 };
 
-// ── Check if a base_url points to OmniRoute ──────────────────────────────
+// Check if a base_url points to OmniRoute
 const isOmniRouteUrl = (baseUrl) => {
   if (!baseUrl) return false;
   return baseUrl.includes(":20128") || baseUrl.includes(":3000") || baseUrl.includes("omniroute");
 };
 
-// ── Check if OmniRoute is configured ─────────────────────────────────────
+// Check if OmniRoute is configured
 const hasOmniRouteConfig = (authFile) => {
   if (!authFile?.providers) return false;
   const provider = authFile.providers[PROVIDER_NAME];
@@ -85,7 +85,7 @@ const hasOmniRouteConfig = (authFile) => {
   return isOmniRouteUrl(provider.base_url);
 };
 
-// ── GET - Check Letta CLI and read current settings ────────────────────
+// GET - Check Letta CLI and read current settings
 export async function GET(request: Request) {
   const authError = await requireCliToolsAuth(request);
   if (authError) return authError;
@@ -129,7 +129,7 @@ export async function GET(request: Request) {
   }
 }
 
-// ── POST - Apply OmniRoute as LM Studio provider + switch to local mode ──
+// POST - Apply OmniRoute as LM Studio provider + switch to local mode
 /**
  * Steps 1-2 of POST: read the existing Letta auth.json, refuse to clobber a real
  * LM Studio configuration unless `overwrite` is set (409 with conflict info), and back
@@ -197,14 +197,14 @@ export async function POST(request: Request) {
 
     const normalizedBaseUrl = baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
 
-    // ── 1-2. Read auth.json, guard non-OmniRoute conflicts, back up before overwrite ──
+    // 1-2. Read auth.json, guard non-OmniRoute conflicts, back up before overwrite
     const prepared = await prepareLettaAuthFile(overwrite);
     if ("conflictResponse" in prepared) {
       return prepared.conflictResponse;
     }
     const { authFile, authPath } = prepared;
 
-    // ── 3. Switch to local mode in settings.json ──
+    // 3. Switch to local mode in settings.json
     const settingsPath = getSettingsPath();
     const lettaDir = getLettaDir();
     await fs.mkdir(lettaDir, { recursive: true });
@@ -220,7 +220,7 @@ export async function POST(request: Request) {
     settings.preferredBackendMode = "local";
     await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2));
 
-    // ── 4. Write lmstudio provider to auth.json ──
+    // 4. Write lmstudio provider to auth.json
     // Clean up legacy lc-omniroute provider if present
     if (authFile.providers?.["lc-omniroute"]) {
       delete authFile.providers["lc-omniroute"];
@@ -253,12 +253,12 @@ export async function POST(request: Request) {
   }
 }
 
-// ── DELETE - Remove OmniRoute configuration ──────────────────────────────
+// DELETE - Remove OmniRoute configuration
 export async function DELETE(request: Request) {
   const authError = await requireCliToolsAuth(request);
   if (authError) return authError;
   try {
-    // ── 1. Remove lmstudio provider from auth.json, restore backup if exists ──
+    // 1. Remove lmstudio provider from auth.json, restore backup if exists
     const authPath = getProviderAuthPath();
     const backupPath = getBackupPath();
     let authFile = { version: 1, providers: {} };
@@ -298,7 +298,7 @@ export async function DELETE(request: Request) {
       await fs.writeFile(authPath, JSON.stringify(authFile, null, 2));
     }
 
-    // ── 2. Reset backend mode to api in settings.json ──
+    // 2. Reset backend mode to api in settings.json
     const settingsPath = getSettingsPath();
     try {
       const existing = await fs.readFile(settingsPath, "utf-8");

--- a/src/app/api/oauth/kiro/auto-import/route.ts
+++ b/src/app/api/oauth/kiro/auto-import/route.ts
@@ -62,7 +62,7 @@ export async function GET(request: Request) {
   });
 }
 
-// ── kiro-cli SQLite reader ────────────────────────────────────────────────────
+// kiro-cli SQLite reader
 
 async function tryKiroCliSqlite(): Promise<{
   found: boolean;
@@ -206,7 +206,7 @@ async function tryKiroCliSqlite(): Promise<{
   return { found: false, triedPaths: candidatePaths };
 }
 
-// ── ~/.aws/sso/cache fallback ─────────────────────────────────────────────────
+// ~/.aws/sso/cache fallback
 
 /**
  * Read the Amazon Q Developer profileArn the Kiro IDE persists in its
@@ -401,7 +401,7 @@ async function tryAwsSsoCache(targetProvider: string): Promise<{
   return { found: false, triedPath: cachePath };
 }
 
-// ── Helpers (exported for unit-testing) ──────────────────────────────────────
+// Helpers (exported for unit-testing)
 
 /**
  * Derives a human-readable display name for a Kiro/AWS connection when the
@@ -450,7 +450,7 @@ export function findKiroConnectionByProfileArn(
   return findKiroConnectionByIdentity(connections, { profileArn });
 }
 
-// ── Save to OmniRoute DB ──────────────────────────────────────────────────────
+// Save to OmniRoute DB
 
 type SaveAndRespondResult = Awaited<ReturnType<typeof tryKiroCliSqlite>> & {
   // Fields added by tryAwsSsoCache for IDC tokens (#2059)

--- a/src/app/api/pricing/models/route.ts
+++ b/src/app/api/pricing/models/route.ts
@@ -28,7 +28,7 @@ export async function GET() {
   try {
     const catalog: Record<string, any> = {};
 
-    // ── 1. Registry models (hardcoded) ──────────────────────────────
+    // 1. Registry models (hardcoded)
     for (const entry of Object.values(REGISTRY)) {
       const alias = entry.alias || entry.id;
       if (!entry.models || entry.models.length === 0) continue;
@@ -86,7 +86,7 @@ export async function GET() {
       }
     };
 
-    // ── 2. Synced available models (DB) ─────────────────────────────
+    // 2. Synced available models (DB)
     let syncedModelsMap: Record<string, unknown> = {};
     try {
       syncedModelsMap = asRecord(await getAllSyncedAvailableModels());
@@ -98,7 +98,7 @@ export async function GET() {
       appendDbModels(providerId, rawModels);
     }
 
-    // ── 3. Custom models (DB) ───────────────────────────────────────
+    // 3. Custom models (DB)
     let customModelsMap: Record<string, unknown> = {};
     try {
       customModelsMap = asRecord(await getAllCustomModels());
@@ -110,7 +110,7 @@ export async function GET() {
       appendDbModels(providerId, rawModels);
     }
 
-    // ── 4. Pricing-only models (DB) ─────────────────────────────────
+    // 4. Pricing-only models (DB)
     let pricingData: Record<string, any> = {};
     try {
       pricingData = await getPricing();

--- a/src/app/api/providers/[id]/login/route.ts
+++ b/src/app/api/providers/[id]/login/route.ts
@@ -11,7 +11,7 @@ import { getCachedProviderConnectionById, updateProviderConnection } from "@/lib
 import { requireManagementAuth } from "@/lib/api/requireManagementAuth";
 import { sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";
 
-// ─── POST: Start login flow ────────────────────────────────────────────────
+// POST: Start login flow
 
 export async function POST(
   req: NextRequest,

--- a/src/app/api/skills/collect/chaos/route.ts
+++ b/src/app/api/skills/collect/chaos/route.ts
@@ -34,7 +34,7 @@ import * as log from "@/sse/utils/logger";
 
 export const dynamic = "force-dynamic";
 
-// ── Schema ───────────────────────────────────────────────────────────────────
+// Schema
 
 const chaosSchema = z.object({
   task: z.string().min(1, "task is required").max(100_000, "task too long"),
@@ -44,7 +44,7 @@ const chaosSchema = z.object({
   maxTokens: z.number().int().min(256).max(128_000).optional(),
 });
 
-// ── Auth helpers ─────────────────────────────────────────────────────────────
+// Auth helpers
 
 /**
  * Extract Bearer token from Authorization header.
@@ -89,11 +89,11 @@ async function verifyChaosKey(bearerToken: string): Promise<{ ok: boolean; error
   return { ok: true };
 }
 
-// ── Main handler ─────────────────────────────────────────────────────────────
+// Main handler
 
 export async function POST(request: Request) {
   try {
-    // ── API Key auth check ─────────────────────────────────────────────
+    // API Key auth check
     const bearerToken = extractBearerToken(request);
     if (!bearerToken) {
       return NextResponse.json(
@@ -107,7 +107,7 @@ export async function POST(request: Request) {
       return NextResponse.json(buildErrorBody(403, auth.error!), { status: 403 });
     }
 
-    // ── Parse request body ─────────────────────────────────────────────
+    // Parse request body
     const rawBody = await request.json();
     const validation = validateBody(chaosSchema, rawBody);
     if (isValidationFailure(validation)) {
@@ -118,7 +118,7 @@ export async function POST(request: Request) {
 
     const { task, providers, mode, systemPrompt, maxTokens } = validation.data;
 
-    // ── Load global chaos config ───────────────────────────────────────
+    // Load global chaos config
     const globalConfig = await getChaosConfig();
     if (!globalConfig.enabled) {
       return NextResponse.json(
@@ -127,7 +127,7 @@ export async function POST(request: Request) {
       );
     }
 
-    // ── Execute via the shared executor ────────────────────────────────
+    // Execute via the shared executor
     const result: ChaosRunResult = await executeChaosRun({
       task,
       providers,

--- a/src/app/api/tools/traffic-inspector/internal/ingest/route.ts
+++ b/src/app/api/tools/traffic-inspector/internal/ingest/route.ts
@@ -27,7 +27,7 @@ import { globalTrafficBuffer } from "@/mitm/inspector/buffer";
 import { maskSecret } from "@/mitm/maskSecrets";
 import { sanitizeHeaders } from "@/mitm/sanitizeHeaders";
 
-// ── Token management ────────────────────────────────────────────────────────
+// Token management
 
 let _cachedToken: string | null = null;
 
@@ -55,7 +55,7 @@ function tokenMatches(received: string): boolean {
   }
 }
 
-// ── Partial schema (only required fields; rest optional) ───────────────────
+// Partial schema (only required fields; rest optional)
 
 const IngestBodySchema = InterceptedRequestSchema.partial().required({
   id: true,
@@ -71,7 +71,7 @@ const IngestBodySchema = InterceptedRequestSchema.partial().required({
   status: true,
 });
 
-// ── Handler ─────────────────────────────────────────────────────────────────
+// Handler
 
 export async function POST(request: Request): Promise<Response> {
   // Token gate (second layer after LOCAL_ONLY IP check).

--- a/src/app/api/v1/issues/report/route.ts
+++ b/src/app/api/v1/issues/report/route.ts
@@ -52,7 +52,7 @@ export async function POST(request: Request) {
   const repo = process.env.GITHUB_ISSUES_REPO;
   const token = process.env.GITHUB_ISSUES_TOKEN;
 
-  // ── Structured body for the GitHub issue ──
+  // Structured body for the GitHub issue
   const issueBody = [
     `## ${errorCode ?? "Key Issuance Event"}`,
     "",
@@ -71,7 +71,7 @@ export async function POST(request: Request) {
     .filter(Boolean)
     .join("\n");
 
-  // ── Log locally regardless ──
+  // Log locally regardless
   console.log(
     `[issues/report] title="${title}" errorCode=${errorCode ?? "—"} provider=${provider ?? "—"} accountId=${accountId ?? "—"}`
   );
@@ -88,7 +88,7 @@ export async function POST(request: Request) {
     );
   }
 
-  // ── Create GitHub issue ──
+  // Create GitHub issue
   try {
     const [owner, repoName] = repo.split("/");
     const ghRes = await fetch(`https://api.github.com/repos/${owner}/${repoName}/issues`, {

--- a/src/app/api/v1/registered-keys/[id]/route.ts
+++ b/src/app/api/v1/registered-keys/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { isAuthenticated } from "@/shared/utils/apiAuth";
 import { getRegisteredKey, revokeRegisteredKey } from "@/lib/db/registeredKeys";
 
-// ─── GET /api/v1/registered-keys/[id] ────────────────────────────────────────
+// GET /api/v1/registered-keys/[id]
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   if (!(await isAuthenticated(request))) {
@@ -18,7 +18,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
   return NextResponse.json({ key });
 }
 
-// ─── DELETE /api/v1/registered-keys/[id] ─────────────────────────────────────
+// DELETE /api/v1/registered-keys/[id]
 
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
   if (!(await isAuthenticated(request))) {

--- a/src/app/api/v1/registered-keys/route.ts
+++ b/src/app/api/v1/registered-keys/route.ts
@@ -4,7 +4,7 @@ import { isAuthenticated } from "@/shared/utils/apiAuth";
 import { isValidationFailure, validateBody } from "@/shared/validation/helpers";
 import { issueRegisteredKey, checkQuota, listRegisteredKeys } from "@/lib/db/registeredKeys";
 
-// ─── Validation ───────────────────────────────────────────────────────────────
+// Validation
 
 const issueKeySchema = z.object({
   name: z.string().min(1).max(120),
@@ -16,7 +16,7 @@ const issueKeySchema = z.object({
   hourlyBudget: z.number().int().positive().optional(),
 });
 
-// ─── GET /api/v1/registered-keys ─────────────────────────────────────────────
+// GET /api/v1/registered-keys
 
 /**
  * List registered keys (masked — no raw key material returned after creation).
@@ -40,7 +40,7 @@ export async function GET(request: Request) {
   }
 }
 
-// ─── POST /api/v1/registered-keys ────────────────────────────────────────────
+// POST /api/v1/registered-keys
 
 /**
  * Issue a new registered key.
@@ -68,7 +68,7 @@ export async function POST(request: Request) {
 
   const { provider, accountId } = validation.data;
 
-  // ── Quota check ──
+  // Quota check
   try {
     const quota = checkQuota(provider, accountId);
     if (!quota.allowed) {
@@ -82,7 +82,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Quota check failed" }, { status: 500 });
   }
 
-  // ── Issue ──
+  // Issue
   try {
     const result = issueRegisteredKey(validation.data);
 

--- a/tests/unit/api-route-u2500-build-input.test.ts
+++ b/tests/unit/api-route-u2500-build-input.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const API_ROOT = path.join(process.cwd(), "src", "app", "api");
+const ROUTE_SOURCE = /^route\.(?:ts|tsx|js|mjs)$/;
+
+function routeSources(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      return routeSources(entryPath);
+    }
+
+    return entry.isFile() && ROUTE_SOURCE.test(entry.name) ? [entryPath] : [];
+  });
+}
+
+test("compiled API route handlers contain no U+2500 code-frame hazard", () => {
+  const offenders = routeSources(API_ROOT)
+    .filter((file) => readFileSync(file, "utf8").includes("\u2500"))
+    .map((file) => path.relative(API_ROOT, file))
+    .sort();
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `U+2500 box-drawing comments can panic Next/Turbopack code-frame rendering in backend-only builds:\n${offenders.join("\n")}`
+  );
+});


### PR DESCRIPTION
## Scope

Removes decorative U+2500 box-drawing separators only from the nine compiled `src/app/api/**/route.ts` handlers retained by backend-only builds, and adds a narrow recursive guard for `route.{ts,tsx,js,mjs}`. No application logic, imports, exports, user-facing copy, workflow, dependency, or release changes.

## Provenance

- Base: `8a74889b23e277e41e7c362d24f91e8b0d2ac198`
- Head: `fcb50bf206113ed9dda3c433f92807b01bf8413c`

## Local evidence

- RED: the new guard failed with exactly the nine expected API-route paths.
- GREEN: native Node and project-equivalent `tsx` focused runs pass.
- Focused ESLint passes for all changed paths; `git diff --check` passes.
- Recursive scan finds no U+2500 in compiled API route handlers.
- The new test passes Prettier; three unrelated pre-existing formatting differences on `main` were intentionally not reformatted.

## Remaining gates

This is not release evidence. Fresh hosted DAST, qgate, and macOS/Ubuntu/Windows CLI matrix runs are required; this draft PR exists to exercise those PR-gated workflows.