### PR TITLE
fix: restore OmniRoute main parse contracts

### DIFF
--- a/open-sse/executors/kimi-web.ts
+++ b/open-sse/executors/kimi-web.ts
@@ -26,7 +26,10 @@
  * session; the upstream returns the same response either way.
  */
 import { BaseExecutor, type ExecuteInput } from "./base.ts";
-import { makeExecutorErrorResult as makeErrorResult, sanitizeErrorMessage } from "../utils/error.ts";
+import {
+  makeExecutorErrorResult as makeErrorResult,
+  sanitizeErrorMessage,
+} from "../utils/error.ts";
 import { extractKimiJwt } from "@/lib/providers/webCookieAuth";
 
 export { extractKimiJwt };
@@ -35,6 +38,93 @@ const BASE_URL = "https://www.kimi.com";
 const CHAT_URL = `${BASE_URL}/apiv2/kimi.gateway.chat.v1.ChatService/Chat`;
 const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36";
+
+const DEFAULT_SCENARIO = "SCENARIO_K2D5";
+
+export function frameConnectMessage(json: string): Uint8Array {
+  const payload = new TextEncoder().encode(json);
+  const framed = new Uint8Array(5 + payload.length);
+  framed[0] = 0;
+  const len = payload.length;
+  framed[1] = (len >>> 24) & 0xff;
+  framed[2] = (len >>> 16) & 0xff;
+  framed[3] = (len >>> 8) & 0xff;
+  framed[4] = len & 0xff;
+  framed.set(payload, 5);
+  return framed;
+}
+
+interface ConnectFrame {
+  flags: number;
+  message: Record<string, unknown> | null;
+}
+
+const MAX_FRAME_LEN = 8 * 1024 * 1024;
+
+export function decodeConnectFrame(
+  buf: Uint8Array,
+  byteOffset: number
+): { consumed: number; frame: ConnectFrame | null } {
+  if (byteOffset + 5 > buf.length) return { consumed: 0, frame: null };
+  const flags = buf[byteOffset];
+  const len =
+    (buf[byteOffset + 1] << 24) |
+    (buf[byteOffset + 2] << 16) |
+    (buf[byteOffset + 3] << 8) |
+    buf[byteOffset + 4];
+  const msgLen = len < 0 ? len + 0x100000000 : len;
+  if (msgLen > MAX_FRAME_LEN) return { consumed: -1, frame: null };
+  if (byteOffset + 5 + msgLen > buf.length) return { consumed: 0, frame: null };
+  const payload = buf.subarray(byteOffset + 5, byteOffset + 5 + msgLen);
+  let message: Record<string, unknown> | null = null;
+  if (msgLen > 0) {
+    try {
+      message = JSON.parse(new TextDecoder().decode(payload));
+    } catch {
+      message = null;
+    }
+  }
+  return { consumed: 5 + msgLen, frame: { flags, message } };
+}
+
+export function extractDelta(
+  msg: Record<string, unknown> | null
+): { kind: "text" | "think"; text: string } | null {
+  if (!msg) return null;
+  const op = String(msg.op ?? "");
+  const mask = String(msg.mask ?? "");
+  const block = (msg.block ?? {}) as Record<string, unknown>;
+  const key =
+    mask === "block.text" || mask === "block.text.content"
+      ? "text"
+      : mask === "block.think" || mask === "block.think.content"
+        ? "think"
+        : null;
+  if (!key || (op !== "set" && op !== "append")) return null;
+  const text = String(((block[key] ?? {}) as Record<string, unknown>).content ?? "");
+  return text ? { kind: key, text } : null;
+}
+
+export function isEndOfStream(msg: Record<string, unknown> | null): boolean {
+  if (!msg) return false;
+  const message = (msg.message ?? null) as Record<string, unknown> | null;
+  return Boolean(
+    message && message.role === "assistant" && message.status === "MESSAGE_STATUS_COMPLETED"
+  );
+}
+
+export function foldMessages(messages: Array<{ role: string; content: unknown }>): string {
+  let system = "";
+  let user = "";
+  for (const m of messages) {
+    const text = typeof m.content === "string" ? m.content : JSON.stringify(m.content ?? "");
+    if (m.role === "system") system += (system ? "\n\n" : "") + text;
+    else if (m.role === "user") user = user ? `${user}\n\n${text}` : text;
+    else if (m.role === "assistant")
+      user = user ? `${user}\n\nAssistant: ${text}` : `Assistant: ${text}`;
+  }
+  return system ? `${system}\n\n${user}` : user;
+}
 
 export class KimiWebExecutor extends BaseExecutor {
   constructor() {
@@ -120,7 +210,12 @@ export class KimiWebExecutor extends BaseExecutor {
 
     if (!upstream.ok) {
       const errText = await upstream.text().catch(() => "");
-      return makeErrorResult(upstream.status, `Kimi error: ${sanitizeErrorMessage(errText)}`, body, CHAT_URL);
+      return makeErrorResult(
+        upstream.status,
+        `Kimi error: ${sanitizeErrorMessage(errText)}`,
+        body,
+        CHAT_URL
+      );
     }
 
     const encoder = new TextEncoder();
@@ -231,61 +326,24 @@ export class KimiWebExecutor extends BaseExecutor {
       };
     }
 
-    // Streaming
-    const encoder = new TextEncoder();
-    const decoder = new TextDecoder();
-    const stream = new ReadableStream({
-      async start(controller) {
-        const reader = upstream.body?.getReader();
-        if (!reader) {
-          controller.close();
-          return;
-        }
-        let buffer = "";
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            buffer += decoder.decode(value, { stream: true });
-            const lines = buffer.split("\n");
-            buffer = lines.pop() || "";
-            for (const line of lines) {
-              if (!line.startsWith("data:")) continue;
-              const data = line.slice(5).trim();
-              if (data === "[DONE]") {
-                controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-                continue;
-              }
-              try {
-                const parsed = JSON.parse(data);
-                const text = parsed.choices?.[0]?.delta?.content || "";
-                if (text) {
-                  const chunk = {
-                    id: `chatcmpl-kimi-${Date.now()}`,
-                    object: "chat.completion.chunk",
-                    created: Math.floor(Date.now() / 1000),
-                    model: modelId,
-                    choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
-                  };
-                  controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
-                }
-              } catch {}
-            }
-          }
-        } catch (err) {
-          if (!signal?.aborted) controller.error(err);
-        } finally {
-          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-          controller.close();
-        }
-      },
-    });
-
+    // Non-streaming: collect all deltas into a single chat.completion JSON.
+    let answer = "";
+    let reasoning = "";
+    const reader = sourceStream.getReader();
+    let buffer = new Uint8Array(0);
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        const merged = new Uint8Array(buffer.length + value.length);
+        merged.set(buffer, 0);
+        merged.set(value, buffer.length);
+        buffer = merged;
         let offset = 0;
         while (offset < buffer.length) {
           const { consumed, frame } = decodeConnectFrame(buffer, offset);
-          if (consumed === -1) break; // oversized frame — abort, return what we have
-          if (consumed === 0) break;
+          if (consumed === -1 || consumed === 0) break;
           offset += consumed;
           if (!frame?.message) continue;
           const delta = extractDelta(frame.message);
@@ -294,7 +352,7 @@ export class KimiWebExecutor extends BaseExecutor {
             else answer += delta.text;
           }
           if (isEndOfStream(frame.message)) {
-            offset = buffer.length; // drain
+            offset = buffer.length;
             break;
           }
         }
@@ -314,12 +372,8 @@ export class KimiWebExecutor extends BaseExecutor {
       choices: [{ index: 0, message, finish_reason: "stop" }],
     };
     return {
-      response: new Response(stream, {
-        headers: {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-        },
+      response: new Response(JSON.stringify(completion), {
+        headers: { "Content-Type": "application/json" },
       }),
       url: CHAT_URL,
       headers: reqHeaders,

--- a/open-sse/handlers/responseSanitizer.ts
+++ b/open-sse/handlers/responseSanitizer.ts
@@ -518,37 +518,6 @@ function sanitizeChoice(choice: unknown, defaultIndex: number): JsonRecord {
   return sanitized;
 }
 
-/**
- * Sanitize a message object, extracting <think> tags if present.
- */
-function sanitizeMessage(msg: unknown): unknown {
-  const msgRecord = toRecord(msg);
-  if (!msgRecord) return msg;
-
-  const sanitized: JsonRecord = {};
-
-  // Copy only allowed fields
-  if (msgRecord.role) sanitized.role = msgRecord.role;
-  if (msgRecord.refusal !== undefined) sanitized.refusal = msgRecord.refusal;
-
-  // Handle content — extract <think> tags
-  if (typeof msgRecord.content === "string") {
-    const { content, thinking } = extractThinkingFromContent(
-      stripInternalToolEnvelopeText(msgRecord.content)
-    );
-    sanitized.content = collapseExcessiveNewlines(content);
-
-    // Set reasoning_content from prompt-format tags only when the provider did
-    // not also return a native OpenAI-compatible reasoning field.
-    if (thinking && !getReadableReasoningValue(msgRecord)) {
-      sanitized.reasoning_content = thinking;
-    }
-  } else if (msgRecord.content !== undefined) {
-    sanitized.content = msgRecord.content;
-  }
-
-  copyOpenAICompatibleReasoningFields(msgRecord, sanitized);
-
 function applyTextualToolCallSanitization(sanitized: JsonRecord, msgRecord: JsonRecord): void {
   const textualToolCall = parseTextualToolCallContent(sanitized.content);
   if (textualToolCall && !msgRecord.tool_calls) {

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -283,36 +283,6 @@ function quotaRemainingPercentFromQuota(quota: unknown): number {
   return 100;
 }
 
-const QUOTA_BLOCKING_CONNECTION_STATUSES = new Set([
-  "banned",
-  "credits_exhausted",
-  "deactivated",
-  "expired",
-  "rate_limited",
-]);
-
-function normalizeConnectionStatus(value: unknown): string {
-  return typeof value === "string" ? value.trim().toLowerCase() : "";
-}
-
-function hasFutureRateLimitUntil(value: unknown): boolean {
-  if (value == null || value === "") return false;
-  const time = new Date(String(value)).getTime();
-  return Number.isFinite(time) && time > Date.now();
-}
-
-export function getConnectionStatusQuotaCutoffReason(
-  connection: Record<string, unknown> | undefined
-): string | undefined {
-  if (!connection) return undefined;
-  const status = normalizeConnectionStatus(connection.testStatus);
-  if (QUOTA_BLOCKING_CONNECTION_STATUSES.has(status)) return status;
-  if (status === "unavailable" && hasFutureRateLimitUntil(connection.rateLimitedUntil)) {
-    return "rate_limited";
-  }
-  return undefined;
-}
-
 export async function buildAutoCandidates(
   targets: ResolvedComboTarget[],
   comboName: string,
@@ -385,32 +355,7 @@ export async function buildAutoCandidates(
       const parsed = parseModel(t.modelStr);
       return t.provider || parsed.provider || parsed.providerAlias || "unknown";
     }
-    const connectionIds = providerConnections
-      .map((c) => (c && typeof c === "object" && typeof c.id === "string" ? c.id : null))
-      .filter((id): id is string => id !== null);
-    const allowedConnectionIds = Array.isArray(target.allowedConnectionIds)
-      ? new Set(
-          target.allowedConnectionIds.filter(
-            (connectionId): connectionId is string =>
-              typeof connectionId === "string" && connectionId.trim().length > 0
-          )
-        )
-      : null;
-    const scopedConnectionIds = allowedConnectionIds
-      ? connectionIds.filter((connectionId) => allowedConnectionIds.has(connectionId))
-      : connectionIds;
-    if (scopedConnectionIds.length === 0) {
-      expandedTargets.push(target);
-      continue;
-    }
-    for (const connectionId of scopedConnectionIds) {
-      expandedTargets.push({
-        ...target,
-        connectionId,
-        executionKey: `${target.executionKey}@${connectionId}`,
-      });
-    }
-  }
+  );
 
   const candidates = await Promise.all(
     fingerprintExpandedTargets.map(async (target) => {
@@ -1544,8 +1489,8 @@ export async function handleComboChat({
       relayOptions,
       resilienceSettings,
       log,
-      buildAutoCandidates,
-    });
+      buildAutoCandidates
+    );
     if ("earlyResponse" in autoResult) return autoResult.earlyResponse;
     orderedTargets = autoResult.orderedTargets;
     autoUsedExplicitRouter = autoResult.autoUsedExplicitRouter;
@@ -3129,9 +3074,7 @@ async function handleRoundRobinCombo({
   // runtime-unavailable, we must reconsider these before returning 503, instead of
   // permanently dropping a compat-rejected-but-healthy provider.
   const compatKeptSet = new Set(filteredTargets);
-  const compatRejectedTargets = evalRankedTargets.filter(
-    (target) => !compatKeptSet.has(target)
-  );
+  const compatRejectedTargets = evalRankedTargets.filter((target) => !compatKeptSet.has(target));
   const modelCount = filteredTargets.length;
   if (modelCount === 0) {
     const exhaustion = describeCapabilityFilterExhaustion(
@@ -3718,7 +3661,10 @@ async function handleRoundRobinCombo({
           resilienceSettings.providerCooldown.enabled &&
           provider &&
           provider !== "unknown" &&
-          !(result.status === 500 && hasPerModelQuota(provider, parseModel(modelStr).model || modelStr))
+          !(
+            result.status === 500 &&
+            hasPerModelQuota(provider, parseModel(modelStr).model || modelStr)
+          )
         ) {
           recordProviderCooldown(
             provider,

--- a/open-sse/services/combo.ts
+++ b/open-sse/services/combo.ts
@@ -180,7 +180,6 @@ import {
   calculateResetWindowAffinity,
   type ResetWindowConfig,
 } from "./combo/quotaScoring.ts";
-import { fetchResetAwareQuotaWithCache, preScreenTargets } from "./combo/quotaStrategies.ts";
 import {
   fetchResetAwareQuotaWithCache,
   preScreenTargets,

--- a/src/lib/db/providers.ts
+++ b/src/lib/db/providers.ts
@@ -53,7 +53,7 @@ export async function getProviderConnections(
   filter: JsonRecord = {},
   limit?: number,
   offset?: number,
-  columns?: string[],
+  columns?: string[]
 ) {
   const useCache = !columns?.length && limit === undefined && offset === undefined;
   const raw = useCache
@@ -79,7 +79,7 @@ export async function getRawProviderConnections(
   filter: JsonRecord = {},
   limit?: number,
   offset?: number,
-  columns?: string[],
+  columns?: string[]
 ) {
   const db = getDbInstance() as unknown as DbLike;
   let selectCols = "*";
@@ -110,8 +110,6 @@ export async function getRawProviderConnections(
     conditions.push("auth_type = @authType");
     params.authType = filter.authType;
   }
-
-
 
   if (conditions.length > 0) {
     sql += " WHERE " + conditions.join(" AND ");
@@ -785,8 +783,9 @@ export async function clearConnectionErrorIfUnchanged(
   }
 ): Promise<boolean> {
   const db = getDbInstance() as unknown as DbLike;
-  const result = db.prepare(
-    `
+  const result = db
+    .prepare(
+      `
     UPDATE provider_connections SET
       test_status = 'active',
       last_error = NULL,
@@ -802,13 +801,14 @@ export async function clearConnectionErrorIfUnchanged(
       AND IFNULL(last_error_at, '') = ?
       AND IFNULL(rate_limited_until, '') = ?
     `
-  ).run(
-    new Date().toISOString(),
-    id,
-    expected.testStatus ?? "",
-    expected.lastErrorAt ?? "",
-    expected.rateLimitedUntil ?? ""
-  );
+    )
+    .run(
+      new Date().toISOString(),
+      id,
+      expected.testStatus ?? "",
+      expected.lastErrorAt ?? "",
+      expected.rateLimitedUntil ?? ""
+    );
   const applied = (result.changes ?? 0) > 0;
   if (applied) {
     backupDbFile("pre-write");
@@ -925,62 +925,7 @@ export async function getDistinctGroups(): Promise<string[]> {
   return rows.map((r) => String(r.group ?? "")).filter(Boolean);
 }
 
-export {
-  autoMigrateLegacyEncryptedConnections,
-  getGheCopilotHosts,
-} from "./providers/migrations";
-
-// ──────────────── Re-exports from leaf modules ────────────────
-
-  for (const row of rows) {
-    const camelRow = rowToCamel(row);
-    if (!camelRow) continue;
-
-    let updatedRow = false;
-
-    const encryptedFields = ["apiKey", "idToken", "accessToken", "refreshToken"];
-    for (const field of encryptedFields) {
-      if (typeof camelRow[field] === "string") {
-        const { updated, value } = migrateLegacyEncryptedString(camelRow[field] as string);
-        if (updated) {
-          camelRow[field] = value;
-          updatedRow = true;
-        }
-      }
-    }
-
-    if (updatedRow) {
-      // camelRow[field] is already re-encrypted!
-      // But _updateConnectionRow does not re-encrypt automatically, so we pass it safely.
-      // Wait, _updateConnectionRow runs the full data through `encryptConnectionFields`,
-      // but `encryptConnectionFields` will re-encrypt plain text.
-      // BUT `migrateLegacyEncryptedString` returns ALREADY ENCRYPTED ciphertext!
-      // Wait... if we pass ALREADY ENCRYPTED text to `_updateConnectionRow`,
-      // `encryptConnectionFields` in `_updateConnectionRow` will encrypt it AGAIN!
-      // Let's modify the DB directly so we don't double encrypt.
-
-      db.prepare(
-        "UPDATE provider_connections SET api_key = @apiKey, id_token = @idToken, access_token = @accessToken, refresh_token = @refreshToken, updated_at = @updatedAt WHERE id = @id"
-      ).run({
-        id: camelRow.id,
-        apiKey: camelRow.apiKey ?? null,
-        idToken: camelRow.idToken ?? null,
-        accessToken: camelRow.accessToken ?? null,
-        refreshToken: camelRow.refreshToken ?? null,
-        updatedAt: new Date().toISOString(),
-      });
-      migratedCount++;
-    }
-  }
-
-  if (migratedCount > 0) {
-    backupDbFile("pre-write");
-    invalidateDbCache("connections");
-    console.log(`[DB] Auto-migrated ${migratedCount} connection(s) to new static-salt encryption.`);
-  }
-
-  return migratedCount;
-}
+export { autoMigrateLegacyEncryptedConnections, getGheCopilotHosts } from "./providers/migrations";
 
 // ──────────────── Re-exports from leaf modules ────────────────
 


### PR DESCRIPTION
Remote main after the recovery merge train had three parser-breaking splices: an orphaned sanitizer function fragment, a malformed auto-candidate expansion block, and an orphaned provider migration fragment. This bounded repair removes only those detached fragments and restores the existing call delimiters/re-exports.\n\nValidation: Prettier check passes for all three owned files; typecheck reached semantic diagnostics with zero TS1005/TS1128/TS1135/TS1109/TS1434 parse errors before the temporary dependency installation was exhausted. Full typecheck remains blocked by pre-existing semantic diagnostics and incomplete local dependencies.