### PR TITLE
ci(format): preserve append-only handoff ledger

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,10 @@
 # Long reference tables are manually aligned; formatting the whole file causes noisy diffs.
 docs/reference/ENVIRONMENT.md
 
+# This is an append-only cross-chat handoff ledger. Reformatting historical
+# entries rewrites provenance rather than changing a document's meaning.
+docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
+
 # Dense auto-generated free-tier budget rows (one object per line) — prettier multi-line expand blows past file-size cap 800.
 open-sse/config/freeModelCatalog.data.ts
 


### PR DESCRIPTION
## Summary
- exempt the explicitly append-only cross-chat handoff ledger from Prettier
- preserve the existing formatter policy for source, workflow, and normal documentation files

## Evidence
- RED: `origin/main` fails `npx prettier --check docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md`
- GREEN: `npx prettier --check docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md --ignore-path .prettierignore`
- `git diff --check`

## Rationale
Prettier rewrites historical ledger provenance. This is consistent with the existing narrow ignores for manually aligned reference material and generated skill files.