### PR TITLE
fix(open-sse): remove 5 duplicate function definitions in perplexity-web.ts

### DIFF
--- a/open-sse/executors/perplexity-web.ts
+++ b/open-sse/executors/perplexity-web.ts
@@ -91,22 +91,6 @@ function sessionStore(
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
-
-function cleanResponse(text: string, strip = true): string {
-  let t = text;
-  t = t.replace(XML_DECL_RE, "");
-  t = t.replace(CITATION_RE, "");
-  t = t.replace(GROK_TAG_RE, "");
-  t = t.replace(GROK_SELF_RE, "");
-  t = t.replace(RESPONSE_TAG_RE, "");
-  if (strip) {
-    t = t.replace(MULTI_SPACE, " ");
-    t = t.replace(MULTI_NL, "\n\n");
-    t = t.trim();
-  }
-  return t;
-}
-
 // ─── SSE types ──────────────────────────────────────────────────────────────
 
 interface PplxDiffPatch {
@@ -226,123 +210,11 @@ interface ParsedMessages {
   history: Array<{ role: string; content: string }>;
   currentMsg: string;
 }
-
-function parseOpenAIMessages(messages: Array<Record<string, unknown>>): ParsedMessages {
-  let systemMsg = "";
-  const history: Array<{ role: string; content: string }> = [];
-
-  for (const msg of messages) {
-    let role = String(msg.role || "user");
-    if (role === "developer") role = "system";
-
-    let content = "";
-    if (typeof msg.content === "string") {
-      content = msg.content;
-    } else if (Array.isArray(msg.content)) {
-      content = (msg.content as Array<Record<string, unknown>>)
-        .filter((c) => c.type === "text")
-        .map((c) => String(c.text || ""))
-        .join(" ");
-    }
-    if (!content.trim()) continue;
-
-    if (role === "system") {
-      systemMsg += content + "\n";
-    } else if (role === "user" || role === "assistant") {
-      history.push({ role, content });
-    }
-  }
-
-  let currentMsg = "";
-  if (history.length > 0 && history[history.length - 1].role === "user") {
-    currentMsg = history.pop()!.content;
-  }
-
-  return { systemMsg, history, currentMsg };
-}
-
-function buildPplxRequestBody(
-  query: string,
-  dslQuery: string,
-  mode: string,
-  modelPref: string,
-  followUpUuid: string | null,
-  requestId: string
-): Record<string, unknown> {
-  const tz = typeof Intl !== "undefined" ? Intl.DateTimeFormat().resolvedOptions().timeZone : "UTC";
-
-  // Mirrors the current www.perplexity.ai/rest/sse/perplexity_ask request body. Perplexity's
-  // schematized API validates this shape; an outdated version or missing required fields → HTTP 400.
-  const params: Record<string, unknown> = {
-    attachments: [],
-    language: "en-US",
-    timezone: tz,
-    search_focus: "internet",
-    sources: ["web"],
-    frontend_uuid: requestId,
-    mode,
-    model_preference: modelPref,
-    is_related_query: false,
-    is_sponsored: false,
-    frontend_context_uuid: crypto.randomUUID(),
-    prompt_source: "user",
-    query_source: "home",
-    is_incognito: true,
-    local_search_enabled: false,
-    use_schematized_api: true,
-    send_back_text_in_streaming_api: false,
-    supported_block_use_cases: PPLX_SUPPORTED_BLOCK_USE_CASES,
-    client_coordinates: null,
-    mentions: [],
-    dsl_query: dslQuery && dslQuery.trim() ? dslQuery : query,
-    skip_search_enabled: true,
-    is_nav_suggestions_disabled: false,
-    source: "default",
-    always_search_override: false,
-    override_no_search: false,
-    client_search_results_cache_key: requestId,
-    should_ask_for_mcp_tool_confirmation: true,
-    browser_agent_allow_once_from_toggle: false,
-    force_enable_browser_agent: false,
-    supported_features: ["browser_agent_permission_banner_v1.1"],
-    extended_context: false,
-    version: PPLX_API_VERSION,
-    rum_session_id: crypto.randomUUID(),
-  };
-
-  // Only present on follow-ups (matches the browser, which omits it for a fresh query).
-  if (followUpUuid) {
-    params.last_backend_uuid = followUpUuid;
-  }
-
   return {
     query_str: query,
     params,
   };
 }
-
-function buildQuery(parsed: ParsedMessages, followUpUuid: string | null): string {
-  if (followUpUuid) return parsed.currentMsg;
-
-  const obj: Record<string, unknown> = {};
-  if (parsed.systemMsg.trim()) {
-    obj.instructions = [
-      parsed.systemMsg.trim(),
-      "You have built-in web search. Answer questions directly using search results.",
-    ];
-  }
-  if (parsed.history.length > 0) {
-    obj.history = parsed.history;
-  }
-  if (parsed.currentMsg) {
-    obj.query = parsed.currentMsg;
-  } else if (parsed.history.length === 0) {
-    obj.query = "";
-  }
-  const json = JSON.stringify(obj);
-  return json.length > 96000 ? json.slice(-96000) : json;
-}
-
 // ─── Content extraction ─────────────────────────────────────────────────────
 
 interface ContentChunk {
@@ -513,11 +385,6 @@ async function* extractContent(
 }
 
 // ─── OpenAI SSE format ──────────────────────────────────────────────────────
-
-function sseChunk(data: unknown): string {
-  return `data: ${JSON.stringify(data)}\n\n`;
-}
-
 function buildStreamingResponse(
   eventStream: ReadableStream<Uint8Array>,
   model: string,


### PR DESCRIPTION
## **User description**
## Problem
`open-sse/executors/perplexity-web.ts` imports 5 functions from `./perplexity-web/protocol.ts` (`cleanResponse`, `parseOpenAIMessages`, `buildPplxRequestBody`, `buildQuery`, `sseChunk`) AND also defines them locally — causing 37 cascading TypeScript 'name is defined multiple times' errors, breaking the Windows CLI Build in PR #700.

## Fix
Remove the 5 local definitions. Verified byte-identical to the protocol.ts exports.

## Verification
After merge, the Windows CLI Build for #700 should turn green.

Continues Codex session 019f6924-7ca3-72b3-b28b-ea1ed6829124.


___

## **CodeAnt-AI Description**
Restore successful builds for the Perplexity web executor

### What Changed
- Removed duplicate local helper definitions that conflicted with the shared implementations
- Preserved existing Perplexity request parsing, query building, response cleanup, and streaming behavior

### Impact
`✅ Successful Windows CLI builds`
`✅ Fewer TypeScript compilation errors`
`✅ Unchanged Perplexity response behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
