### PR TITLE
fix(startup): break data path logger cycle

### DIFF
--- a/src/lib/dataPaths.ts
+++ b/src/lib/dataPaths.ts
@@ -1,11 +1,12 @@
 import path from "path";
 import os from "os";
 import fs from "fs";
-import { createLogger } from "@/shared/utils/logger";
-
-const log = createLogger("lib:data-paths");
-
 export const APP_NAME = "omniroute";
+
+type WritableDataDirOptions = {
+  isCloud?: boolean;
+  onPermissionFallback?: (details: { resolved: string; fallback: string; code: "EACCES" | "EPERM" }) => void;
+};
 
 function fallbackHomeDir() {
   const envHome = process.env.HOME || process.env.USERPROFILE;
@@ -86,7 +87,10 @@ export function resolveDataDir({ isCloud = false }: { isCloud?: boolean } = {}):
  * Use this only at the single startup site that owns directory creation
  * (currently `db/core.ts`); everywhere else keep using the pure resolver.
  */
-export function resolveWritableDataDir({ isCloud = false }: { isCloud?: boolean } = {}): string {
+export function resolveWritableDataDir({
+  isCloud = false,
+  onPermissionFallback,
+}: WritableDataDirOptions = {}): string {
   const resolved = resolveDataDir({ isCloud });
 
   // Cloud/serverless never owns a writable home dir; leave its sentinel alone.
@@ -103,10 +107,7 @@ export function resolveWritableDataDir({ isCloud = false }: { isCloud?: boolean 
     const code = (err as NodeJS.ErrnoException | null)?.code;
     if (code === "EACCES" || code === "EPERM") {
       const fallback = getDefaultDataDir();
-      log.warn(
-        { resolved, fallback, code },
-        "data-paths: configured DATA_DIR is not writable — falling back to default"
-      );
+      onPermissionFallback?.({ resolved, fallback, code });
       return fallback;
     }
     throw err;

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -15,6 +15,7 @@ import {
 import path from "path";
 import fs from "fs";
 import { resolveWritableDataDir, getLegacyDotDataDir } from "../dataPaths";
+import { createLogger } from "@/shared/utils/logger";
 import { runMigrations } from "./migrationRunner";
 import { runDbHealthCheck } from "./healthCheck";
 import { resetAllDbModuleState } from "./stateReset";
@@ -86,7 +87,16 @@ export const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
 
 // ──────────────── Paths ────────────────
 
-export const DATA_DIR = resolveWritableDataDir({ isCloud });
+const dataPathsLog = createLogger("lib:data-paths");
+export const DATA_DIR = resolveWritableDataDir({
+  isCloud,
+  onPermissionFallback: ({ resolved, fallback, code }) => {
+    dataPathsLog.warn(
+      { resolved, fallback, code },
+      "data-paths: configured DATA_DIR is not writable — falling back to default"
+    );
+  },
+});
 const LEGACY_DATA_DIR = isCloud ? null : getLegacyDotDataDir();
 export const SQLITE_FILE = isCloud ? null : path.join(DATA_DIR, "storage.sqlite");
 const JSON_DB_FILE = isCloud ? null : path.join(DATA_DIR, "db.json");

--- a/src/lib/db/readCache.ts
+++ b/src/lib/db/readCache.ts
@@ -254,15 +254,6 @@ export function getModelCatalogCacheVersion(): number {
 }
 
 /**
- * Current model-catalog-cache version. `getUnifiedModelsResponse()` folds this
- * into its response cache key; a change means settings/connections/combos were
- * written since the cache was populated and the cached body is stale.
- */
-export function getModelCatalogCacheVersion(): number {
-  return modelCatalogCacheVersion;
-}
-
-/**
  * Invalidate caches (call after writes to any of: settings, pricing,
  * connections, combos, nodes).
  *

--- a/src/lib/modelsDevSync.ts
+++ b/src/lib/modelsDevSync.ts
@@ -49,27 +49,6 @@ export type {
   PricingByProvider,
 } from "./modelsDevSync/transform";
 
-import {
-  transformModelsDevToPricing,
-  transformModelsDevToCapabilities,
-} from "./modelsDevSync/transform";
-import type {
-  PricingModels,
-  PricingByProvider,
-  ModelCapabilityEntry,
-  CapabilitiesByProvider,
-  ModelsDevData,
-} from "./modelsDevSync/transform";
-
-// Re-export the pure transform layer (moved to ./modelsDevSync/transform)
-// so this module's public API is unchanged.
-export {
-  mapProviderId,
-  transformModelsDevToPricing,
-  transformModelsDevToCapabilities,
-} from "./modelsDevSync/transform";
-export type { ModelCapabilityEntry, CapabilitiesByProvider } from "./modelsDevSync/transform";
-
 // ─── Types ───────────────────────────────────────────────
 
 interface SyncStatus {
@@ -98,89 +77,6 @@ const MODELS_DEV_API_URL = "https://models.dev/api.json";
 const parsedInterval = parseInt(process.env.MODELS_DEV_SYNC_INTERVAL || "86400", 10);
 const SYNC_INTERVAL_MS =
   Number.isFinite(parsedInterval) && parsedInterval > 0 ? parsedInterval * 1000 : 86400 * 1000;
-
-// ─── Provider mapping: models.dev provider ID → OmniRoute provider IDs/aliases ──
-//
-// models.dev uses canonical provider IDs (e.g. "openai", "anthropic", "google").
-// OmniRoute uses both full IDs and short aliases (e.g. "cc" for claude, "cx" for codex).
-// We map each models.dev provider to ALL OmniRoute identifiers that should receive
-// its pricing/capability data.
-
-const MODELS_DEV_PROVIDER_MAP: Record<string, string[]> = {
-  // Major providers
-  openai: ["openai", "cx"], // cx = Codex (uses OpenAI models)
-  anthropic: ["anthropic", "cc"], // cc = Claude Code
-  google: ["gemini"],
-  "google-vertex": ["gemini", "vertex"],
-  "google-vertex-anthropic": ["anthropic", "cc", "vertex"],
-  vertex_ai: ["gemini", "vertex"],
-  deepseek: ["deepseek", "if"], // if = Qoder (routes through DeepSeek)
-  groq: ["groq"],
-  xai: ["xai"],
-  mistral: ["mistral"],
-  togetherai: ["together", "openrouter"],
-  together_ai: ["together", "openrouter"],
-  "fireworks-ai": ["fireworks"],
-  fireworks: ["fireworks"],
-  cerebras: ["cerebras"],
-  cohere: ["cohere"],
-  nvidia: ["nvidia"],
-  nebius: ["nebius"],
-  siliconflow: ["siliconflow"],
-  hyperbolic: ["hyperbolic"],
-  huggingface: ["hf", "huggingface"],
-  openrouter: ["openrouter"],
-  perplexity: ["pplx", "perplexity"],
-  // OAuth / special providers
-  bedrock: ["kiro", "kr"], // kr = Kiro (AWS Bedrock)
-  "github-copilot": ["github", "gh"],
-  "github-models": ["github", "gh"],
-  kilo: ["kilocode", "kc", "kilo-gateway"],
-  kilocode: ["kilocode", "kc", "kilo-gateway"],
-  "kimi-for-coding": ["kimi-coding", "kmc", "kimi-coding-apikey", "kmca"],
-  // The `opencode` models.dev entry used to map only to "opencode-zen" because
-  // that is the historical alias pair. But OmniRoute's catalog & combo targets
-  // reference models under BOTH provider IDs:
-  //   - `opencode-zen/big-pickle` (alias form)
-  //   - `opencode/big-pickle`    (canonical id form, used by live API catalog
-  //                               and by combos like "Opencode FREE Omni")
-  // If we only store synced capabilities under "opencode-zen", the canonical
-  // `opencode/<model>` lookup in getCanonicalModelMetadata returns null and
-  // any combo that targets `opencode/...` ends up with no computed context.
-  // Symmetric mapping keeps both lookup paths populated.
-  opencode: ["opencode", "opencode-zen"],
-  "opencode-go": ["opencode-go", "opencode-zen"],
-  // Additional providers that may overlap with OmniRoute
-  alibaba: ["ali", "alibaba"],
-  "alibaba-cn": ["ali-cn", "alibaba-cn", "alibaba-china"],
-  "alibaba-coding-plan": ["bcp", "bailian-coding-plan"],
-  zai: ["zai", "glm"], // GLM models via Z.AI
-  "zai-coding-plan": ["zai", "glm"],
-  moonshotai: ["moonshot", "kimi"],
-  "moonshotai-cn": ["moonshot", "kimi"],
-  moonshot: ["moonshot", "kimi", "kimi-coding", "kmc", "kmca"],
-  minimax: ["minimax", "minimax-cn"],
-  "minimax-cn": ["minimax-cn"],
-  longcat: ["lc", "longcat"],
-  pollinations: ["pol", "pollinations"],
-  puter: ["pu", "puter"],
-  cloudflare: ["cf"],
-  scaleway: ["scw"],
-  ollama: ["ollamacloud", "ollama-cloud"],
-  blackbox: ["bb", "blackbox"],
-  cline: ["cl", "cline"],
-  cursor: ["cu", "cursor"],
-  github: ["gh", "github"],
-  // Fallback: if no mapping exists, use the models.dev ID as-is
-};
-
-/**
- * Map a models.dev provider ID to OmniRoute provider IDs.
- * Returns array of provider identifiers (may include aliases).
- */
-export function mapProviderId(modelsDevProviderId: string): string[] {
-  return MODELS_DEV_PROVIDER_MAP[modelsDevProviderId] || [modelsDevProviderId];
-}
 
 // ─── Periodic sync state ─────────────────────────────────
 

--- a/tests/unit/logger-datapaths-import-cycle.test.ts
+++ b/tests/unit/logger-datapaths-import-cycle.test.ts
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { getDefaultDataDir, resolveWritableDataDir } from "../../src/lib/dataPaths.ts";
+
+function withDataDirEnv(fn: () => void): void {
+  const previousDataDir = process.env.DATA_DIR;
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-datapaths-cycle-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(home, { recursive: true });
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  process.env.DATA_DIR = path.join(root, "configured-data");
+
+  try {
+    fn();
+  } finally {
+    if (previousDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = previousDataDir;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = previousUserProfile;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("logger dynamically imports without a data-path initialization cycle", async () => {
+  const previousLogToFile = process.env.APP_LOG_TO_FILE;
+  process.env.APP_LOG_TO_FILE = "false";
+
+  try {
+    const loggerModule = await import("../../src/shared/utils/logger.ts");
+
+    assert.equal(typeof loggerModule.logger.info, "function");
+    assert.equal(typeof loggerModule.createLogger("import-cycle-test").warn, "function");
+  } finally {
+    if (previousLogToFile === undefined) delete process.env.APP_LOG_TO_FILE;
+    else process.env.APP_LOG_TO_FILE = previousLogToFile;
+  }
+});
+
+test("permission failures notify the optional callback with typed fallback details", () => {
+  withDataDirEnv(() => {
+    const originalMkdirSync = fs.mkdirSync;
+    const expectedFallback = getDefaultDataDir();
+    let details: { resolved: string; fallback: string; code: "EACCES" | "EPERM" } | undefined;
+    fs.mkdirSync = (() => {
+      const error = Object.assign(new Error("permission denied"), { code: "EACCES" });
+      throw error;
+    }) as typeof fs.mkdirSync;
+
+    try {
+      const resolved = resolveWritableDataDir({
+        onPermissionFallback: (value) => {
+          details = value;
+        },
+      });
+
+      assert.equal(resolved, expectedFallback);
+      assert.deepEqual(details, {
+        resolved: path.resolve(process.env.DATA_DIR!),
+        fallback: expectedFallback,
+        code: "EACCES",
+      });
+    } finally {
+      fs.mkdirSync = originalMkdirSync;
+    }
+  });
+});
+
+test("non-permission data directory failures are rethrown without invoking the callback", () => {
+  withDataDirEnv(() => {
+    const originalMkdirSync = fs.mkdirSync;
+    let callbackCalls = 0;
+    const expectedError = Object.assign(new Error("not a directory"), { code: "ENOTDIR" });
+    fs.mkdirSync = (() => {
+      throw expectedError;
+    }) as typeof fs.mkdirSync;
+
+    try {
+      assert.throws(
+        () => resolveWritableDataDir({ onPermissionFallback: () => callbackCalls++ }),
+        (error) => error === expectedError
+      );
+      assert.equal(callbackCalls, 0);
+    } finally {
+      fs.mkdirSync = originalMkdirSync;
+    }
+  });
+});


### PR DESCRIPTION
## **User description**
Carries forward local branch. Small focused fix.


___

## **CodeAnt-AI Description**
Prevent startup failures caused by data-path logging import cycles

### What Changed
- Startup can resolve a configured data directory without triggering a logger initialization cycle
- Permission errors still fall back to the default user data directory, while the startup logger reports the resolved and fallback paths
- Other data-directory errors continue to surface instead of being silently ignored
- Added coverage for logger loading and data-directory fallback behavior
- Removed duplicate model sync and cache exports that could cause import conflicts

### Impact
`✅ Reliable application startup with configured data paths`
`✅ Clearer warnings when a data directory is not writable`
`✅ Fewer import conflicts during initialization`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
