### PR TITLE
fix(sanitizer): restore module boundary

### DIFF
--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -518,37 +518,6 @@ function sanitizeChoice(choice: unknown, defaultIndex: number): JsonRecord {
   return sanitized;
 }
 
-/**
- * Sanitize a message object, extracting <think> tags if present.
- */
-function sanitizeMessage(msg: unknown): unknown {
-  const msgRecord = toRecord(msg);
-  if (!msgRecord) return msg;
-
-  const sanitized: JsonRecord = {};
-
-  // Copy only allowed fields
-  if (msgRecord.role) sanitized.role = msgRecord.role;
-  if (msgRecord.refusal !== undefined) sanitized.refusal = msgRecord.refusal;
-
-  // Handle content — extract <think> tags
-  if (typeof msgRecord.content === "string") {
-    const { content, thinking } = extractThinkingFromContent(
-      stripInternalToolEnvelopeText(msgRecord.content)
-    );
-    sanitized.content = collapseExcessiveNewlines(content);
-
-    // Set reasoning_content from prompt-format tags only when the provider did
-    // not also return a native OpenAI-compatible reasoning field.
-    if (thinking && !getReadableReasoningValue(msgRecord)) {
-      sanitized.reasoning_content = thinking;
-    }
-  } else if (msgRecord.content !== undefined) {
-    sanitized.content = msgRecord.content;
-  }
-
-  copyOpenAICompatibleReasoningFields(msgRecord, sanitized);
-
 function applyTextualToolCallSanitization(sanitized: JsonRecord, msgRecord: JsonRecord): void {
   const textualToolCall = parseTextualToolCallContent(sanitized.content);
   if (textualToolCall && !msgRecord.tool_calls) {

--- a/tests/unit/response-sanitizer.test.ts
+++ b/tests/unit/response-sanitizer.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 const {
   extractThinkingFromContent,
+  isResponsesCommentaryMessageItem,
   sanitizeOpenAIResponse,
   sanitizeResponsesApiResponse,
   sanitizeStreamingChunk,
@@ -899,4 +900,21 @@ test("sanitizeStreamingChunk leaves function_call_arguments.delta byte-exact (to
 
   assert.equal(sanitized.delta, '{"path":"o\u200dpencode"}');
   assert.equal((sanitized.delta as string).includes("\u200d"), true);
+});
+
+// Parser/import regression: an obsolete sanitizer body must never nest later module exports.
+test("response sanitizer imports and classifies commentary items", () => {
+  const sanitized = sanitizeOpenAIResponse({
+    choices: [{ message: { role: "assistant", content: "visible" } }],
+  }) as any;
+
+  assert.equal(sanitized.choices[0].message.content, "visible");
+  assert.equal(
+    isResponsesCommentaryMessageItem({ type: "message", role: "assistant", phase: "commentary" }),
+    true
+  );
+  assert.equal(
+    isResponsesCommentaryMessageItem({ type: "message", role: "assistant", phase: "final" }),
+    false
+  );
 });


### PR DESCRIPTION
## Scope

Fixes the first fatal backend-only DAST parser error only: removes the obsolete unclosed duplicate sanitizeMessage body, keeps the later option-aware implementation, and adds a direct module-import/commentary-classifier regression.

## Evidence

- Base: `8a74889b23e277e41e7c362d24f91e8b0d2ac198`
- Head: `6c5a53e741f39f5d87400985679bce7ea8a530d1`
- Red: DAST run 31856064272 failed at responseSanitizer.ts:729 because an export was nested inside the obsolete body.
- Local execution remains unavailable while the worktree-safety freeze is active.

## Required gates

Fresh hosted DAST and all CLI builds must pass this parser boundary before later dynamic-import/native-module failures are addressed. This is not a release claim.