### PR TITLE
fix(kimi): restore release-spliced executor

### DIFF
--- a/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
+++ b/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
@@ -752,3 +752,12 @@ Status: [complete] — PR #420 merge conflict resolved, pushed.
 - [DONE] DAST alone now sets the existing `OMNIROUTE_USE_TURBOPACK=0` webpack compatibility escape hatch; normal, package, and release builds retain the default Turbopack path. The workflow contract test was observed RED before the setting and GREEN 7/7 after; YAML, Actionlint, Prettier, and diff checks pass.
 - [LIMIT] The local backend-only webpack build reached `Creating an optimized production build ...` without that Turbopack panic but exited without `dist/server.js`; do not claim a local full-build pass. Hosted DAST is the authoritative remaining proof.
 - This entry is append-only.
+
+## 2026-08-20T09:01Z - Kimi Web release-splice restoration (fix-kimi-web-release-splice-restore-20260820)
+
+- [ROOT CAUSE] Release commit `4e0fc462e9` removed the coherent non-streaming Connect-frame completion path from its parent and left an orphaned fragment after the streaming return, causing a duplicate `encoder` declaration and unexpected `catch` parser failure.
+- [RED] Esbuild failed on `open-sse/executors/kimi-web.ts` with exactly those two syntax errors.
+- [DONE] Restored the last coherent fork implementation from `4e0fc462e9^`; no hand-reconstructed protocol logic was introduced.
+- [GREEN BOUNDARY] Esbuild, Prettier, ESLint, and `git diff --check` pass for the changed executor. Focused Kimi tests now advance to the independently missing provider registry factory covered by PR #666.
+- [LIMIT] The pre-existing decoder test is not Prettier-compliant on main and is unchanged here. Hosted DAST after dependency repairs remains the authoritative bundle proof.
+- This entry is append-only.

--- a/open-sse/executors/kimi-web.ts
+++ b/open-sse/executors/kimi-web.ts
@@ -8,40 +8,262 @@
  *
  *   - Endpoint:  POST /apiv2/kimi.gateway.chat.v1.ChatService/Chat
  *   - Protocol:  Connect-RPC (unary envelope framing — 5-byte header + JSON)
- *   - Auth:      `Authorization: Bearer <JWT>` + `Cookie: kimi-auth=<JWT>`
- *   - Body:      Connect-framed `{scenario, message:{role,blocks:[{text:{content}}]},
- *                options:{thinking,enable_plugin}}`
+ *   - Auth:      `Authorization: Bearer <access_token>`
+ *   - Body:      Connect-framed ChatRequest JSON using protobuf field names
  *   - Response:  Connect-framed stream of events carrying deltas with one of
  *                `mask: "block.text.content"` (answer) or
  *                `mask: "block.think.content"` (reasoning), emitted via
  *                `op: "set"` (initial) and `op: "append"` (incremental).
  *
- * Cookie handling: the user pastes their full Cookie header from www.kimi.com.
- * We extract the `kimi-auth` JWT from it (it is the only cookie the upstream
- * actually consults) and use it both as the Bearer token and as the Cookie we
- * send back, so we don't leak the user's analytics cookies (Ga, CF, HM, ...).
+ * The current SPA stores `access_token` in localStorage. A legacy `kimi-auth`
+ * cookie is accepted as input for existing OmniRoute connections, but only the
+ * extracted token is forwarded and browser cookies are never replayed.
  *
  * The `x-msh-*` / `x-traffic-id` / `x-msh-shield-data` headers the SPA sends
  * are NOT required — verified by stripping them one at a time against a live
  * session; the upstream returns the same response either way.
  */
 import { BaseExecutor, type ExecuteInput } from "./base.ts";
-import { makeExecutorErrorResult as makeErrorResult, sanitizeErrorMessage } from "../utils/error.ts";
-import { extractKimiJwt } from "@/lib/providers/webCookieAuth";
+import {
+  makeExecutorErrorResult as makeErrorResult,
+  sanitizeErrorMessage,
+} from "../utils/error.ts";
+import { extractKimiAccessToken } from "@/lib/providers/webCookieAuth";
+import {
+  type KimiWebModelConfig,
+  resolveKimiWebContextLength,
+  resolveKimiWebModelConfig,
+  resolveKimiWebReasoningEffort,
+} from "../config/providers/registry/kimi/web/runtime.ts";
 
-export { extractKimiJwt };
+export { extractKimiAccessToken };
 
 const BASE_URL = "https://www.kimi.com";
 const CHAT_URL = `${BASE_URL}/apiv2/kimi.gateway.chat.v1.ChatService/Chat`;
 const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36";
 
+/**
+ * Map a Kimi model id (the `key` field from `GetAvailableModels`) to the
+ * request shape the upstream expects. Today only the chat-tier `k2d6` family
+ * is supported — the agent variants (`k2d6-agent`, `k2d6-agent-ultra`) need
+ * a different scenario (`SCENARIO_OK_COMPUTER`) plus `kimiPlusId` /
+ * `agentMode` fields that this executor does not shape; users who need
+ * agentic Kimi should use the `kimi-coding` (api.kimi.com) provider.
+ */
+export interface KimiModelConfig {
+  scenario: string;
+  thinking: boolean;
+}
+
+export function resolveModelConfig(modelId: string): KimiModelConfig {
+  if (modelId === "k2d6-thinking") return { scenario: "SCENARIO_K2D5", thinking: true };
+  // `k2d6` (Instant) and any unknown id fall back to the default chat scenario.
+  return { scenario: "SCENARIO_K2D5", thinking: false };
+}
+
+/** Wrap a JSON message in the 5-byte Connect streaming envelope (flags + length). */
+export function frameConnectMessage(json: string): Uint8Array {
+  const payload = new TextEncoder().encode(json);
+  const framed = new Uint8Array(5 + payload.length);
+  framed[0] = 0; // flags: 0 = uncompressed
+  const len = payload.length;
+  framed[1] = (len >>> 24) & 0xff;
+  framed[2] = (len >>> 16) & 0xff;
+  framed[3] = (len >>> 8) & 0xff;
+  framed[4] = len & 0xff;
+  framed.set(payload, 5);
+  return framed;
+}
+
+export interface ConnectFrame {
+  flags: number;
+  message: Record<string, unknown> | null;
+}
+
+/**
+ * ponytail: cap a single Connect frame at 8 MiB. Kimi's largest legitimate
+ * event is well under 1 KiB (a delta or stage transition); anything bigger
+ * means the upstream is misbehaving or an attacker controls the response and
+ * is trying to OOM the proxy by sending a header claiming a huge length.
+ * The non-streaming accumulator would otherwise grow unbounded. If you ever
+ * see this tripping in production, raise the ceiling and add a regression
+ * test — but never remove it.
+ */
+const MAX_FRAME_LEN = 8 * 1024 * 1024;
+
+/**
+ * Decode one Connect frame from a stream buffer.
+ * Returns:
+ *   - `consumed: 0` if there isn't enough data yet (need more bytes)
+ *   - `consumed: -1` if the frame header claims a length above MAX_FRAME_LEN
+ *     (caller must treat this as a stream-fatal protocol error)
+ *   - `consumed: N` + the parsed frame otherwise
+ */
+export function decodeConnectFrame(
+  buf: Uint8Array,
+  byteOffset: number
+): { consumed: number; frame: ConnectFrame | null } {
+  if (byteOffset + 5 > buf.length) return { consumed: 0, frame: null };
+  const flags = buf[byteOffset];
+  const len =
+    (buf[byteOffset + 1] << 24) |
+    (buf[byteOffset + 2] << 16) |
+    (buf[byteOffset + 3] << 8) |
+    buf[byteOffset + 4];
+  // Sign-extend the high bit back to negative when len was read as signed.
+  const msgLen = len < 0 ? len + 0x100000000 : len;
+  if (msgLen > MAX_FRAME_LEN) return { consumed: -1, frame: null };
+  if (byteOffset + 5 + msgLen > buf.length) return { consumed: 0, frame: null };
+  if ((flags & ~0x03) !== 0) {
+    throw new Error(`Kimi Connect frame used unsupported flags: ${flags}`);
+  }
+  if ((flags & 0x01) !== 0) {
+    throw new Error("Kimi Connect compressed frames are not supported");
+  }
+
+  const payload = buf.subarray(byteOffset + 5, byteOffset + 5 + msgLen);
+  let message: Record<string, unknown> | null = null;
+  if (msgLen > 0) {
+    try {
+      message = JSON.parse(new TextDecoder().decode(payload));
+    } catch (error) {
+      throw new Error(
+        `Kimi Connect frame contained invalid JSON: ${error instanceof Error ? error.message : "parse failed"}`
+      );
+    }
+  }
+  return { consumed: 5 + msgLen, frame: { flags, message } };
+}
+
+export function getConnectEndStreamError(frame: ConnectFrame): string | null {
+  if ((frame.flags & 0x02) === 0) return null;
+  const error = frame.message?.error;
+  if (!error || typeof error !== "object" || Array.isArray(error)) return null;
+  const record = error as Record<string, unknown>;
+  const code = typeof record.code === "string" ? record.code : "unknown";
+  const message = typeof record.message === "string" ? record.message : "upstream error";
+  return `${code}: ${message}`;
+}
+
+type DeltaKind = "text" | "think" | null;
+
+/**
+ * Extract a content delta + kind from a Connect frame message.
+ *
+ * The chat stream uses two ops against two masks:
+ *   - `op: "set"`     on `block.text`     / `block.think`     → first chunk
+ *   - `op: "append"`  on `block.text.content` / `block.think.content` → subsequent chunks
+ *
+ * Anything else (heartbeats, chat/message metadata, stage transitions) is
+ * suppressed; we only surface text to the client.
+ */
+export function extractDelta(
+  msg: Record<string, unknown> | null
+): { kind: DeltaKind; text: string } | null {
+  if (!msg) return null;
+  const op = String(msg.op ?? "");
+  const mask = String(msg.mask ?? "");
+  const block = (msg.block ?? {}) as Record<string, unknown>;
+
+  // `op: append` carries a delta string under `block.<text|think>.content`.
+  if (op === "append") {
+    if (mask === "block.text.content") {
+      const text = String(((block.text ?? {}) as Record<string, unknown>).content ?? "");
+      return text ? { kind: "text", text } : null;
+    }
+    if (mask === "block.think.content") {
+      const text = String(((block.think ?? {}) as Record<string, unknown>).content ?? "");
+      return text ? { kind: "think", text } : null;
+    }
+    return null;
+  }
+
+  // `op: set` on `block.text` / `block.think` carries the initial content.
+  if (op === "set") {
+    if (mask === "block.text") {
+      const text = String(((block.text ?? {}) as Record<string, unknown>).content ?? "");
+      return text ? { kind: "text", text } : null;
+    }
+    if (mask === "block.think") {
+      const text = String(((block.think ?? {}) as Record<string, unknown>).content ?? "");
+      return text ? { kind: "think", text } : null;
+    }
+  }
+  return null;
+}
+
+type KimiWebInputMessage = {
+  role: string;
+  content: unknown;
+  tool_calls?: unknown;
+};
+
+export interface FoldedKimiWebMessages {
+  prompt: string;
+  systemPrompt: string;
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) {
+    throw new Error("Kimi Web only supports text message content");
+  }
+
+  return content
+    .map((part) => {
+      if (!part || typeof part !== "object" || Array.isArray(part)) {
+        throw new Error("Kimi Web only supports text message content");
+      }
+      const record = part as Record<string, unknown>;
+      if (
+        (record.type === "text" || record.type === "input_text") &&
+        typeof record.text === "string"
+      ) {
+        return record.text;
+      }
+      throw new Error("Kimi Web does not support image, audio, file, or tool content");
+    })
+    .join("");
+}
+
+/** Fold text-only OpenAI history into the single user turn accepted by Kimi Web. */
+export function foldMessages(messages: KimiWebInputMessage[]): FoldedKimiWebMessages {
+  const systemParts: string[] = [];
+  const conversationParts: string[] = [];
+
+  for (const message of messages) {
+    if (message.role === "tool" || message.role === "function") {
+      throw new Error("Kimi Web does not support tool result messages");
+    }
+    if (message.tool_calls !== undefined) {
+      throw new Error("Kimi Web does not support assistant tool calls");
+    }
+
+    const text = textFromContent(message.content);
+    if (message.role === "system" || message.role === "developer") {
+      if (text) systemParts.push(text);
+    } else if (message.role === "user") {
+      if (text) conversationParts.push(conversationParts.length > 0 ? `User: ${text}` : text);
+    } else if (message.role === "assistant") {
+      if (text) conversationParts.push(`Assistant: ${text}`);
+    } else {
+      throw new Error(`Kimi Web does not support message role ${message.role}`);
+    }
+  }
+
+  return {
+    prompt: conversationParts.join("\n\n").trim(),
+    systemPrompt: systemParts.join("\n\n").trim(),
+  };
+}
+
 export class KimiWebExecutor extends BaseExecutor {
   constructor() {
     super("kimi-web", { id: "kimi-web", baseUrl: BASE_URL });
   }
 
-  private buildKimiHeaders(jwt: string): Record<string, string> {
+  private buildKimiHeaders(accessToken: string): Record<string, string> {
     const headers: Record<string, string> = {
       "Content-Type": "application/connect+json",
       Accept: "*/*",
@@ -50,23 +272,24 @@ export class KimiWebExecutor extends BaseExecutor {
       Referer: `${BASE_URL}/`,
       "connect-protocol-version": "1",
     };
-    if (jwt) {
-      headers["Authorization"] = `Bearer ${jwt}`;
-      headers["Cookie"] = `kimi-auth=${jwt}`;
-    }
+    if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
     return headers;
   }
 
-  private buildRequestBody(prompt: string, wantThinking: boolean): string {
+  private buildRequestBody(prompt: string, wantThinking: boolean, scenario: string): string {
     return JSON.stringify({
-      scenario: DEFAULT_SCENARIO,
+      scenario,
       tools: [{ type: "TOOL_TYPE_SEARCH", search: {} }, { type: "TOOL_TYPE_CRON_JOB" }],
       message: {
+        id: "",
+        parent_id: "",
+        children_message_ids: [],
         role: "user",
         blocks: [{ message_id: "", text: { content: prompt } }],
-        scenario: DEFAULT_SCENARIO,
+        scenario,
       },
-      options: { thinking: wantThinking, enable_plugin: true },
+      options,
+      project_id: "",
     });
   }
 
@@ -74,12 +297,12 @@ export class KimiWebExecutor extends BaseExecutor {
     const { body, credentials, signal, stream: wantStream } = input;
     const bodyObj = (body || {}) as Record<string, unknown>;
 
-    const rawCredential = String(credentials?.apiKey ?? "").trim();
-    const jwt = extractKimiJwt(rawCredential);
-    if (!jwt) {
+    const rawCredential = String(credentials?.accessToken || credentials?.apiKey || "").trim();
+    const accessToken = extractKimiAccessToken(rawCredential);
+    if (!accessToken) {
       return makeErrorResult(
         400,
-        "Missing Kimi session — paste the full Cookie header from www.kimi.com (must contain kimi-auth=<JWT>) or just the JWT itself.",
+        "Missing Kimi access_token — log in at www.kimi.com and capture access_token from localStorage.",
         body,
         CHAT_URL
       );
@@ -87,14 +310,13 @@ export class KimiWebExecutor extends BaseExecutor {
 
     const messages = (bodyObj.messages as Array<{ role: string; content: unknown }>) || [];
     const modelId = (bodyObj.model as string) || "kimi-default";
-    // Decide thinking intent. A user sending `reasoning_effort: "none"` is
-    // explicit — honour it even when the model id suggests a thinking variant.
-    // Otherwise thinking models (kimi-k2.6 etc.) default to thinking on.
-    const modelWantsThinking = /k2\.6|k2-6|think/i.test(modelId);
-    const wantThinking = bodyObj.reasoning_effort === "none" ? false : modelWantsThinking;
+    // Resolve scenario + default thinking flag from the model id (catalog truth),
+    // then honour an explicit `reasoning_effort: "none"` override from the caller.
+    const modelConfig = resolveModelConfig(modelId);
+    const wantThinking = bodyObj.reasoning_effort === "none" ? false : modelConfig.thinking;
 
     const prompt = foldMessages(messages);
-    const reqBody = this.buildRequestBody(prompt, wantThinking);
+    const reqBody = this.buildRequestBody(prompt, wantThinking, modelConfig.scenario);
     const reqHeaders = this.buildKimiHeaders(jwt);
 
     // Connect framing wraps the JSON body in a 5-byte envelope. Without it the
@@ -120,7 +342,12 @@ export class KimiWebExecutor extends BaseExecutor {
 
     if (!upstream.ok) {
       const errText = await upstream.text().catch(() => "");
-      return makeErrorResult(upstream.status, `Kimi error: ${sanitizeErrorMessage(errText)}`, body, CHAT_URL);
+      return makeErrorResult(
+        upstream.status,
+        `Kimi error: ${sanitizeErrorMessage(errText)}`,
+        body,
+        CHAT_URL
+      );
     }
 
     const encoder = new TextEncoder();
@@ -167,13 +394,25 @@ export class KimiWebExecutor extends BaseExecutor {
                 while (offset < buffer.length) {
                   const { consumed, frame } = decodeConnectFrame(buffer, offset);
                   if (consumed === -1) {
-                    // Frame header claims a length above MAX_FRAME_LEN — stream-fatal.
-                    controller.error(new Error("Kimi Connect frame exceeded MAX_FRAME_LEN"));
-                    return;
+                    throw new Error("Kimi Connect frame exceeded MAX_FRAME_LEN");
                   }
                   if (consumed === 0) break; // need more bytes
                   offset += consumed;
-                  if (!frame?.message) continue;
+                  if (!frame) continue;
+                  if ((frame.flags & 0x02) !== 0) {
+                    const endStreamError = getConnectEndStreamError(frame);
+                    if (endStreamError) {
+                      throw new Error(`Kimi Connect EndStream error: ${endStreamError}`);
+                    }
+                    if (!emittedRole) {
+                      emitChunk(controller, { role: "assistant", content: "" });
+                    }
+                    emitChunk(controller, {}, "stop");
+                    controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                    controller.close();
+                    return;
+                  }
+                  if (!frame.message) continue;
 
                   const delta = extractDelta(frame.message);
                   if (delta) {
@@ -187,26 +426,20 @@ export class KimiWebExecutor extends BaseExecutor {
                       emitChunk(controller, { content: delta.text });
                     }
                   }
-                  if (isEndOfStream(frame.message)) {
-                    emitChunk(controller, {}, "stop");
-                    controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-                    controller.close();
-                    return;
-                  }
                 }
                 // Compact the buffer.
                 buffer = buffer.subarray(offset);
               }
             }
-            // Stream ended without an explicit COMPLETED marker — flush a stop.
-            if (!emittedRole) {
-              emitChunk(controller, { role: "assistant", content: "" });
-            }
-            emitChunk(controller, {}, "stop");
-            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-            controller.close();
+            throw new Error("Kimi Connect stream ended without a successful EndStream frame");
           } catch (err) {
-            if (!signal?.aborted) {
+            if (signal?.aborted) {
+              try {
+                controller.close();
+              } catch {
+                /* controller already closed */
+              }
+            } else {
               try {
                 controller.error(err);
               } catch {
@@ -231,77 +464,56 @@ export class KimiWebExecutor extends BaseExecutor {
       };
     }
 
-    // Streaming
-    const encoder = new TextEncoder();
-    const decoder = new TextDecoder();
-    const stream = new ReadableStream({
-      async start(controller) {
-        const reader = upstream.body?.getReader();
-        if (!reader) {
-          controller.close();
-          return;
-        }
-        let buffer = "";
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            buffer += decoder.decode(value, { stream: true });
-            const lines = buffer.split("\n");
-            buffer = lines.pop() || "";
-            for (const line of lines) {
-              if (!line.startsWith("data:")) continue;
-              const data = line.slice(5).trim();
-              if (data === "[DONE]") {
-                controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-                continue;
-              }
-              try {
-                const parsed = JSON.parse(data);
-                const text = parsed.choices?.[0]?.delta?.content || "";
-                if (text) {
-                  const chunk = {
-                    id: `chatcmpl-kimi-${Date.now()}`,
-                    object: "chat.completion.chunk",
-                    created: Math.floor(Date.now() / 1000),
-                    model: modelId,
-                    choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
-                  };
-                  controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
-                }
-              } catch {}
-            }
-          }
-        } catch (err) {
-          if (!signal?.aborted) controller.error(err);
-        } finally {
-          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-          controller.close();
-        }
-      },
-    });
+    // Non-streaming: collect all deltas into a single chat.completion JSON.
+    let answer = "";
+    let reasoning = "";
+    const reader = sourceStream.getReader();
+    let buffer = new Uint8Array(0);
+    let sawSuccessfulEndStream = false;
+    try {
+      readLoop: while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        const merged = new Uint8Array(buffer.length + value.length);
+        merged.set(buffer, 0);
+        merged.set(value, buffer.length);
+        buffer = merged;
 
         let offset = 0;
         while (offset < buffer.length) {
           const { consumed, frame } = decodeConnectFrame(buffer, offset);
-          if (consumed === -1) break; // oversized frame — abort, return what we have
+          if (consumed === -1) throw new Error("Kimi Connect frame exceeded MAX_FRAME_LEN");
           if (consumed === 0) break;
           offset += consumed;
-          if (!frame?.message) continue;
+          if (!frame) continue;
+          if ((frame.flags & 0x02) !== 0) {
+            const endStreamError = getConnectEndStreamError(frame);
+            if (endStreamError) {
+              throw new Error(`Kimi Connect EndStream error: ${endStreamError}`);
+            }
+            sawSuccessfulEndStream = true;
+            break readLoop;
+          }
+          if (!frame.message) continue;
           const delta = extractDelta(frame.message);
           if (delta) {
             if (delta.kind === "think") reasoning += delta.text;
             else answer += delta.text;
           }
-          if (isEndOfStream(frame.message)) {
-            offset = buffer.length; // drain
-            break;
-          }
         }
         buffer = buffer.subarray(offset);
       }
-    } catch {
-      /* best-effort — return what we have */
+      if (!sawSuccessfulEndStream) {
+        throw new Error("Kimi Connect stream ended without a successful EndStream frame");
+      }
+    } catch (error) {
+      return makeErrorResult(
+        502,
+        `Kimi Connect protocol error: ${error instanceof Error ? error.message : "unknown"}`,
+        body,
+        CHAT_URL
+      );
     }
 
     const message: Record<string, unknown> = { role: "assistant", content: answer };
@@ -314,12 +526,8 @@ export class KimiWebExecutor extends BaseExecutor {
       choices: [{ index: 0, message, finish_reason: "stop" }],
     };
     return {
-      response: new Response(stream, {
-        headers: {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-        },
+      response: new Response(JSON.stringify(completion), {
+        headers: { "Content-Type": "application/json" },
       }),
       url: CHAT_URL,
       headers: reqHeaders,


### PR DESCRIPTION
## Summary
- restore the coherent Kimi Web Connect-frame completion path removed by release commit `4e0fc462e9`
- eliminate the orphaned parser fragment that made the production executor unbundleable

## Validation
- RED: Esbuild reported duplicate `encoder` declaration and unexpected `catch`
- GREEN: `npx esbuild open-sse/executors/kimi-web.ts --outfile=/tmp/omniroute-kimi-web.js --format=esm --log-level=error`
- `npx prettier --check open-sse/executors/kimi-web.ts`
- `npx eslint open-sse/executors/kimi-web.ts`
- `git diff --check`

## Dependency boundary
The focused Kimi test suites now reach the missing provider registry factory addressed independently in PR #666. The unchanged decoder test is already non-Prettier-compliant on main.