### PR TITLE
fix(build): ignore optional MCP import during bundling

### DIFF
--- a/src/lib/a2a/skills/providerDiscovery.ts
+++ b/src/lib/a2a/skills/providerDiscovery.ts
@@ -383,12 +383,15 @@ async function discoverFromMcp(discoveredAt: string): Promise<SourceScanResult> 
   let mod: McpClient | undefined;
   // The MCP client module is optional infrastructure. We import lazily and
   // tolerate any failure (module missing, runtime error, network error).
-  // We route the module specifier through a `string` local so TypeScript
-  // does not statically resolve the path (the file may not exist in this
-  // checkout; the .catch() below ensures runtime tolerance regardless).
+  // Keep this import outside the build graph: the client may be provisioned
+  // only in a deployed runtime, and the .catch() below preserves its absence
+  // as an empty optional source.
   const mcpModuleSpec: string = "../../mcp/client.js";
   try {
-    mod = (await import(mcpModuleSpec).catch((err) => {
+    mod = (await import(
+      /* webpackIgnore: true */
+      mcpModuleSpec
+    ).catch((err) => {
       log.warn(
         { err, mcpModuleSpec },
         "a2a:providerDiscovery: optional MCP client module failed to load — 'mcp' source will be skipped"

--- a/tests/unit/provider-discovery-optional-mcp-build.test.ts
+++ b/tests/unit/provider-discovery-optional-mcp-build.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const providerDiscoveryPath = join(__dirname, "../../src/lib/a2a/skills/providerDiscovery.ts");
+const source = readFileSync(providerDiscoveryPath, "utf8");
+
+test("DAST-W1: optional MCP discovery is excluded from static backend-only resolution", () => {
+  assert.match(
+    source,
+    /const mcpModuleSpec: string = [^;]+;/,
+    "optional MCP discovery must keep the module specifier computed rather than a literal import"
+  );
+  assert.doesNotMatch(
+    source,
+    /import\(\s*["']\.\.\/\.\.\/mcp\/client\.js["']\s*\)/,
+    "backend-only builds must not statically resolve the absent optional MCP client"
+  );
+  assert.match(
+    source,
+    /import\(\s*\/\* webpackIgnore: true \*\/\s*mcpModuleSpec\s*\)/,
+    "the optional MCP dynamic import must opt out of Next/Turbopack static resolution"
+  );
+  assert.match(
+    source,
+    /import\([\s\S]*?mcpModuleSpec[\s\S]*?\)\.catch\(/,
+    "missing optional MCP infrastructure must remain runtime-tolerant"
+  );
+});


### PR DESCRIPTION
## Scope

Two files only:

- `src/lib/a2a/skills/providerDiscovery.ts`
- `tests/unit/provider-discovery-optional-mcp-build.test.ts`

The optional MCP provider source references infrastructure that is intentionally absent in this checkout. This change keeps the existing computed runtime import and error-tolerant empty-source behavior, while adding `/* webpackIgnore: true */` so Next/Turbopack does not statically resolve it during the backend-only build.

## Evidence

- Base: `8a74889b23e277e41e7c362d24f91e8b0d2ac198`
- Head: `d9449e85b90f1c1de4dfea310496466907a3fc3a`
- Red: focused build-contract test failed without the Turbopack ignore directive.
- Green: focused test, scoped ESLint, test Prettier, and `git diff --check`.

## Local build limitation

The local backend-only build could not reach source compilation because this isolated worktree deliberately reuses the canonical dependency tree through an external `node_modules` symlink, which Turbopack rejects as outside its filesystem root. This is not the MCP module error.

A fresh hosted DAST build remains required proof. No release or merge-readiness claim.