### PR TITLE
fix(models): restore custom vision metadata for custom models

### DIFF
--- a/src/app/api/v1/models/catalog.ts
+++ b/src/app/api/v1/models/catalog.ts
@@ -1410,8 +1410,9 @@ async function buildUnifiedModelsResponseCore(
           ) {
             continue;
           }
-          const visionFields =
-            modelType === "chat" ? getCustomVisionCapabilityFields(model, aliasId, modelId) : null;
+          const visionFields = !modelType
+            ? getCustomVisionCapabilityFields(model, aliasId, modelId)
+            : null;
 
           if (includeAlias) {
             models.push({
@@ -1441,10 +1442,9 @@ async function buildUnifiedModelsResponseCore(
           if (includeCanonical && canonicalProviderId !== alias && !prefix && !isNoAuthProvider) {
             const providerPrefixedId = `${canonicalProviderId}/${modelId}`;
             if (models.some((m) => m.id === providerPrefixedId)) continue;
-            const providerVisionFields =
-              modelType === "chat"
-                ? getCustomVisionCapabilityFields(model, providerPrefixedId, modelId)
-                : null;
+            const providerVisionFields = !modelType
+              ? getCustomVisionCapabilityFields(model, providerPrefixedId, modelId)
+              : null;
             models.push({
               id: providerPrefixedId,
               object: "model",


### PR DESCRIPTION
## **User description**
## Summary
- restore custom-model vision metadata when endpoint classification leaves a chat model untyped
- remove impossible `modelType === "chat"` checks; specialty endpoint types remain excluded

## Validation
- On the newer upstream-based checkout, `npm run check:open-sse-typecheck` passed with 0 live errors.
- On that checkout, focused catalog/vision tests passed: 62/62.
- `git diff --check` passed.

## Origin/main limitations
- This fork `origin/main` is an older 3.8.38 lineage and does not contain `check:open-sse-typecheck`.
- Direct open-sse tsc is currently blocked by pre-existing syntax error `open-sse/executors/perplexity-web.ts:217`.
- Focused tests cannot start in this worktree because the available shared dependency tree lacks `opossum`.


___

## **CodeAnt-AI Description**
Restore vision capabilities for custom chat models in the model catalog

### What Changed
- Custom models without a classified specialty endpoint now retain their vision metadata
- Vision capabilities are included consistently for both aliased and provider-prefixed model listings
- Embedding, reranking, image, and audio models remain excluded from custom vision metadata

### Impact
`✅ Vision-enabled custom models advertise image support`
`✅ Consistent capabilities across model identifiers`
`✅ Specialty models keep their correct classifications`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
