### PR TITLE
fix(db): remove duplicate model catalog cache accessor

### DIFF
--- a/src/lib/db/readCache.ts
+++ b/src/lib/db/readCache.ts
@@ -254,15 +254,6 @@ export function getModelCatalogCacheVersion(): number {
 }
 
 /**
- * Current model-catalog-cache version. `getUnifiedModelsResponse()` folds this
- * into its response cache key; a change means settings/connections/combos were
- * written since the cache was populated and the cached body is stale.
- */
-export function getModelCatalogCacheVersion(): number {
-  return modelCatalogCacheVersion;
-}
-
-/**
  * Invalidate caches (call after writes to any of: settings, pricing,
  * connections, combos, nodes).
  *


### PR DESCRIPTION
## **User description**
## Root cause
`src/lib/db/readCache.ts` declared `getModelCatalogCacheVersion()` twice, causing a duplicate declaration failure.

## Validation
- Verified the head is one commit after current `main`.
- Verified the diff changes only `src/lib/db/readCache.ts`, removing the nine-line duplicate declaration.
- Confirmed the preserved WIP ref resolves to this exact SHA and no prior GitHub PR owns it.

## Residuals
Hosted CI and review remain pending; this PR does not change DAST, release contracts, or logging.


___

## **CodeAnt-AI Description**
Remove the duplicate model catalog cache accessor that prevented the database cache module from loading

### What Changed
- Eliminated the duplicate declaration of the model catalog cache version accessor
- Preserved cache version tracking so cached model responses are still invalidated after related data changes

### Impact
`✅ Database cache module loads successfully`
`✅ Model catalog responses continue to refresh after writes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal cache management by removing an unused cache version accessor.
  * Cache invalidation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->