### PR TITLE
fix(skills): add missing cli-skill-collector catalog entry + coverage total

### DIFF
--- a/src/lib/agentSkills/catalog.ts
+++ b/src/lib/agentSkills/catalog.ts
@@ -150,7 +150,7 @@ export function computeCoverage(): SkillCoverage {
 
   return {
     api: { have: apiHave, total: 23 },
-    cli: { have: cliHave, total: 20 },
+    cli: { have: cliHave, total: 21 },
     config: { have: configHave, total: configTotal },
     totalSkills: apiHave + cliHave + configHave,
     generatedAt: new Date().toISOString(),

--- a/src/shared/constants/agentSkills.ts
+++ b/src/shared/constants/agentSkills.ts
@@ -428,6 +428,15 @@ export const CURATED_SKILLS: CuratedSkillEntry[] = [
     area: "cli-setup",
     icon: "build",
   },
+  {
+    id: "cli-skill-collector",
+    name: "CLI: Skill Collector",
+    description:
+      "Detect installed CLI coding tools (Claude Code, Codex, Cursor, Copilot, Cline and more), search GitHub for matching agent skills, and install them to the detected tools via OmniRoute's built-in APIs.",
+    category: "cli",
+    area: "cli-skill-collector",
+    icon: "download",
+  },
 
   // ── Config Skills ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## **User description**
## Root cause

PR #699 added `cli-skill-collector` to `CLI_SKILL_IDS`, the skill type union, the tests, and the generated `skills/cli-skill-collector/SKILL.md` - but the matching `CURATED_SKILLS` entry was never added.

Result on main: `getCatalog()` returns 20 CLI skills while `CLI_SKILL_IDS` has 21, failing four tests in `tests/unit/agentSkills-catalog.test.ts` (catalog count, filter count, area mapping, coverage shape).

## Fix

- `src/shared/constants/agentSkills.ts`: add the `cli-skill-collector` entry (category `cli`, area `cli-skill-collector`, icon `download`, description matching the generated SKILL.md).
- `src/lib/agentSkills/catalog.ts`: `computeCoverage()` CLI total 20 -> 21 so the coverage summary matches the 21-skill catalog.

## Test plan

- `tests/unit/agentSkills-catalog.test.ts`: all previously failing assertions now hold (21 catalog entries, filter count 21, coverage total 21, last ID is cli-skill-collector).
- No other catalog entries or behavior changed.


___

## **CodeAnt-AI Description**
Restore the complete CLI skills catalog and accurate coverage totals

### What Changed
- Adds the missing “CLI: Skill Collector” entry to the skills catalog
- CLI skill coverage now reports all 21 available skills instead of 20

### Impact
`✅ Skill Collector appears in the CLI catalog`
`✅ Accurate CLI skill coverage totals`
`✅ Catalog and coverage checks pass`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
