### PR TITLE
fix(kiro): restore runtime region imports

### DIFF
--- a/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
+++ b/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
@@ -752,3 +752,11 @@ Status: [complete] — PR #420 merge conflict resolved, pushed.
 - [DONE] DAST alone now sets the existing `OMNIROUTE_USE_TURBOPACK=0` webpack compatibility escape hatch; normal, package, and release builds retain the default Turbopack path. The workflow contract test was observed RED before the setting and GREEN 7/7 after; YAML, Actionlint, Prettier, and diff checks pass.
 - [LIMIT] The local backend-only webpack build reached `Creating an optimized production build ...` without that Turbopack panic but exited without `dist/server.js`; do not claim a local full-build pass. Hosted DAST is the authoritative remaining proof.
 - This entry is append-only.
+
+## 2026-08-20T09:17Z - Kiro runtime-host import restoration (fix-kiro-runtime-host-import-20260820)
+
+- [ROOT CAUSE] `kiroRuntimeHost` and `resolveKiroRuntimeRegion` live in `services/kiroRegion.ts`, but the executor used and re-exported them without an import; hosted webpack correctly rejected `export { kiroRuntimeHost }` as undefined.
+- [DONE] Restored the upstream import pair only, retaining the existing executor compatibility re-export.
+- [GREEN BOUNDARY] Esbuild and Prettier pass; `git diff --check` passes. Prettier also made three existing formatting-only normalizations in the same file.
+- [LIMIT] ESLint could not resolve `eslint-config-next` because this isolated worktree's dependency install was interrupted with `ENOTEMPTY`; no source lint diagnostic was produced.
+- This entry is append-only.

--- a/open-sse/executors/kiro.ts
+++ b/open-sse/executors/kiro.ts
@@ -8,7 +8,12 @@ import {
 import { PROVIDERS } from "../config/constants.ts";
 import { v4 as uuidv4 } from "uuid";
 import { refreshKiroToken } from "../services/tokenRefresh.ts";
-import { splitInlineThinking, flushPendingThinking, type KiroThinkingState } from "./kiroThinking.ts";
+import {
+  splitInlineThinking,
+  flushPendingThinking,
+  type KiroThinkingState,
+} from "./kiroThinking.ts";
+import { kiroRuntimeHost, resolveKiroRuntimeRegion } from "../services/kiroRegion.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -283,16 +288,18 @@ export class KiroExecutor extends BaseExecutor {
     // channel.
     const tb = transformedBody as Record<string, unknown>;
     const userContent =
-      (
+      ((
         (
-          (
-            (tb?.conversationState as Record<string, unknown>)
-              ?.currentMessage as Record<string, unknown>
-          )?.userInputMessage as Record<string, unknown>
-        )?.content as string
-      ) || "";
+          (tb?.conversationState as Record<string, unknown>)?.currentMessage as Record<
+            string,
+            unknown
+          >
+        )?.userInputMessage as Record<string, unknown>
+      )?.content as string) || "";
     const thinkingExpected = userContent.includes("<thinking_mode>enabled</thinking_mode>");
-    const transformedResponse = this.transformEventStreamToSSE(response, model, { thinkingExpected });
+    const transformedResponse = this.transformEventStreamToSSE(response, model, {
+      thinkingExpected,
+    });
 
     return { response: transformedResponse, url, headers, transformedBody };
   }
@@ -473,7 +480,10 @@ export class KiroExecutor extends BaseExecutor {
                       choices: [
                         {
                           index: 0,
-                          delta: chunkIndex === 0 ? { role: "assistant", content: text } : { content: text },
+                          delta:
+                            chunkIndex === 0
+                              ? { role: "assistant", content: text }
+                              : { content: text },
                           finish_reason: null,
                         },
                       ],


### PR DESCRIPTION
## **User description**
## Summary
Restore Kiro runtime region imports that were lost during release.

## Changes
- Restore runtime region imports for Kiro module

## Testing
```bash
cargo check --manifest-path src-tauri/Cargo.toml
```


___

## **CodeAnt-AI Description**
Restore Kiro runtime region handling so deployments can build and run successfully

### What Changed
- Restored the Kiro runtime host and region imports required by the executor
- Preserved the existing Kiro streaming behavior while correcting formatting-only changes

### Impact
`✅ Successful Kiro production builds`
`✅ Kiro requests can resolve their runtime region`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
