### PR TITLE
fix(db): restore model catalog cache invalidation contract

### DIFF
--- a/src/lib/db/readCache.ts
+++ b/src/lib/db/readCache.ts
@@ -258,10 +258,6 @@ export function getModelCatalogCacheVersion(): number {
  * into its response cache key; a change means settings/connections/combos were
  * written since the cache was populated and the cached body is stale.
  */
-export function getModelCatalogCacheVersion(): number {
-  return modelCatalogCacheVersion;
-}
-
 /**
  * Invalidate caches (call after writes to any of: settings, pricing,
  * connections, combos, nodes).
@@ -271,7 +267,10 @@ export function getModelCatalogCacheVersion(): number {
  * cache must still be fully cleared since overlapping filter results
  * cannot be selectively invalidated).
  */
-export function invalidateDbCache(scope?: "settings" | "pricing" | "connections" | "combos"): void {
+export function invalidateDbCache(
+  scope?: "settings" | "pricing" | "connections" | "combos" | "nodes",
+  id?: string
+): void {
   if (!scope || scope === "settings") settingsCache.invalidate();
   if (!scope || scope === "pricing") pricingCache.invalidate();
   if (!scope || scope === "connections") {

--- a/tests/unit/db-read-cache.test.ts
+++ b/tests/unit/db-read-cache.test.ts
@@ -47,6 +47,15 @@ test.after(async () => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
+test("model catalog cache version advances when cache state is invalidated", async () => {
+  const readCache = await importFresh("src/lib/db/readCache.ts");
+  const before = readCache.getModelCatalogCacheVersion();
+
+  readCache.invalidateDbCache("settings");
+
+  assert.equal(readCache.getModelCatalogCacheVersion(), before + 1);
+});
+
 test("getCachedSettings returns cached data until TTL expires or cache is invalidated", async () => {
   const readCache = await importFresh("src/lib/db/readCache.ts");
   const db = core.getDbInstance();


### PR DESCRIPTION
## Scope

Revives the preserved, two-file qgate precondition repair:

- removes the duplicate `getModelCatalogCacheVersion` export that prevents the coverage transform from starting;
- restores `invalidateDbCache` support for `nodes` and optional `id`;
- adds the focused cache-version invalidation regression test.

## Provenance

- Base: `8a74889b23e277e41e7c362d24f91e8b0d2ac198`
- Head: `0a80bca6aa33af614b06255fb42b2a8f03025498`
- The original PR #624 was externally closed and its branch deleted; this PR restores the exact immutable commit non-force, without source changes.

## Required gates

A fresh hosted qgate must run past coverage setup before this repair is considered effective. DAST, release, desktop, and migration parity remain separate workstreams.