### PR TITLE
fix(providers): restore registry entry factory

### DIFF
--- a/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
+++ b/docs/sessions/20260719-cross-chat-alignment/HANDOFFS.md
@@ -752,3 +752,12 @@ Status: [complete] — PR #420 merge conflict resolved, pushed.
 - [DONE] DAST alone now sets the existing `OMNIROUTE_USE_TURBOPACK=0` webpack compatibility escape hatch; normal, package, and release builds retain the default Turbopack path. The workflow contract test was observed RED before the setting and GREEN 7/7 after; YAML, Actionlint, Prettier, and diff checks pass.
 - [LIMIT] The local backend-only webpack build reached `Creating an optimized production build ...` without that Turbopack panic but exited without `dist/server.js`; do not claim a local full-build pass. Hosted DAST is the authoritative remaining proof.
 - This entry is append-only.
+
+## 2026-08-20T08:15Z - Provider registry factory restoration (fix-provider-registry-factory-restore-20260820)
+
+- [ROOT CAUSE] Current main provider modules and `refactor-registryFactory.test.ts` import `buildOpenAiCompatibleRegistryEntry`, but release-train commits `ffa6f5e13e` / `4e0fc462e9` removed its export from `config/providers/shared.ts`. Fork predecessor `9006473d90` and current upstream agree on the implementation.
+- [RED] `node --import tsx --test tests/unit/refactor-registryFactory.test.ts` failed exactly because `shared.ts` did not export the factory.
+- [DONE] Restored the lost factory only; it supplies the standard OpenAI format, default executor, API-key auth type, and bearer header while allowing explicit overrides.
+- [GREEN BOUNDARY] Esbuild parses `shared.ts` and a representative `registry/navy` consumer; Prettier, ESLint, and `git diff --check` pass. The focused runtime test now proceeds past the export and exposes independent current-main `ANTIGRAVITY_FALLBACK_VERSION` undefined initialization.
+- [WAIT] Hosted PR checks are authoritative; the Antigravity initialization error is not included in this scope.
+- This entry is append-only.

--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -150,6 +150,24 @@ export interface RegistryEntry {
   forceStream?: boolean;
 }
 
+/**
+ * Build a standard OpenAI-compatible provider registry entry.
+ * Eliminates the 4-field boilerplate (format, executor, authType, authHeader)
+ * repeated across provider files.
+ */
+export function buildOpenAiCompatibleRegistryEntry(
+  overrides: Pick<RegistryEntry, "id"> &
+    Partial<Omit<RegistryEntry, "id" | "format" | "executor" | "authType" | "authHeader">>
+): RegistryEntry {
+  return {
+    format: "openai",
+    executor: "default",
+    authType: "apikey",
+    authHeader: "bearer",
+    ...overrides,
+  } as RegistryEntry;
+}
+
 export interface LegacyProvider {
   format: string;
   baseUrl?: string;


### PR DESCRIPTION
## **User description**
## Summary
Restore the provider registry entry factory that was lost during release.

## Changes
- Restore registry entry factory for provider module

## Testing
```bash
cargo check --manifest-path src-tauri/Cargo.toml
```


___

## **CodeAnt-AI Description**
Restore shared provider registry entry creation

### What Changed
- Provider modules can once again create standard OpenAI-compatible registry entries
- Restored entries use the expected OpenAI format, default executor, API-key authentication, and bearer authorization
- Provider-specific settings can override the standard defaults

### Impact
`✅ Provider registry loading works again`
`✅ Consistent authentication for OpenAI-compatible providers`
`✅ Less repeated provider configuration`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
