### PR TITLE
fix(antigravity): restore header identity contract

### DIFF
--- a/open-sse/services/antigravityHeaders.ts
+++ b/open-sse/services/antigravityHeaders.ts
@@ -1,5 +1,6 @@
 import type { AntigravityClientProfile } from "@/shared/constants/antigravityClientProfile";
 import {
+  ANTIGRAVITY_IDE_FALLBACK_VERSION,
   getCachedAntigravityCliVersion,
   getCachedAntigravityIdeVersion,
 } from "./antigravityVersion.ts";
@@ -7,13 +8,17 @@ import {
 export const ANTIGRAVITY_IDE_NODE_API_CLIENT = "google-api-nodejs-client/10.3.0";
 export const ANTIGRAVITY_IDE_NODE_X_GOOG_API_CLIENT = "gl-node/22.21.1";
 
-type AntigravityHeaderProfile = "loadCodeAssist" | "fetchAvailableModels" | "models";
+// Antigravity presents the native macOS desktop client fingerprint: the upstream
+// backend expects the Mac build, so the OS/arch token is pinned to darwin/arm64
+// regardless of the host OmniRoute happens to run on. The IDE / CLI / IDE-Node
+// User-Agent split is preserved; only the platform token is fixed.
+const ANTIGRAVITY_OS_TYPE = "darwin";
+const ANTIGRAVITY_ARCH = "arm64";
 
-const ANTIGRAVITY_VERSION = ANTIGRAVITY_FALLBACK_VERSION;
 // IDE desktop fingerprint synced with Antigravity-Manager v4.2.0 constants.rs.
 export const ANTIGRAVITY_CHROME_VERSION = "142.0.7444.175";
 export const ANTIGRAVITY_ELECTRON_VERSION = "39.2.3";
-export const ANTIGRAVITY_LOAD_CODE_ASSIST_USER_AGENT = `vscode/1.X.X (Antigravity/${ANTIGRAVITY_FALLBACK_VERSION})`;
+export const ANTIGRAVITY_LOAD_CODE_ASSIST_USER_AGENT = `vscode/1.X.X (Antigravity/${ANTIGRAVITY_IDE_FALLBACK_VERSION})`;
 export const ANTIGRAVITY_LOAD_CODE_ASSIST_API_CLIENT = "";
 export const ANTIGRAVITY_NODE_API_CLIENT = "google-api-nodejs-client/10.3.0";
 // Harness/bootstrap X-Goog-Api-Client synced with CLIProxyAPI misc.AntigravityGoogAPIClientUA.
@@ -30,6 +35,17 @@ function withOptionalBearerAuth(
   return headers;
 }
 
+function getAntigravityPlatformInfo(platform: NodeJS.Platform): string {
+  switch (platform) {
+    case "darwin":
+      return "Macintosh; Intel Mac OS X 10_15_7";
+    case "win32":
+      return "Windows NT 10.0; Win64; x64";
+    default:
+      return "X11; Linux x86_64";
+  }
+}
+
 export function antigravityIdeUserAgent(version = getCachedAntigravityIdeVersion()): string {
   return `antigravity/ide/${version} ${ANTIGRAVITY_OS_TYPE}/${ANTIGRAVITY_ARCH}`;
 }
@@ -39,8 +55,15 @@ export function antigravityIdeUserAgent(version = getCachedAntigravityIdeVersion
  * "Antigravity/VERSION (PLATFORM) Chrome/142... Electron/39..."
  */
 export function antigravityUserAgent(
-  version = getCachedAntigravityVersion(),
+  version = getCachedAntigravityIdeVersion(),
   platform: NodeJS.Platform = process.platform
+): string {
+  return `Antigravity/${version} (${getAntigravityPlatformInfo(platform)}) Chrome/${ANTIGRAVITY_CHROME_VERSION} Electron/${ANTIGRAVITY_ELECTRON_VERSION}`;
+}
+
+export function antigravityCliUserAgent(
+  version = getCachedAntigravityCliVersion(),
+  authMethod = "consumer"
 ): string {
   return `antigravity/cli/${version} (aidev_client; os_type=${ANTIGRAVITY_OS_TYPE}; arch=${ANTIGRAVITY_ARCH}; auth_method=${authMethod})`;
 }


### PR DESCRIPTION
## Recovery

Restores the coherent Antigravity header contract after a partial merge left module initialization and multiple public functions broken. Preserves both the native IDE/CLI identity split and the desktop Antigravity Manager fingerprint API required by current tests.

## Validation

- `node --import tsx/esm --test tests/unit/antigravity-headers.test.ts` (6/6)
- `node --import tsx/esm --test tests/unit/refactor-registryFactory.test.ts` (8/8)
- logger import-cycle test (1/1)
- models.dev transform suite (7/7)
- Prettier and `git diff --check`

The broader `antigravity-client-profile.test.ts` still contains pre-existing missing test bindings and is intentionally outside this one-file runtime-contract recovery.

Stacked on #642; review/merge only after the full base chain.