### PR TITLE
fix(omlx-sse): drop 104 lines of duplicate re-exports from modelsDevSync.ts

### DIFF
--- a/src/lib/modelsDevSync.ts
+++ b/src/lib/modelsDevSync.ts
@@ -49,27 +49,6 @@ export type {
   PricingByProvider,
 } from "./modelsDevSync/transform";
 
-import {
-  transformModelsDevToPricing,
-  transformModelsDevToCapabilities,
-} from "./modelsDevSync/transform";
-import type {
-  PricingModels,
-  PricingByProvider,
-  ModelCapabilityEntry,
-  CapabilitiesByProvider,
-  ModelsDevData,
-} from "./modelsDevSync/transform";
-
-// Re-export the pure transform layer (moved to ./modelsDevSync/transform)
-// so this module's public API is unchanged.
-export {
-  mapProviderId,
-  transformModelsDevToPricing,
-  transformModelsDevToCapabilities,
-} from "./modelsDevSync/transform";
-export type { ModelCapabilityEntry, CapabilitiesByProvider } from "./modelsDevSync/transform";
-
 // ─── Types ───────────────────────────────────────────────
 
 interface SyncStatus {
@@ -98,89 +77,6 @@ const MODELS_DEV_API_URL = "https://models.dev/api.json";
 const parsedInterval = parseInt(process.env.MODELS_DEV_SYNC_INTERVAL || "86400", 10);
 const SYNC_INTERVAL_MS =
   Number.isFinite(parsedInterval) && parsedInterval > 0 ? parsedInterval * 1000 : 86400 * 1000;
-
-// ─── Provider mapping: models.dev provider ID → OmniRoute provider IDs/aliases ──
-//
-// models.dev uses canonical provider IDs (e.g. "openai", "anthropic", "google").
-// OmniRoute uses both full IDs and short aliases (e.g. "cc" for claude, "cx" for codex).
-// We map each models.dev provider to ALL OmniRoute identifiers that should receive
-// its pricing/capability data.
-
-const MODELS_DEV_PROVIDER_MAP: Record<string, string[]> = {
-  // Major providers
-  openai: ["openai", "cx"], // cx = Codex (uses OpenAI models)
-  anthropic: ["anthropic", "cc"], // cc = Claude Code
-  google: ["gemini"],
-  "google-vertex": ["gemini", "vertex"],
-  "google-vertex-anthropic": ["anthropic", "cc", "vertex"],
-  vertex_ai: ["gemini", "vertex"],
-  deepseek: ["deepseek", "if"], // if = Qoder (routes through DeepSeek)
-  groq: ["groq"],
-  xai: ["xai"],
-  mistral: ["mistral"],
-  togetherai: ["together", "openrouter"],
-  together_ai: ["together", "openrouter"],
-  "fireworks-ai": ["fireworks"],
-  fireworks: ["fireworks"],
-  cerebras: ["cerebras"],
-  cohere: ["cohere"],
-  nvidia: ["nvidia"],
-  nebius: ["nebius"],
-  siliconflow: ["siliconflow"],
-  hyperbolic: ["hyperbolic"],
-  huggingface: ["hf", "huggingface"],
-  openrouter: ["openrouter"],
-  perplexity: ["pplx", "perplexity"],
-  // OAuth / special providers
-  bedrock: ["kiro", "kr"], // kr = Kiro (AWS Bedrock)
-  "github-copilot": ["github", "gh"],
-  "github-models": ["github", "gh"],
-  kilo: ["kilocode", "kc", "kilo-gateway"],
-  kilocode: ["kilocode", "kc", "kilo-gateway"],
-  "kimi-for-coding": ["kimi-coding", "kmc", "kimi-coding-apikey", "kmca"],
-  // The `opencode` models.dev entry used to map only to "opencode-zen" because
-  // that is the historical alias pair. But OmniRoute's catalog & combo targets
-  // reference models under BOTH provider IDs:
-  //   - `opencode-zen/big-pickle` (alias form)
-  //   - `opencode/big-pickle`    (canonical id form, used by live API catalog
-  //                               and by combos like "Opencode FREE Omni")
-  // If we only store synced capabilities under "opencode-zen", the canonical
-  // `opencode/<model>` lookup in getCanonicalModelMetadata returns null and
-  // any combo that targets `opencode/...` ends up with no computed context.
-  // Symmetric mapping keeps both lookup paths populated.
-  opencode: ["opencode", "opencode-zen"],
-  "opencode-go": ["opencode-go", "opencode-zen"],
-  // Additional providers that may overlap with OmniRoute
-  alibaba: ["ali", "alibaba"],
-  "alibaba-cn": ["ali-cn", "alibaba-cn", "alibaba-china"],
-  "alibaba-coding-plan": ["bcp", "bailian-coding-plan"],
-  zai: ["zai", "glm"], // GLM models via Z.AI
-  "zai-coding-plan": ["zai", "glm"],
-  moonshotai: ["moonshot", "kimi"],
-  "moonshotai-cn": ["moonshot", "kimi"],
-  moonshot: ["moonshot", "kimi", "kimi-coding", "kmc", "kmca"],
-  minimax: ["minimax", "minimax-cn"],
-  "minimax-cn": ["minimax-cn"],
-  longcat: ["lc", "longcat"],
-  pollinations: ["pol", "pollinations"],
-  puter: ["pu", "puter"],
-  cloudflare: ["cf"],
-  scaleway: ["scw"],
-  ollama: ["ollamacloud", "ollama-cloud"],
-  blackbox: ["bb", "blackbox"],
-  cline: ["cl", "cline"],
-  cursor: ["cu", "cursor"],
-  github: ["gh", "github"],
-  // Fallback: if no mapping exists, use the models.dev ID as-is
-};
-
-/**
- * Map a models.dev provider ID to OmniRoute provider IDs.
- * Returns array of provider identifiers (may include aliases).
- */
-export function mapProviderId(modelsDevProviderId: string): string[] {
-  return MODELS_DEV_PROVIDER_MAP[modelsDevProviderId] || [modelsDevProviderId];
-}
 
 // ─── Periodic sync state ─────────────────────────────────
 


### PR DESCRIPTION
## **User description**
Forward-port of `fix/models-dev-sync-duplicate-exports-20260816` (single commit, tip `fcc1cf5ccf6f`) onto current main (`8a74889b23`).

## What this PR does

The original commit removes the inline provider-mapping table and redundant re-exports from `src/lib/modelsDevSync.ts` because the same types and mappings were already being imported from the consolidated location at `./modelsDevSync/transform`. Keeping both copies was causing duplicate-export lint warnings in the registry test suite.

## Diff stat

```
1 file changed, 104 deletions(-)
```

No semantic change — symbols are still imported, just from the canonical (consolidated) location instead of being re-declared here.

🤖 Generated with [Forge](https://forgecode.dev)


___

## **CodeAnt-AI Description**
Consolidate model sync provider mappings without changing behavior

### What Changed
- Model synchronization continues to use the same provider mappings, pricing data, and capability data
- Duplicate exports and the locally repeated provider mapping table were removed
- Existing public model-sync exports remain available from the shared source

### Impact
`✅ Fewer duplicate-export lint warnings`
`✅ Consistent provider mappings during model sync`
`✅ No change to synced pricing or capability results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated model synchronization exports and transformations.
  * Preserved provider ID mapping functionality through the shared transformation layer.
  * Made pricing-by-provider information publicly available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->