### PR TITLE
fix(kiro): restore runtime region imports

### DIFF
--- a/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
+++ b/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
@@ -752,3 +752,11 @@ Status: [complete] — PR #420 merge conflict resolved, pushed.
 - [DONE] DAST alone now sets the existing `OMNIROUTE_USE_TURBOPACK=0` webpack compatibility escape hatch; normal, package, and release builds retain the default Turbopack path. The workflow contract test was observed RED before the setting and GREEN 7/7 after; YAML, Actionlint, Prettier, and diff checks pass.
 - [LIMIT] The local backend-only webpack build reached `Creating an optimized production build ...` without that Turbopack panic but exited without `dist/server.js`; do not claim a local full-build pass. Hosted DAST is the authoritative remaining proof.
 - This entry is append-only.
+
+## 2026-08-20T09:17Z - Kiro runtime-host import restoration (fix-kiro-runtime-host-import-20260820)
+
+- [ROOT CAUSE] `kiroRuntimeHost` and `resolveKiroRuntimeRegion` live in `services/kiroRegion.ts`, but the executor used and re-exported them without an import; hosted webpack correctly rejected `export { kiroRuntimeHost }` as undefined.
+- [DONE] Restored the upstream import pair only, retaining the existing executor compatibility re-export.
+- [GREEN BOUNDARY] Esbuild and Prettier pass; `git diff --check` passes. Prettier also made three existing formatting-only normalizations in the same file.
+- [LIMIT] ESLint could not resolve `eslint-config-next` because this isolated worktree's dependency install was interrupted with `ENOTEMPTY`; no source lint diagnostic was produced.
+- This entry is append-only.

--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -8,7 +8,12 @@ import {
 import { PROVIDERS } from "../config/constants.ts";
 import { v4 as uuidv4 } from "uuid";
 import { refreshKiroToken } from "../services/tokenRefresh.ts";
-import { splitInlineThinking, flushPendingThinking, type KiroThinkingState } from "./kiroThinking.ts";
+import {
+  splitInlineThinking,
+  flushPendingThinking,
+  type KiroThinkingState,
+} from "./kiroThinking.ts";
+import { kiroRuntimeHost, resolveKiroRuntimeRegion } from "../services/kiroRegion.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -283,16 +288,18 @@ export class KiroExecutor extends BaseExecutor {
     // channel.
     const tb = transformedBody as Record<string, unknown>;
     const userContent =
-      (
+      ((
         (
-          (
-            (tb?.conversationState as Record<string, unknown>)
-              ?.currentMessage as Record<string, unknown>
-          )?.userInputMessage as Record<string, unknown>
-        )?.content as string
-      ) || "";
+          (tb?.conversationState as Record<string, unknown>)?.currentMessage as Record<
+            string,
+            unknown
+          >
+        )?.userInputMessage as Record<string, unknown>
+      )?.content as string) || "";
     const thinkingExpected = userContent.includes("<thinking_mode>enabled</thinking_mode>");
-    const transformedResponse = this.transformEventStreamToSSE(response, model, { thinkingExpected });
+    const transformedResponse = this.transformEventStreamToSSE(response, model, {
+      thinkingExpected,
+    });
 
     return { response: transformedResponse, url, headers, transformedBody };
   }
@@ -473,7 +480,10 @@ export class KiroExecutor extends BaseExecutor {
                       choices: [
                         {
                           index: 0,
-                          delta: chunkIndex === 0 ? { role: "assistant", content: text } : { content: text },
+                          delta:
+                            chunkIndex === 0
+                              ? { role: "assistant", content: text }
+                              : { content: text },
                           finish_reason: null,
                         },
                       ],


### PR DESCRIPTION
## Summary
- import the shared Kiro runtime-host and region resolver before using/re-exporting them
- include narrow formatting-only normalization required for the changed file

## Validation
- hosted DAST RED: webpack rejected `export { kiroRuntimeHost }` because the binding was undefined
- `esbuild` parse/bundle pass
- Prettier pass
- `git diff --check`

## Local harness note
ESLint did not execute because the isolated worktree dependency install was interrupted (`ENOTEMPTY`), leaving `eslint-config-next` unavailable. No source lint error was observed.