### PR TITLE
fix(web): preserve BFF proxy transport contract

### DIFF
--- a/apps/web/src/routes/api/[...path]/+server.ts
+++ b/apps/web/src/routes/api/[...path]/+server.ts
@@ -1,0 +1,89 @@
+import { bffUrl } from "$lib/server/bff";
+import { error } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+
+const BFF_ROUTE_FAMILIES = new Set(["auth", "dashboard", "trpc"]);
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+function proxyHeaders(
+  request: Request,
+  url: URL,
+  getClientAddress?: () => string
+): Headers {
+  const headers = new Headers();
+  for (const name of ["accept", "content-type", "cookie", "x-request-id"]) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  headers.set("x-forwarded-proto", url.protocol.slice(0, -1));
+  headers.set("x-forwarded-host", url.host);
+  const clientAddress = getClientAddress?.();
+  if (clientAddress) headers.set("x-forwarded-for", clientAddress);
+  return headers;
+}
+
+function proxyResponseHeaders(source: Headers): Headers {
+  const headers = new Headers();
+  const connectionHeaders = new Set(
+    (source.get("connection") ?? "")
+      .split(",")
+      .map((header) => header.trim().toLowerCase())
+      .filter(Boolean)
+  );
+  source.forEach((value, name) => {
+    const normalizedName = name.toLowerCase();
+    if (
+      normalizedName !== "set-cookie" &&
+      !HOP_BY_HOP_HEADERS.has(normalizedName) &&
+      !connectionHeaders.has(normalizedName)
+    ) {
+      headers.set(name, value);
+    }
+  });
+
+  type HeadersWithSetCookie = Headers & { getSetCookie?: () => string[] };
+  const getSetCookie = (source as HeadersWithSetCookie).getSetCookie;
+  const cookies = getSetCookie
+    ? getSetCookie.call(source)
+    : [source.get("set-cookie")].filter((cookie): cookie is string => cookie !== null);
+  for (const cookie of cookies) {
+    headers.append("set-cookie", cookie);
+  }
+  return headers;
+}
+
+async function proxyToBff(
+  { params, request, fetch, getClientAddress, url }: Parameters<RequestHandler>[0],
+  method: "GET" | "POST" | "PUT" | "DELETE"
+): Promise<Response> {
+  const [family] = params.path.split("/");
+  if (!BFF_ROUTE_FAMILIES.has(family)) error(404, "API route not found");
+
+  const target = bffUrl(`/api/${params.path}`);
+  target.search = url.search;
+  const response = await fetch(target, {
+    method,
+    headers: proxyHeaders(request, url, getClientAddress),
+    body: method === "GET" ? undefined : await request.arrayBuffer(),
+  });
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: proxyResponseHeaders(response.headers),
+  });
+}
+
+export const GET: RequestHandler = (event) => proxyToBff(event, "GET");
+export const POST: RequestHandler = (event) => proxyToBff(event, "POST");
+export const PUT: RequestHandler = (event) => proxyToBff(event, "PUT");
+export const DELETE: RequestHandler = (event) => proxyToBff(event, "DELETE");

--- a/apps/web/tests/unit/routes/proxy-handlers.test.ts
+++ b/apps/web/tests/unit/routes/proxy-handlers.test.ts
@@ -1,16 +1,32 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from "vitest";
 
-vi.mock('$lib/server/bff', () => ({ bffUrl: (path: string) => `http://bff.test${path}` }));
+vi.mock("$lib/server/bff", () => ({ bffUrl: (path: string) => new URL(`http://bff.test${path}`) }));
 
-import { GET } from '../../../src/routes/api/bff/healthz/+server';
-import { POST } from '../../../src/routes/api/v1/telemetry/web-vitals/+server';
+import { GET } from "../../../src/routes/api/bff/healthz/+server";
+import { POST } from "../../../src/routes/api/v1/telemetry/web-vitals/+server";
+import {
+  DELETE as proxyDelete,
+  GET as proxyGet,
+  POST as proxyPost,
+  PUT as proxyPut,
+} from "../../../src/routes/api/[...path]/+server";
 
-describe('typed proxy route handlers', () => {
-  it('preserves the BFF health response', async () => {
-    const fetch = vi.fn(async () => new Response('{"ok":true}', {
-      status: 200,
-      headers: { 'content-type': 'application/json' },
-    }));
+function responseCookies(headers: Headers): string[] {
+  const getSetCookie = (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie;
+  return getSetCookie
+    ? getSetCookie.call(headers)
+    : [headers.get("set-cookie")].filter((cookie): cookie is string => cookie !== null);
+}
+
+describe("typed proxy route handlers", () => {
+  it("preserves the BFF health response", async () => {
+    const fetch = vi.fn(
+      async () =>
+        new Response('{"ok":true}', {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+    );
     const response = await GET({ fetch } as unknown as Parameters<typeof GET>[0]);
 
     expect(fetch).toHaveBeenCalledOnce();
@@ -18,12 +34,14 @@ describe('typed proxy route handlers', () => {
     expect(await response.text()).toBe('{"ok":true}');
   });
 
-  it('preserves the telemetry request body', async () => {
-    const fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) =>
-      new Response(init?.body, { status: 202, headers: { 'content-type': 'application/json' } }));
-    const request = new Request('http://localhost/api/v1/telemetry/web-vitals', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
+  it("preserves the telemetry request body", async () => {
+    const fetch = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Response(init?.body, { status: 202, headers: { "content-type": "application/json" } })
+    );
+    const request = new Request("http://localhost/api/v1/telemetry/web-vitals", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
       body: '{"name":"LCP","value":1}',
     });
     const response = await POST({ request, fetch } as unknown as Parameters<typeof POST>[0]);
@@ -33,13 +51,183 @@ describe('typed proxy route handlers', () => {
     expect(await response.text()).toBe('{"name":"LCP","value":1}');
   });
 
-  it('rejects telemetry without content-type as 415', async () => {
-    const request = new Request('http://localhost/api/v1/telemetry/web-vitals', {
-      method: 'POST',
+  it("rejects telemetry without content-type as 415", async () => {
+    const request = new Request("http://localhost/api/v1/telemetry/web-vitals", {
+      method: "POST",
       body: '{"name":"LCP","value":1}',
     });
 
-    await expect(POST({ request, fetch: vi.fn() } as unknown as Parameters<typeof POST>[0]))
-      .rejects.toMatchObject({ status: 415 });
+    await expect(
+      POST({ request, fetch: vi.fn() } as unknown as Parameters<typeof POST>[0])
+    ).rejects.toMatchObject({ status: 415 });
+  });
+
+  it("forwards a browser tRPC read with the BFF session and trusted request metadata", async () => {
+    const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("http://bff.test/api/trpc/providers.list?batch=1&input=%7B%7D");
+      expect(init?.method).toBe("GET");
+      const headers = new Headers(init?.headers);
+      expect(headers.get("cookie")).toBe("session=browser-session");
+      expect(headers.get("x-forwarded-proto")).toBe("https");
+      expect(headers.get("x-forwarded-host")).toBe("renderer.test");
+      expect(headers.get("x-forwarded-for")).toBe("203.0.113.7");
+      expect(headers.get("x-request-id")).toBe("requestid123");
+      return new Response('{"result":[]}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const request = new Request(
+      "https://renderer.test/api/trpc/providers.list?batch=1&input=%7B%7D",
+      {
+        headers: {
+          cookie: "session=browser-session",
+          "x-forwarded-for": "198.51.100.9",
+          "x-forwarded-host": "spoofed.example",
+          "x-forwarded-proto": "http",
+          "x-request-id": "requestid123",
+        },
+      }
+    );
+
+    const response = await proxyGet({
+      params: { path: "trpc/providers.list" },
+      request,
+      fetch,
+      url: new URL(request.url),
+      getClientAddress: () => "203.0.113.7",
+    } as unknown as Parameters<typeof proxyGet>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"result":[]}');
+  });
+
+  it("forwards a dashboard mutation body and session cookie to the BFF", async () => {
+    const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("http://bff.test/api/dashboard/settings");
+      expect(init?.method).toBe("POST");
+      expect(new Headers(init?.headers).get("content-type")).toBe("application/json");
+      expect(new Headers(init?.headers).get("cookie")).toBe("session_id=browser-session");
+      expect(await new Response(init?.body).text()).toBe('{"theme":"dark"}');
+      return new Response('{"ok":true}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const request = new Request("http://renderer.test/api/dashboard/settings", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie: "session_id=browser-session",
+      },
+      body: '{"theme":"dark"}',
+    });
+
+    const response = await proxyPost({
+      params: { path: "dashboard/settings" },
+      request,
+      fetch,
+      url: new URL(request.url),
+    } as unknown as Parameters<typeof proxyPost>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"ok":true}');
+  });
+
+  it("preserves an auth callback session cookie from the BFF", async () => {
+    const fetch = vi.fn(async () => {
+      const headers = new Headers({ "content-type": "application/json" });
+      headers.append("set-cookie", "session=callback-session; Path=/; HttpOnly; SameSite=Lax");
+      return new Response('{"ok":true}', { status: 200, headers });
+    });
+    const request = new Request("http://renderer.test/api/auth/callback?code=one-time-code");
+
+    const response = await proxyGet({
+      params: { path: "auth/callback" },
+      request,
+      fetch,
+      url: new URL(request.url),
+    } as unknown as Parameters<typeof proxyGet>[0]);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toContain("session=callback-session");
+  });
+
+  it("forwards PUT and DELETE requests with their bodies and preserves transport response headers", async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.method).toBe("PUT");
+      expect(await new Response(init?.body).text()).toBe('{"theme":"light"}');
+      return new Response(null, {
+        status: 201,
+        headers: {
+          location: "/api/dashboard/settings/next",
+          "cache-control": "no-store",
+          "retry-after": "30",
+          "set-cookie": "session=updated-session; Path=/; HttpOnly",
+        },
+      });
+    });
+    const putRequest = new Request("https://renderer.test/api/dashboard/settings", {
+      method: "PUT",
+      headers: { "content-type": "application/json", cookie: "session=browser-session" },
+      body: '{"theme":"light"}',
+    });
+
+    const putResponse = await proxyPut({
+      params: { path: "dashboard/settings" },
+      request: putRequest,
+      fetch,
+      url: new URL(putRequest.url),
+      getClientAddress: () => "203.0.113.7",
+    } as unknown as Parameters<typeof proxyPut>[0]);
+
+    expect(putResponse.status).toBe(201);
+    expect(putResponse.headers.get("location")).toBe("/api/dashboard/settings/next");
+    expect(putResponse.headers.get("cache-control")).toBe("no-store");
+    expect(putResponse.headers.get("retry-after")).toBe("30");
+
+    const deleteFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.method).toBe("DELETE");
+      expect(await new Response(init?.body).text()).toBe('{"reason":"logout"}');
+      const headers = new Headers({ "cache-control": "no-store" });
+      headers.append("set-cookie", "session=; Path=/; Max-Age=0");
+      headers.append("set-cookie", "csrf=rotated-token; Path=/; SameSite=Lax");
+      return new Response(null, { status: 204, headers });
+    });
+    const deleteRequest = new Request("https://renderer.test/api/dashboard/sessions/current", {
+      method: "DELETE",
+      headers: { "content-type": "application/json", cookie: "session=browser-session" },
+      body: '{"reason":"logout"}',
+    });
+
+    const deleteResponse = await proxyDelete({
+      params: { path: "dashboard/sessions/current" },
+      request: deleteRequest,
+      fetch: deleteFetch,
+      url: new URL(deleteRequest.url),
+      getClientAddress: () => "203.0.113.7",
+    } as unknown as Parameters<typeof proxyDelete>[0]);
+
+    expect(deleteResponse.status).toBe(204);
+    expect(responseCookies(deleteResponse.headers)).toEqual([
+      "session=; Path=/; Max-Age=0",
+      "csrf=rotated-token; Path=/; SameSite=Lax",
+    ]);
+  });
+
+  it("rejects route families that are not BFF-owned before fetching", async () => {
+    const fetch = vi.fn();
+    const request = new Request("http://renderer.test/api/v1/telemetry/web-vitals");
+
+    await expect(
+      proxyGet({
+        params: { path: "v1/telemetry/web-vitals" },
+        request,
+        fetch,
+        url: new URL(request.url),
+      } as unknown as Parameters<typeof proxyGet>[0])
+    ).rejects.toMatchObject({ status: 404 });
+
+    expect(fetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Scope

Restores the Svelte BFF proxy contract in exactly two paths: forwarded trusted request context, PUT/DELETE body forwarding, and selected upstream response-header and multi-cookie preservation.

## Evidence

- Base: `8a74889b23e277e41e7c362d24f91e8b0d2ac198`
- Head: `e4a1206867620179867f31637ad812957f9b6260`
- Red: focused proxy tests failed for missing forwarded context and PUT handler.
- Green: focused Vitest 8/8; `svelte-check` 0 errors/0 warnings; `npm ci --ignore-scripts`; `git diff --check`.

## Boundary

This is a user-facing transport-parity slice only. It does not claim backend/frontend feature parity, hosted CI success, release readiness, or desktop dogfood evidence. Hosted checks and review remain required.