### PR TITLE
fix: complete retry and quota recovery follow-ups

### DIFF
--- a/open-sse/services/retryAfterJson.ts
+++ b/open-sse/services/retryAfterJson.ts
@@ -1,5 +1,8 @@
 type JsonRecord = Record<string, unknown>;
 
+const MAX_DELAY_TEXT_LENGTH = 64;
+const MAX_DELAY_MS = 30 * 24 * 60 * 60 * 1000;
+
 function objectRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
 }
@@ -23,19 +26,32 @@ function futureTimestampMs(value: unknown, maxMs: number): number | null {
  * number of seconds. Shared by account-fallback retry parsing and rate-limit handling.
  */
 export function parseDelayString(value: unknown): number | null {
-  if (!value) return null;
-  const str = String(value).trim();
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 && value * 1000 <= MAX_DELAY_MS
+      ? Math.round(value * 1000)
+      : null;
+  }
+  if (typeof value !== "string" || value.length > MAX_DELAY_TEXT_LENGTH) return null;
+  const str = value.trim();
+  if (!str || str.length > MAX_DELAY_TEXT_LENGTH) return null;
+
+  function toDelayMs(amount: string, multiplier: number): number | null {
+    const delayMs = Number(amount) * multiplier;
+    return Number.isFinite(delayMs) && delayMs >= 0 && delayMs <= MAX_DELAY_MS
+      ? Math.round(delayMs)
+      : null;
+  }
+
   const msMatch = /^(\d+(?:\.\d+)?)\s*ms$/i.exec(str);
-  if (msMatch) return Math.round(Number.parseFloat(msMatch[1]));
+  if (msMatch) return toDelayMs(msMatch[1], 1);
   const secMatch = /^(\d+(?:\.\d+)?)\s*s$/i.exec(str);
-  if (secMatch) return Math.round(Number.parseFloat(secMatch[1]) * 1000);
+  if (secMatch) return toDelayMs(secMatch[1], 1000);
   const minMatch = /^(\d+(?:\.\d+)?)\s*m$/i.exec(str);
-  if (minMatch) return Math.round(Number.parseFloat(minMatch[1]) * 60 * 1000);
+  if (minMatch) return toDelayMs(minMatch[1], 60 * 1000);
   const hrMatch = /^(\d+(?:\.\d+)?)\s*h$/i.exec(str);
-  if (hrMatch) return Math.round(Number.parseFloat(hrMatch[1]) * 3600 * 1000);
+  if (hrMatch) return toDelayMs(hrMatch[1], 3600 * 1000);
   // Bare number means seconds.
-  const num = Number.parseFloat(str);
-  return Number.isFinite(num) ? Math.round(num * 1000) : null;
+  return /^\d+(?:\.\d+)?$/.test(str) ? toDelayMs(str, 1000) : null;
 }
 
 /**

--- a/open-sse/services/retryAfterJson.ts
+++ b/open-sse/services/retryAfterJson.ts
@@ -19,6 +19,26 @@ function futureTimestampMs(value: unknown, maxMs: number): number | null {
 }
 
 /**
+ * Parse delay strings like "33s", "26.660853464s", "2m", "1h", "1500ms", or a bare
+ * number of seconds. Shared by account-fallback retry parsing and rate-limit handling.
+ */
+export function parseDelayString(value: unknown): number | null {
+  if (!value) return null;
+  const str = String(value).trim();
+  const msMatch = /^(\d+(?:\.\d+)?)\s*ms$/i.exec(str);
+  if (msMatch) return Math.round(Number.parseFloat(msMatch[1]));
+  const secMatch = /^(\d+(?:\.\d+)?)\s*s$/i.exec(str);
+  if (secMatch) return Math.round(Number.parseFloat(secMatch[1]) * 1000);
+  const minMatch = /^(\d+(?:\.\d+)?)\s*m$/i.exec(str);
+  if (minMatch) return Math.round(Number.parseFloat(minMatch[1]) * 60 * 1000);
+  const hrMatch = /^(\d+(?:\.\d+)?)\s*h$/i.exec(str);
+  if (hrMatch) return Math.round(Number.parseFloat(hrMatch[1]) * 3600 * 1000);
+  // Bare number means seconds.
+  const num = Number.parseFloat(str);
+  return Number.isFinite(num) ? Math.round(num * 1000) : null;
+}
+
+/**
  * Parse Retry-After hints from a 429 JSON response body. Providers use both
  * top-level and nested `error` fields for ISO timestamps and millisecond values.
  */

--- a/src/domain/quotaCache.ts
+++ b/src/domain/quotaCache.ts
@@ -231,7 +231,11 @@ function normalizeQuotas(rawQuotas: Record<string, any>): Record<string, QuotaIn
 // ─── Public API ─────────────────────────────────────────────────────────────
 
 export function __clearForTests() {
-  getState().cache.clear();
+  stopBackgroundRefresh();
+  const state = getState();
+  state.cache.clear();
+  state.refreshingSet.clear();
+  state.tickRunning = false;
 }
 
 export function isQuotaExhaustedForRequest(

--- a/src/domain/quotaCache.ts
+++ b/src/domain/quotaCache.ts
@@ -73,6 +73,7 @@ interface QuotaCacheState {
   refreshingSet: Set<string>;
   refreshTimer: ReturnType<typeof setInterval> | null;
   tickRunning: boolean;
+  generation: number;
 }
 
 declare global {
@@ -86,6 +87,7 @@ function getState(): QuotaCacheState {
       refreshingSet: new Set(),
       refreshTimer: null,
       tickRunning: false,
+      generation: 0,
     };
   }
   return globalThis.__omnirouteQuotaCacheState;
@@ -231,11 +233,11 @@ function normalizeQuotas(rawQuotas: Record<string, any>): Record<string, QuotaIn
 // ─── Public API ─────────────────────────────────────────────────────────────
 
 export function __clearForTests() {
-  stopBackgroundRefresh();
   const state = getState();
+  state.generation += 1;
+  stopBackgroundRefresh();
   state.cache.clear();
   state.refreshingSet.clear();
-  state.tickRunning = false;
 }
 
 export function isQuotaExhaustedForRequest(
@@ -474,13 +476,15 @@ export function markAccountExhaustedFrom429(connectionId: string, provider: stri
 
 // ─── Background Refresh ─────────────────────────────────────────────────────
 
-async function refreshEntry(entry: QuotaCacheEntry) {
+async function refreshEntry(entry: QuotaCacheEntry, generation: number) {
   const { cache, refreshingSet } = getState();
+  if (generation !== getState().generation) return;
   if (refreshingSet.has(entry.connectionId)) return;
   refreshingSet.add(entry.connectionId);
 
   try {
     const connection = await getCachedProviderConnectionById(entry.connectionId);
+    if (generation !== getState().generation) return;
     if (!connection || connection.authType !== "oauth" || !connection.isActive) {
       cache.delete(entry.connectionId);
       return;
@@ -491,7 +495,7 @@ async function refreshEntry(entry: QuotaCacheEntry) {
       getUsageForProvider(connection)
     );
 
-    if (usage?.quotas) {
+    if (generation === getState().generation && usage?.quotas) {
       setQuotaCache(entry.connectionId, entry.provider, usage.quotas);
     }
   } catch (err) {
@@ -500,7 +504,7 @@ async function refreshEntry(entry: QuotaCacheEntry) {
       (err as any)?.message || err
     );
   } finally {
-    refreshingSet.delete(entry.connectionId);
+    if (generation === getState().generation) refreshingSet.delete(entry.connectionId);
   }
 }
 
@@ -520,16 +524,19 @@ async function backgroundRefreshTick() {
   const state = getState();
   if (state.tickRunning) return;
   state.tickRunning = true;
+  const generation = state.generation;
 
   try {
     cleanupOldSnapshots();
+    if (generation !== state.generation) return;
     const now = Date.now();
     const pending = [...state.cache.values()].filter((e) => needsRefresh(e, now));
 
     // Refresh in batches to avoid thundering herd
     for (let i = 0; i < pending.length; i += MAX_CONCURRENT_REFRESHES) {
+      if (generation !== state.generation) return;
       const batch = pending.slice(i, i + MAX_CONCURRENT_REFRESHES);
-      await Promise.allSettled(batch.map(refreshEntry));
+      await Promise.allSettled(batch.map((entry) => refreshEntry(entry, generation)));
     }
   } finally {
     state.tickRunning = false;

--- a/tests/unit/quota-cache-test-reset.test.ts
+++ b/tests/unit/quota-cache-test-reset.test.ts
@@ -5,19 +5,24 @@ const quotaCache = await import("../../src/domain/quotaCache.ts");
 
 test("__clearForTests resets every quota cache global state field", () => {
   quotaCache.__clearForTests();
-  quotaCache.setQuotaCache("quota-reset-connection", "codex", {
-    session: { remainingPercentage: 0, resetAt: null },
-  });
-  quotaCache.startBackgroundRefresh();
+  try {
+    quotaCache.setQuotaCache("quota-reset-connection", "codex", {
+      session: { remainingPercentage: 0, resetAt: null },
+    });
+    quotaCache.startBackgroundRefresh();
 
-  const state = globalThis.__omnirouteQuotaCacheState!;
-  state.refreshingSet.add("quota-reset-connection");
-  state.tickRunning = true;
+    const state = globalThis.__omnirouteQuotaCacheState!;
+    const generation = state.generation;
+    state.refreshingSet.add("quota-reset-connection");
 
-  quotaCache.__clearForTests();
+    quotaCache.__clearForTests();
 
-  assert.equal(state.cache.size, 0);
-  assert.equal(state.refreshingSet.size, 0);
-  assert.equal(state.refreshTimer, null);
-  assert.equal(state.tickRunning, false);
+    assert.equal(state.cache.size, 0);
+    assert.equal(state.refreshingSet.size, 0);
+    assert.equal(state.refreshTimer, null);
+    assert.equal(state.tickRunning, false);
+    assert.equal(state.generation, generation + 1);
+  } finally {
+    quotaCache.__clearForTests();
+  }
 });

--- a/tests/unit/quota-cache-test-reset.test.ts
+++ b/tests/unit/quota-cache-test-reset.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const quotaCache = await import("../../src/domain/quotaCache.ts");
+
+test("__clearForTests resets every quota cache global state field", () => {
+  quotaCache.__clearForTests();
+  quotaCache.setQuotaCache("quota-reset-connection", "codex", {
+    session: { remainingPercentage: 0, resetAt: null },
+  });
+  quotaCache.startBackgroundRefresh();
+
+  const state = globalThis.__omnirouteQuotaCacheState!;
+  state.refreshingSet.add("quota-reset-connection");
+  state.tickRunning = true;
+
+  quotaCache.__clearForTests();
+
+  assert.equal(state.cache.size, 0);
+  assert.equal(state.refreshingSet.size, 0);
+  assert.equal(state.refreshTimer, null);
+  assert.equal(state.tickRunning, false);
+});

--- a/tests/unit/retry-after-json-delay.test.ts
+++ b/tests/unit/retry-after-json-delay.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseDelayString } from "../../open-sse/services/retryAfterJson.ts";
+
+test("parseDelayString accepts zero and valid delay units", () => {
+  assert.equal(parseDelayString(0), 0);
+  assert.equal(parseDelayString("0"), 0);
+  assert.equal(parseDelayString("1500ms"), 1500);
+  assert.equal(parseDelayString("26.5s"), 26_500);
+  assert.equal(parseDelayString("2m"), 120_000);
+  assert.equal(parseDelayString("1h"), 3_600_000);
+});
+
+test("parseDelayString rejects malformed, negative, and nonfinite input", () => {
+  for (const value of [
+    "12msjunk",
+    "12s later",
+    "12.",
+    "12..0",
+    "-1",
+    "-1s",
+    -1,
+    Infinity,
+    Number.NaN,
+  ]) {
+    assert.equal(parseDelayString(value), null, `expected ${String(value)} to be rejected`);
+  }
+});
+
+test("parseDelayString bounds provider-controlled delay text and values", () => {
+  assert.equal(parseDelayString("1".repeat(65)), null);
+  assert.equal(
+    parseDelayString("999999999999999999999999999999999999999999999999999999999999s"),
+    null
+  );
+  assert.equal(parseDelayString(Number.MAX_VALUE), null);
+});


### PR DESCRIPTION
## **User description**
## Summary
- restore the extracted retry delay-string parser used by account fallback
- fully reset global quota-cache test state, including active timer and refresh flags

## Verification
- retry parser direct cases: 6/6 passed
- account fallback direct import passed
- formatter, diff, and pre-commit gates passed

## Known baseline blockers
- Combo matrix now executes but has pre-existing semantic expectation failures
- quota reset test is blocked at load time by missing `clearConnectionRateLimit` export in `src/lib/db/providers`.


___

## **CodeAnt-AI Description**
**Restore retry delays and fully reset quota recovery state**

### What Changed
- Retry handling again accepts delays expressed in milliseconds, seconds, minutes, hours, or as a number of seconds
- Quota-cache cleanup now stops background refreshes and clears cached entries, active refreshes, timers, and running-state markers
- Added coverage to verify quota state is fully reset between tests

### Impact
`✅ Correct retry wait times for provider responses`
`✅ Fewer stale quota refreshes`
`✅ Reliable quota recovery tests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of retry delays expressed in milliseconds, seconds, minutes, hours, or plain numeric values.
  * Invalid or missing delay values are now handled more safely.
* **Reliability**
  * Improved cleanup of cached quota state, helping prevent stale background activity and ensuring more predictable behavior during resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->