### PR TITLE
fix(db): restore model catalog cache invalidation contract

### DIFF
--- a/src/lib/db/readCache.ts
+++ b/src/lib/db/readCache.ts
@@ -258,10 +258,6 @@ export function getModelCatalogCacheVersion(): number {
  * into its response cache key; a change means settings/connections/combos were
  * written since the cache was populated and the cached body is stale.
  */
-export function getModelCatalogCacheVersion(): number {
-  return modelCatalogCacheVersion;
-}
-
 /**
  * Invalidate caches (call after writes to any of: settings, pricing,
  * connections, combos, nodes).
@@ -271,7 +267,10 @@ export function getModelCatalogCacheVersion(): number {
  * cache must still be fully cleared since overlapping filter results
  * cannot be selectively invalidated).
  */
-export function invalidateDbCache(scope?: "settings" | "pricing" | "connections" | "combos"): void {
+export function invalidateDbCache(
+  scope?: "settings" | "pricing" | "connections" | "combos" | "nodes",
+  id?: string
+): void {
   if (!scope || scope === "settings") settingsCache.invalidate();
   if (!scope || scope === "pricing") pricingCache.invalidate();
   if (!scope || scope === "connections") {

--- a/tests/unit/db-read-cache.test.ts
+++ b/tests/unit/db-read-cache.test.ts
@@ -47,6 +47,15 @@ test.after(async () => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
+test("model catalog cache version advances when cache state is invalidated", async () => {
+  const readCache = await importFresh("src/lib/db/readCache.ts");
+  const before = readCache.getModelCatalogCacheVersion();
+
+  readCache.invalidateDbCache("settings");
+
+  assert.equal(readCache.getModelCatalogCacheVersion(), before + 1);
+});
+
 test("getCachedSettings returns cached data until TTL expires or cache is invalidated", async () => {
   const readCache = await importFresh("src/lib/db/readCache.ts");
   const db = core.getDbInstance();


### PR DESCRIPTION
## Scope

Two-file release-regression repair only:

- `src/lib/db/readCache.ts`: removes the duplicate `getModelCatalogCacheVersion` export and restores the pre-release `invalidateDbCache` contract for `nodes` plus optional connection `id`.
- `tests/unit/db-read-cache.test.ts`: adds a narrow model-catalog version-increment behavior test.

## Evidence

- Red proof: the focused DB cache test failed at `readCache.ts:261` with `Multiple exports with the same name "getModelCatalogCacheVersion"`.
- The duplicate is a release regression introduced by `0e2ee368`; this PR is based on current main `8a74889b`.
- Source parse and `git diff --check` pass after the repair.

## Known local validation limits

The focused DB cache test now reaches an independent existing `logger` / `dataPaths` ESM initialization cycle (`Cannot access "logger" before initialization`). Core typecheck also reaches independent existing syntax errors in `responseSanitizer.ts`, `combo.ts`, and `providers.ts`. Neither area is changed here.

A fresh hosted qgate run is required to establish the actual post-repair result; this PR makes no release-ready claim.
