### PR TITLE
fix(auth): remove duplicated management-password constant

### DIFF
--- a/src/lib/auth/managementPassword.ts
+++ b/src/lib/auth/managementPassword.ts
@@ -25,10 +25,6 @@ const ARGON2ID_HASH_PATTERN = /^\$argon2(id|i)\$v=\d+\$/;
 // with it leaves the dashboard open to anyone, so we warn loudly on boot (Seg2 hardening).
 const INSECURE_DEFAULT_PASSWORDS = new Set(["CHANGEME"]);
 
-// Well-known placeholder shipped in `.env.example` (INITIAL_PASSWORD=CHANGEME). Bootstrapping
-// with it leaves the dashboard open to anyone, so we warn loudly on boot (Seg2 hardening).
-const INSECURE_DEFAULT_PASSWORDS = new Set(["CHANGEME"]);
-
 type JsonRecord = Record<string, unknown>;
 
 type MigrationSource = "stored_hash" | "stored_plaintext" | "env" | "missing";
@@ -144,7 +140,7 @@ export async function ensurePersistentManagementPasswordHash(
     warn(
       '[AUTH][SECURITY] Management password is set to the well-known default "CHANGEME" ' +
         "(INITIAL_PASSWORD in .env.example). Anyone can sign in to the dashboard with it — " +
-        "change it immediately via the dashboard or a strong INITIAL_PASSWORD."
+        "change it immediately via the dashboard or a strong INITIAL_PASSWORD.",
     );
   }
 

--- a/tests/unit/management-password-parser-integrity.test.ts
+++ b/tests/unit/management-password-parser-integrity.test.ts
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+test("management password source declares its insecure-default set once", () => {
+  const source = fs.readFileSync(new URL("../../../src/lib/auth/managementPassword.ts", import.meta.url), "utf8");
+  assert.equal((source.match(/const INSECURE_DEFAULT_PASSWORDS/g) ?? []).length, 1);
+  assert.doesNotThrow(() => new Bun.Transpiler({ loader: "ts" }).transformSync(source));
+});


### PR DESCRIPTION
## What
Restores `src/lib/auth/managementPassword.ts` from `bcc8ae99cb`, removing the exact duplicated `INSECURE_DEFAULT_PASSWORDS` declaration; adds a source-level regression test.

## Evidence
- Current main: Bun TypeScript transpilation reports the duplicate declaration.
- Diff shows only duplicated comment/constant and a comma difference after the ancestor.

## Non-claims
This does not add the separately missing `@node-rs/argon2` package or claim a release.