### PR TITLE
fix: repair #706 syntax corruption blocking CLI build

### DIFF
--- a/bin/cli/commands/setup-qwen.mjs
+++ b/bin/cli/commands/setup-qwen.mjs
@@ -191,4 +191,3 @@ export function registerSetupQwen(program) {
       if (code !== 0) process.exitCode = code;
     });
 }
-}

--- a/scripts/dev/responses-ws-proxy.mjs
+++ b/scripts/dev/responses-ws-proxy.mjs
@@ -662,11 +662,13 @@ class ResponsesWsSession {
           toStringOrNull(responseBody.service_tier) || toStringOrNull(responseBody.serviceTier),
       };
 
-      const upstream = await this.wsFactory(prepared.json.upstreamUrl, {
-        browser: prepared.json.browser || "chrome_149",
+      const wsOptions = {
+        // #5591: chrome_149 is not a wreq-js 2.3.1 profile (max chrome_147); the
+        // prepare route now sends chrome_142, this fallback matches it.
+        browser: prepared.json.browser || "chrome_142",
         os: prepared.json.os || "windows",
         headers: prepared.json.headers || {},
-      });
+      };
       // #5611: forward the configured proxy so the upstream WS connect honors the
       // Proxy Registry in no-direct-egress deployments.
       if (prepared.json.proxy) wsOptions.proxy = prepared.json.proxy;


### PR DESCRIPTION
## **User description**
## Root cause

Commit 321a89412 (#706 "fix(scripts): close missing braces/parens in mjs files") repaired a paren but left two hard SyntaxErrors that now fail the CLI build and lint on main:

1. **bin/cli/commands/setup-qwen.mjs** - an extra top-level `}` was appended after `registerSetupQwen()` was already closed; any parse of `bin/cli/**` throws `Unexpected token '}'`.
2. **scripts/dev/responses-ws-proxy.mjs:665-673** - a duplicated `wsFactory` connect block (introduced by an earlier upstream reconciliation) still had a duplicate `const upstream` declaration and an undefined `wsOptions` reference.

## Fix

- setup-qwen.mjs: remove the stray brace (restores pre-#706 form).
- responses-ws-proxy.mjs: restore the intact connect block from v3.8.49 (bcc8ae99c): single `wsOptions` object, single `wsFactory` call, and the `chrome_142` fallback per the #5591 note (`wreq-js ^2.3.1` caps at chrome_147; the corrupted copy's `chrome_149` fallback would also be an invalid profile at runtime).

## Evidence

- `CLI Build (windows-latest)` fails at the Build CLI step on main @ 2738bb252; ubuntu is cancelled by fail-fast.
- Duplicate `const` declaration is a guaranteed SyntaxError in any ESM parse.

No other behavior is changed.


___

## **CodeAnt-AI Description**
Restore CLI builds and reliable upstream WebSocket connections

### What Changed
- CLI setup commands can be parsed and built again without a syntax error
- WebSocket sessions use a supported browser profile and establish one upstream connection
- Configured proxies continue to be applied to upstream WebSocket connections

### Impact
`✅ Successful CLI builds`
`✅ Fewer WebSocket connection failures`
`✅ Reliable proxy routing for WebSocket sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of the Qwen setup command by correcting an issue that could prevent it from loading properly.
  - Updated WebSocket proxy connection handling to use the correct browser profile defaults and preserve configured proxy settings, improving connection compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->