### PR TITLE
fix(runtime): break data-path logger initialization cycle

### DIFF
--- a/src/lib/dataPaths.ts
+++ b/src/lib/dataPaths.ts
@@ -1,11 +1,18 @@
 import path from "path";
 import os from "os";
 import fs from "fs";
-import { createLogger } from "@/shared/utils/logger";
-
-const log = createLogger("lib:data-paths");
 
 export const APP_NAME = "omniroute";
+
+function warnConfiguredDataDirFallback(resolved: string, fallback: string, code: string) {
+  try {
+    process.stderr.write(
+      `[data-paths] configured DATA_DIR is not writable (${code}); falling back from ${resolved} to ${fallback}\n`
+    );
+  } catch {
+    // Logging must not make data-directory recovery fail.
+  }
+}
 
 function fallbackHomeDir() {
   const envHome = process.env.HOME || process.env.USERPROFILE;
@@ -103,10 +110,7 @@ export function resolveWritableDataDir({ isCloud = false }: { isCloud?: boolean 
     const code = (err as NodeJS.ErrnoException | null)?.code;
     if (code === "EACCES" || code === "EPERM") {
       const fallback = getDefaultDataDir();
-      log.warn(
-        { resolved, fallback, code },
-        "data-paths: configured DATA_DIR is not writable — falling back to default"
-      );
+      warnConfiguredDataDirFallback(resolved, fallback, code);
       return fallback;
     }
     throw err;

--- a/tests/unit/data-paths-logger-cycle.test.ts
+++ b/tests/unit/data-paths-logger-cycle.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("dataPaths initializes without recursively initializing the logger", async () => {
+  const dataPaths = await import("../../src/lib/dataPaths.ts?logger-cycle-regression");
+
+  assert.equal(dataPaths.APP_NAME, "omniroute");
+  assert.equal(typeof dataPaths.resolveWritableDataDir, "function");
+});


### PR DESCRIPTION
## Summary
- remove the dependency from `dataPaths` to the structured logger, breaking the `logger -> logEnv -> dataPaths -> logger` initialization cycle
- retain fallback observability through best-effort stderr output
- add a dynamic-import regression that fails on the former TDZ

## Validation
- `bun test tests/unit/data-paths-logger-cycle.test.ts` (1 pass)
- `npx prettier --check src/lib/dataPaths.ts tests/unit/data-paths-logger-cycle.test.ts`
- `npx eslint src/lib/dataPaths.ts tests/unit/data-paths-logger-cycle.test.ts`
- `git diff --check`

## Known baseline
- `data-dir-writable-fallback.test.ts` progresses beyond the original cycle, but its writable-fallback assertion assumes `HOME` changes `os.homedir()` under Bun; that test is not changed here.
- Airlock is not enrolled in this isolated worktree, so no Airlock snapshot was created.