### PR TITLE
fix(providers): restore OpenAI registry entry factory

### DIFF
--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -150,6 +150,24 @@ export interface RegistryEntry {
   forceStream?: boolean;
 }
 
+/**
+ * Build a standard OpenAI-compatible provider registry entry.
+ * Eliminates the 4-field boilerplate (format, executor, authType, authHeader)
+ * repeated across provider files.
+ */
+export function buildOpenAiCompatibleRegistryEntry(
+  overrides: Pick<RegistryEntry, "id"> &
+    Partial<Omit<RegistryEntry, "id" | "format" | "executor" | "authType" | "authHeader">>
+): RegistryEntry {
+  return {
+    format: "openai",
+    executor: "default",
+    authType: "apikey",
+    authHeader: "bearer",
+    ...overrides,
+  } as RegistryEntry;
+}
+
 export interface LegacyProvider {
   format: string;
   baseUrl?: string;


### PR DESCRIPTION
## Recovery

Replays only the provider-factory export from preserved closed PR #636 after qgate on #641 reached `shared.ts` and failed because `buildOpenAiCompatibleRegistryEntry` was absent.

## Validation

- `npx prettier --check open-sse/config/providers/shared.ts`
- structural export check
- `git diff --check`
- Existing focused factory test was RED before this change on the missing export. After restoration, it advances to the unrelated pre-existing `ANTIGRAVITY_FALLBACK_VERSION is not defined` module-evaluation failure; this PR intentionally does not change that separate provider-startup issue.

Stacked on #641; do not merge independently before its base.