### PR TITLE
fix(cache): remove duplicate model catalog version export

### DIFF
--- a/src/lib/db/readCache.ts
+++ b/src/lib/db/readCache.ts
@@ -254,15 +254,6 @@ export function getModelCatalogCacheVersion(): number {
 }
 
 /**
- * Current model-catalog-cache version. `getUnifiedModelsResponse()` folds this
- * into its response cache key; a change means settings/connections/combos were
- * written since the cache was populated and the cached body is stale.
- */
-export function getModelCatalogCacheVersion(): number {
-  return modelCatalogCacheVersion;
-}
-
-/**
  * Invalidate caches (call after writes to any of: settings, pricing,
  * connections, combos, nodes).
  *


### PR DESCRIPTION
## Scope

Stacked on #639 because both duplicate declarations must be removed before the existing transform split-guard can import `modelsDevSync`.

Removes the second, byte-identical `getModelCatalogCacheVersion` declaration in `src/lib/db/readCache.ts`.

## Validation

- RED: existing split-guard failed with duplicate `getModelCatalogCacheVersion` declarations.
- After this patch, it advances past both duplicate-export failures and now reaches an independent `logger` initialization cycle (`Cannot access logger before initialization`).
- `git diff --check` passes.

Draft until #639 lands and the separate logger-cycle baseline is repaired.