### PR TITLE
fix(core): break logger data-path initialization cycle

### DIFF
--- a/src/lib/dataPaths.ts
+++ b/src/lib/dataPaths.ts
@@ -1,11 +1,13 @@
 import path from "path";
 import os from "os";
 import fs from "fs";
-import { createLogger } from "@/shared/utils/logger";
-
-const log = createLogger("lib:data-paths");
 
 export const APP_NAME = "omniroute";
+
+type WritableDataDirOptions = {
+  isCloud?: boolean;
+  onPermissionFallback?: (details: { resolved: string; fallback: string; code: string }) => void;
+};
 
 function fallbackHomeDir() {
   const envHome = process.env.HOME || process.env.USERPROFILE;
@@ -86,7 +88,10 @@ export function resolveDataDir({ isCloud = false }: { isCloud?: boolean } = {}):
  * Use this only at the single startup site that owns directory creation
  * (currently `db/core.ts`); everywhere else keep using the pure resolver.
  */
-export function resolveWritableDataDir({ isCloud = false }: { isCloud?: boolean } = {}): string {
+export function resolveWritableDataDir({
+  isCloud = false,
+  onPermissionFallback,
+}: WritableDataDirOptions = {}): string {
   const resolved = resolveDataDir({ isCloud });
 
   // Cloud/serverless never owns a writable home dir; leave its sentinel alone.
@@ -103,10 +108,7 @@ export function resolveWritableDataDir({ isCloud = false }: { isCloud?: boolean 
     const code = (err as NodeJS.ErrnoException | null)?.code;
     if (code === "EACCES" || code === "EPERM") {
       const fallback = getDefaultDataDir();
-      log.warn(
-        { resolved, fallback, code },
-        "data-paths: configured DATA_DIR is not writable — falling back to default"
-      );
+      onPermissionFallback?.({ resolved, fallback, code });
       return fallback;
     }
     throw err;

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -15,6 +15,7 @@ import {
 import path from "path";
 import fs from "fs";
 import { resolveWritableDataDir, getLegacyDotDataDir } from "../dataPaths";
+import { createLogger } from "@/shared/utils/logger";
 import { runMigrations } from "./migrationRunner";
 import { runDbHealthCheck } from "./healthCheck";
 import { resetAllDbModuleState } from "./stateReset";
@@ -86,7 +87,16 @@ export const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
 
 // ──────────────── Paths ────────────────
 
-export const DATA_DIR = resolveWritableDataDir({ isCloud });
+const dataPathsLog = createLogger("lib:data-paths");
+export const DATA_DIR = resolveWritableDataDir({
+  isCloud,
+  onPermissionFallback: ({ resolved, fallback, code }) => {
+    dataPathsLog.warn(
+      { resolved, fallback, code },
+      "data-paths: configured DATA_DIR is not writable — falling back to default"
+    );
+  },
+});
 const LEGACY_DATA_DIR = isCloud ? null : getLegacyDotDataDir();
 export const SQLITE_FILE = isCloud ? null : path.join(DATA_DIR, "storage.sqlite");
 const JSON_DB_FILE = isCloud ? null : path.join(DATA_DIR, "db.json");

--- a/tests/unit/logger-datapaths-import-cycle.test.ts
+++ b/tests/unit/logger-datapaths-import-cycle.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("logger imports without a data-path initialization cycle", async () => {
+  const previousLogToFile = process.env.APP_LOG_TO_FILE;
+  process.env.APP_LOG_TO_FILE = "false";
+
+  try {
+    const loggerModule = await import("../../src/shared/utils/logger.ts");
+
+    assert.equal(typeof loggerModule.logger.info, "function");
+    assert.equal(typeof loggerModule.createLogger("import-cycle-test").warn, "function");
+  } finally {
+    if (previousLogToFile === undefined) {
+      delete process.env.APP_LOG_TO_FILE;
+    } else {
+      process.env.APP_LOG_TO_FILE = previousLogToFile;
+    }
+  }
+});


### PR DESCRIPTION
## Scope

Restores the preserved three-file logger TDZ repair:

- makes `dataPaths` pure by injecting an optional writable-data-directory fallback callback;
- moves structured fallback-warning ownership to `db/core` after logger initialization;
- adds the direct import-cycle regression test.

## Provenance

- Base: `8a74889b23e277e41e7c362d24f91e8b0d2ac198`
- Head: `dc14dc2f3a184f26248cf72551d6af5e9eec20d9`
- Preserved WIP: `wip/omniroute-logger-tdz-20260814-preserved`
- Fresh qgate run 31857320814 now reaches coverage and first fails exactly at `logger.ts:203 <- dataPaths.ts:6`; prior read-cache duplicate export is cleared.

## Review/test boundary

The direct import regression is included. Add or verify a callback-payload assertion for EACCES/EPERM fallback before promotion; non-permission errors must continue to throw.

## Required gates

Fresh qgate and protected CI are required. DAST parser recovery, artifacts, and migration parity are separate lanes.