### PR TITLE
fix(providers): restore registry entry factory

### DIFF
--- a/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
+++ b/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
@@ -752,3 +752,12 @@ Status: [complete] — PR #420 merge conflict resolved, pushed.
 - [DONE] DAST alone now sets the existing `OMNIROUTE_USE_TURBOPACK=0` webpack compatibility escape hatch; normal, package, and release builds retain the default Turbopack path. The workflow contract test was observed RED before the setting and GREEN 7/7 after; YAML, Actionlint, Prettier, and diff checks pass.
 - [LIMIT] The local backend-only webpack build reached `Creating an optimized production build ...` without that Turbopack panic but exited without `dist/server.js`; do not claim a local full-build pass. Hosted DAST is the authoritative remaining proof.
 - This entry is append-only.
+
+## 2026-08-20T08:15Z - Provider registry factory restoration (fix-provider-registry-factory-restore-20260820)
+
+- [ROOT CAUSE] Current main provider modules and `refactor-registryFactory.test.ts` import `buildOpenAiCompatibleRegistryEntry`, but release-train commits `ffa6f5e13e` / `4e0fc462e9` removed its export from `config/providers/shared.ts`. Fork predecessor `9006473d90` and current upstream agree on the implementation.
+- [RED] `node --import tsx --test tests/unit/refactor-registryFactory.test.ts` failed exactly because `shared.ts` did not export the factory.
+- [DONE] Restored the lost factory only; it supplies the standard OpenAI format, default executor, API-key auth type, and bearer header while allowing explicit overrides.
+- [GREEN BOUNDARY] Esbuild parses `shared.ts` and a representative `registry/navy` consumer; Prettier, ESLint, and `git diff --check` pass. The focused runtime test now proceeds past the export and exposes independent current-main `ANTIGRAVITY_FALLBACK_VERSION` undefined initialization.
+- [WAIT] Hosted PR checks are authoritative; the Antigravity initialization error is not included in this scope.
+- This entry is append-only.

--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -150,6 +150,24 @@ export interface RegistryEntry {
   forceStream?: boolean;
 }
 
+/**
+ * Build a standard OpenAI-compatible provider registry entry.
+ * Eliminates the 4-field boilerplate (format, executor, authType, authHeader)
+ * repeated across provider files.
+ */
+export function buildOpenAiCompatibleRegistryEntry(
+  overrides: Pick<RegistryEntry, "id"> &
+    Partial<Omit<RegistryEntry, "id" | "format" | "executor" | "authType" | "authHeader">>
+): RegistryEntry {
+  return {
+    format: "openai",
+    executor: "default",
+    authType: "apikey",
+    authHeader: "bearer",
+    ...overrides,
+  } as RegistryEntry;
+}
+
 export interface LegacyProvider {
   format: string;
   baseUrl?: string;


### PR DESCRIPTION
## Summary
- restore the release-train-deleted `buildOpenAiCompatibleRegistryEntry` export
- retain the established OpenAI-compatible defaults and explicit overrides
- record the evidence and boundary in the append-only session handoff

## Validation
- RED: `node --import tsx --test tests/unit/refactor-registryFactory.test.ts` failed on the missing named export
- `npx esbuild open-sse/config/providers/shared.ts --outfile=/tmp/omniroute-provider-shared.js --format=esm --log-level=error`
- `npx esbuild open-sse/config/providers/registry/navy/index.ts --outfile=/tmp/omniroute-navy-provider.js --format=esm --log-level=error`
- `npx prettier --check open-sse/config/providers/shared.ts tests/unit/refactor-registryFactory.test.ts`
- `npx eslint open-sse/config/providers/shared.ts tests/unit/refactor-registryFactory.test.ts`
- `git diff --check`

## Known independent blocker
After the export is restored, the focused runtime test reaches current-main `ANTIGRAVITY_FALLBACK_VERSION is not defined` in `open-sse/services/antigravityHeaders.ts`; that separate initialization defect is intentionally out of this PR scope.