### PR TITLE
fix(build): keep combo helper code frame ASCII

### DIFF
--- a/src/lib/combos/comboContext.ts
+++ b/src/lib/combos/comboContext.ts
@@ -18,7 +18,7 @@ import { PROVIDER_MODELS, PROVIDER_ID_TO_ALIAS } from "@/shared/constants/models
 import { getTokenLimit } from "@omniroute/open-sse/services/contextManager";
 import { buildAliasMaps, getComboTargetModelId } from "@/app/api/v1/models/catalogProviderMaps";
 
-/* ─── helpers ───────────────────────────────────────────────── */
+/* helpers */
 
 function isPositiveFiniteNumber(v: unknown): v is number {
   return typeof v === "number" && Number.isFinite(v) && v > 0;

--- a/tests/unit/turbopack-code-frame-ascii.test.ts
+++ b/tests/unit/turbopack-code-frame-ascii.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+test("compiled combo helper block comment is ASCII for Turbopack code frames", () => {
+  const source = fs.readFileSync(new URL("../../src/lib/combos/comboContext.ts", import.meta.url), "utf8");
+  const helperBlock = source.match(/\/\*[^\r\n]*helpers[^\r\n]*\*\//i)?.[0];
+
+  assert.ok(helperBlock, "expected the compiled combo helper block comment");
+  assert.match(
+    helperBlock,
+    /^[\x00-\x7F]*$/,
+    "Turbopack code-frame safety requires this compiled helper block comment to be ASCII"
+  );
+});


### PR DESCRIPTION
## Purpose

Avoid the known Next 16/Turbopack code-frame panic in the compiled backend-only combo path.

## Evidence

- RED on current main: the exact helper block comment in `src/lib/combos/comboContext.ts` contains box-drawing characters.
- Hosted DAST and Windows CLI builds panic while rendering that exact `... helpers ... */` code frame under Node 24.19.
- This PR replaces only that block comment with ASCII and adds a focused static regression test.
- Green preflight: transformed source and test parse with esbuild; the repaired helper block is `/* helpers */`.

## Scope

Two files only. This does not hide a build failure or change runtime logic; it prevents the error renderer from panicking so the actual build diagnostic can surface if another error remains.