### PR TITLE
fix(ci): use webpack for DAST backend build

### DIFF
--- a/.github/workflows/dast-smoke.yml
+++ b/.github/workflows/dast-smoke.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Build CLI bundle
         env:
           OMNIROUTE_BUILD_BACKEND_ONLY: "1"
+          # Next/Turbopack can panic while rendering a Unicode code frame before the
+          # backend starts. DAST validates the API only, so use the documented
+          # webpack compatibility escape hatch without changing release builds.
+          OMNIROUTE_USE_TURBOPACK: "0"
         run: npm run build:cli
       - name: Start OmniRoute
         env:

--- a/.github/workflows/dast-smoke.yml
+++ b/.github/workflows/dast-smoke.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Build CLI bundle
         env:
           OMNIROUTE_BUILD_BACKEND_ONLY: "1"
-          # Next/Turbopack can panic while rendering a Unicode code frame before the
-          # backend starts. DAST validates the API only, so use the documented
+          # Next/Turbopack can panic while rendering a Unicode code frame.
+          # DAST validates the API only, so use the documented
           # webpack compatibility escape hatch without changing release builds.
           OMNIROUTE_USE_TURBOPACK: "0"
         run: npm run build:cli

--- a/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
+++ b/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
@@ -744,3 +744,11 @@ Status: [complete] — PR #420 merge conflict resolved, pushed.
 - [DONE] Focused assembler/build tests pass 4/4, including the missing-manifest regression, package scope assertion, CJS guard assertion, and sidecar parity.
 - [WAIT] The next hosted DAST run is the authoritative proof that `dist/server.js` binds before Schemathesis; do not infer endpoint health until it does.
 - This entry is append-only.
+
+## 2026-08-17T00:37Z - DAST webpack compatibility control (fix-dast-webpack-compat-20260817)
+
+- [STATE] Opened draft PR #657 from `origin/main` `8a74889b2`: https://github.com/KooshaPari/OmniRoute/pull/657.
+- [ROOT CAUSE] The hosted DAST backend-only build panicked inside Next 16 Turbopack's Unicode code-frame renderer before the API server started. This is a bundler diagnostic failure, not proof of an application-route failure.
+- [DONE] DAST alone now sets the existing `OMNIROUTE_USE_TURBOPACK=0` webpack compatibility escape hatch; normal, package, and release builds retain the default Turbopack path. The workflow contract test was observed RED before the setting and GREEN 7/7 after; YAML, Actionlint, Prettier, and diff checks pass.
+- [LIMIT] The local backend-only webpack build reached `Creating an optimized production build ...` without that Turbopack panic but exited without `dist/server.js`; do not claim a local full-build pass. Hosted DAST is the authoritative remaining proof.
+- This entry is append-only.

--- a/tests/unit/build/backend-only-smoke-workflows.test.ts
+++ b/tests/unit/build/backend-only-smoke-workflows.test.ts
@@ -73,12 +73,26 @@ for (const { file, jobName, stepName } of TARGETS) {
   });
 }
 
+test("dast-smoke.yml builds the backend-only bundle with webpack when Turbopack's code-frame renderer is incompatible", () => {
+  const doc = loadWorkflow("dast-smoke.yml");
+  const buildStep = doc.jobs["dast-smoke"].steps.find((s) => s.name === "Build CLI bundle");
+  assert.ok(buildStep, "dast-smoke.yml must keep its backend bundle build step");
+  assert.equal(
+    buildStep.env?.OMNIROUTE_USE_TURBOPACK,
+    "0",
+    "DAST must use the documented webpack escape hatch so a Turbopack code-frame panic cannot prevent the API smoke from starting"
+  );
+});
+
 test("npm-publish.yml 'Build CLI bundle (standalone app)' step must NOT be backend-only (it legitimately ships the full dashboard UI)", () => {
   const doc = loadWorkflow("npm-publish.yml");
   const publishJob = Object.values(doc.jobs).find((job) =>
     job.steps.some((s) => s.name === "Build CLI bundle (standalone app)")
   );
-  assert.ok(publishJob, "npm-publish.yml must have a job with a 'Build CLI bundle (standalone app)' step");
+  assert.ok(
+    publishJob,
+    "npm-publish.yml must have a job with a 'Build CLI bundle (standalone app)' step"
+  );
   const step = publishJob!.steps.find((s) => s.name === "Build CLI bundle (standalone app)")!;
   assert.equal(
     isBackendOnly(step),


### PR DESCRIPTION
## Summary
- use the existing webpack escape hatch only for the API-only DAST build
- retain Turbopack as the default for normal and release builds
- guard the DAST workflow contract with a focused unit test

## Evidence
- RED: DAST workflow assertion failed because `OMNIROUTE_USE_TURBOPACK` was unset
- GREEN: `node --import tsx --test tests/unit/build/backend-only-smoke-workflows.test.ts` (7/7)
- `actionlint .github/workflows/dast-smoke.yml`
- `npx prettier --check .github/workflows/dast-smoke.yml tests/unit/build/backend-only-smoke-workflows.test.ts`
- local backend-only webpack build reached Next optimized-production stage without the hosted Turbopack Unicode code-frame panic; it did not complete to `dist/server.js`, so hosted DAST remains the required proof

## Scope
DAST-only workflow compatibility change. No release, desktop, or publication claim.