### PR TITLE
fix(scripts): close missing braces/parens in mjs files

### DIFF
--- a/bin/cli/commands/setup-qwen.mjs
+++ b/bin/cli/commands/setup-qwen.mjs
@@ -191,3 +191,4 @@ export function registerSetupQwen(program) {
       if (code !== 0) process.exitCode = code;
     });
 }
+}

--- a/scripts/dev/responses-ws-proxy.mjs
+++ b/scripts/dev/responses-ws-proxy.mjs
@@ -666,7 +666,7 @@ class ResponsesWsSession {
         browser: prepared.json.browser || "chrome_149",
         os: prepared.json.os || "windows",
         headers: prepared.json.headers || {},
-      };
+      });
       // #5611: forward the configured proxy so the upstream WS connect honors the
       // Proxy Registry in no-direct-egress deployments.
       if (prepared.json.proxy) wsOptions.proxy = prepared.json.proxy;


### PR DESCRIPTION
## **User description**
## Problem
Two `.mjs` files in main were syntactically broken:

- `bin/cli/commands/setup-qwen.mjs`: missing closing `}` for the `registerSetupQwen()` function (file ended inside the `.action()` callback, leaving the outer function unclosed)
- `scripts/dev/responses-ws-proxy.mjs`: line 669 had `};` instead of `});` (the `wsFactory()` call was missing its closing paren)

Both caused parse errors, breaking the Cross-Platform Build & Test CI job for all PRs (#700, #701, #704, #705, etc).

## Fix
- setup-qwen.mjs: add one closing `}` after the `registerSetupQwen` function
- responses-ws-proxy.mjs: change `};` to `});` on line 669

## Verification
`npx tsc --noEmit` is now parse-clean for these files. After merge, the Cross-Platform Build & Test workflow should turn green for blocked PRs.


___

## **CodeAnt-AI Description**
Restore CLI setup and WebSocket proxy parsing

### What Changed
- The Qwen setup command can load and register successfully again.
- The development WebSocket proxy uses a correctly closed upstream connection setup.
- JavaScript validation and cross-platform build checks can proceed instead of failing on syntax errors.

### Impact
`✅ Working Qwen setup command`
`✅ WebSocket proxy starts without parse errors`
`✅ Unblocked cross-platform CI checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed syntax issues in the Qwen setup command.
  * Corrected WebSocket proxy connection setup to ensure upstream connections initialize properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->