### PR TITLE
fix(antigravity): restore header identity contract

### DIFF
--- a/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
+++ b/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
@@ -752,3 +752,12 @@ Status: [complete] — PR #420 merge conflict resolved, pushed.
 - [DONE] DAST alone now sets the existing `OMNIROUTE_USE_TURBOPACK=0` webpack compatibility escape hatch; normal, package, and release builds retain the default Turbopack path. The workflow contract test was observed RED before the setting and GREEN 7/7 after; YAML, Actionlint, Prettier, and diff checks pass.
 - [LIMIT] The local backend-only webpack build reached `Creating an optimized production build ...` without that Turbopack panic but exited without `dist/server.js`; do not claim a local full-build pass. Hosted DAST is the authoritative remaining proof.
 - This entry is append-only.
+
+## 2026-08-20T08:28Z - Antigravity header-contract restoration (fix-antigravity-header-contract-restore-20260820)
+
+- [ROOT CAUSE] Current `antigravityHeaders.ts` evaluated undefined `ANTIGRAVITY_FALLBACK_VERSION` at module load and had overwritten the desktop user-agent builder with a CLI template that referenced undefined `authMethod`; the exported CLI builder was missing. The last known fork repair `63c5221f4c` and upstream establish the intended contract.
+- [RED] Existing header/client-profile tests failed on the undefined initialization and missing `antigravityCliUserAgent` export.
+- [DONE] Restored IDE fallback import, fixed darwin/arm64 identity constants, the desktop platform-fingerprint helper, and the distinct CLI user-agent builder.
+- [GREEN] `tests/unit/antigravity-headers.test.ts` passes 6/6; Esbuild, Prettier, ESLint, and `git diff --check` pass.
+- [LIMIT] `antigravity-client-profile.test.ts` still calls unimported legacy harness symbols and a retired cache API; that independently stale test is deliberately outside this source-restoration PR.
+- This entry is append-only.

--- a/open-sse/services/antigravityHeaders.ts
+++ b/open-sse/services/antigravityHeaders.ts
@@ -1,5 +1,6 @@
 import type { AntigravityClientProfile } from "@/shared/constants/antigravityClientProfile";
 import {
+  ANTIGRAVITY_IDE_FALLBACK_VERSION,
   getCachedAntigravityCliVersion,
   getCachedAntigravityIdeVersion,
 } from "./antigravityVersion.ts";
@@ -9,11 +10,12 @@ export const ANTIGRAVITY_IDE_NODE_X_GOOG_API_CLIENT = "gl-node/22.21.1";
 
 type AntigravityHeaderProfile = "loadCodeAssist" | "fetchAvailableModels" | "models";
 
-const ANTIGRAVITY_VERSION = ANTIGRAVITY_FALLBACK_VERSION;
+const ANTIGRAVITY_OS_TYPE = "darwin";
+const ANTIGRAVITY_ARCH = "arm64";
 // IDE desktop fingerprint synced with Antigravity-Manager v4.2.0 constants.rs.
 export const ANTIGRAVITY_CHROME_VERSION = "142.0.7444.175";
 export const ANTIGRAVITY_ELECTRON_VERSION = "39.2.3";
-export const ANTIGRAVITY_LOAD_CODE_ASSIST_USER_AGENT = `vscode/1.X.X (Antigravity/${ANTIGRAVITY_FALLBACK_VERSION})`;
+export const ANTIGRAVITY_LOAD_CODE_ASSIST_USER_AGENT = `vscode/1.X.X (Antigravity/${ANTIGRAVITY_IDE_FALLBACK_VERSION})`;
 export const ANTIGRAVITY_LOAD_CODE_ASSIST_API_CLIENT = "";
 export const ANTIGRAVITY_NODE_API_CLIENT = "google-api-nodejs-client/10.3.0";
 // Harness/bootstrap X-Goog-Api-Client synced with CLIProxyAPI misc.AntigravityGoogAPIClientUA.
@@ -30,6 +32,17 @@ function withOptionalBearerAuth(
   return headers;
 }
 
+function getAntigravityPlatformInfo(platform: NodeJS.Platform): string {
+  switch (platform) {
+    case "darwin":
+      return "Macintosh; Intel Mac OS X 10_15_7";
+    case "win32":
+      return "Windows NT 10.0; Win64; x64";
+    default:
+      return "X11; Linux x86_64";
+  }
+}
+
 export function antigravityIdeUserAgent(version = getCachedAntigravityIdeVersion()): string {
   return `antigravity/ide/${version} ${ANTIGRAVITY_OS_TYPE}/${ANTIGRAVITY_ARCH}`;
 }
@@ -39,8 +52,15 @@ export function antigravityIdeUserAgent(version = getCachedAntigravityIdeVersion
  * "Antigravity/VERSION (PLATFORM) Chrome/142... Electron/39..."
  */
 export function antigravityUserAgent(
-  version = getCachedAntigravityVersion(),
+  version = getCachedAntigravityIdeVersion(),
   platform: NodeJS.Platform = process.platform
+): string {
+  return `Antigravity/${version} (${getAntigravityPlatformInfo(platform)}) Chrome/${ANTIGRAVITY_CHROME_VERSION} Electron/${ANTIGRAVITY_ELECTRON_VERSION}`;
+}
+
+export function antigravityCliUserAgent(
+  version = getCachedAntigravityCliVersion(),
+  authMethod = "consumer"
 ): string {
   return `antigravity/cli/${version} (aidev_client; os_type=${ANTIGRAVITY_OS_TYPE}; arch=${ANTIGRAVITY_ARCH}; auth_method=${authMethod})`;
 }


### PR DESCRIPTION
## Summary
- restore the missing Antigravity CLI identity builder
- restore the defined IDE fallback and fixed native darwin/arm64 identity constants
- restore the desktop platform-fingerprint user-agent contract

## Validation
- RED: current tests failed on `ANTIGRAVITY_FALLBACK_VERSION is not defined` and missing `antigravityCliUserAgent` export
- `node --import tsx --test tests/unit/antigravity-headers.test.ts` (6/6 pass)
- `npx esbuild open-sse/services/antigravityHeaders.ts --outfile=/tmp/omniroute-antigravity-headers.js --format=esm --log-level=error`
- Prettier, ESLint, and `git diff --check`

## Scope boundary
`antigravity-client-profile.test.ts` separately calls unimported legacy harness symbols and a retired cache API. It remains outside this source-restoration PR.