### PR TITLE
fix(providers): restore xAI OAuth and Xiaomi token-plan contracts

### DIFF
--- a/open-sse/config/providers/shared.ts
+++ b/open-sse/config/providers/shared.ts
@@ -415,6 +415,10 @@ export const CHAT_OPENAI_COMPAT_MODELS: Record<string, RegistryModel[]> = {
     { id: "mimo-v2.5-pro", name: "MiMo-V2.5-Pro", contextLength: 1048576, maxOutputTokens: 131072 },
     { id: "mimo-v2.5", name: "MiMo-V2.5", contextLength: 1048576, maxOutputTokens: 131072 },
   ],
+  "xiaomi-mimo-token-plan": [
+    { id: "mimo-v2.5-pro", name: "MiMo-V2.5-Pro", contextLength: 1048576, maxOutputTokens: 131072 },
+    { id: "mimo-v2.5", name: "MiMo-V2.5", contextLength: 1048576, maxOutputTokens: 131072 },
+  ],
   gitlawb: [
     { id: "mimo-v2.5-pro", name: "MiMo-V2.5-Pro", contextLength: 1048576, maxOutputTokens: 131072 },
     { id: "mimo-v2.5", name: "MiMo-V2.5", contextLength: 1048576, maxOutputTokens: 131072 },

--- a/open-sse/executors/default.ts
+++ b/open-sse/executors/default.ts
@@ -286,7 +286,8 @@ export class DefaultExecutor extends BaseExecutor {
         const baseUrl = this.resolveBaseUrl(credentials);
         return normalizeSapChatUrl(baseUrl);
       }
-      case "xiaomi-mimo": {
+      case "xiaomi-mimo":
+      case "xiaomi-mimo-token-plan": {
         const baseUrl = this.resolveBaseUrl(credentials);
         return normalizeXiaomiMimoChatUrl(baseUrl);
       }
@@ -513,7 +514,8 @@ export class DefaultExecutor extends BaseExecutor {
           // An alternate protocol selected on the connection carries its own auth
           // scheme (e.g. claude uses x-api-key where openai uses bearer).
           const entry = getRegistryEntry(this.provider);
-          const authHeader = entry?.authHeader || "bearer";
+          const alternate = this.resolveAlternate(credentials);
+          const authHeader = alternate?.authHeader || entry?.authHeader || "bearer";
           const token = effectiveKey || credentials.accessToken || entry?.anonymousApiKey;
           if (token) {
             if (authHeader === "x-api-key") {

--- a/open-sse/services/usage.ts
+++ b/open-sse/services/usage.ts
@@ -63,6 +63,7 @@ import { getCursorUsage } from "./usage/cursor.ts";
 import { getKimiUsage } from "./usage/kimi.ts";
 import { getClaudePlanLabel } from "./usage/claude.ts";
 import { getKiroUsage } from "./usage/kiro.ts";
+import { getXaiOauthUsage } from "./usage/xaiOauth.ts";
 // Re-exported para os testes kiro-* (importam de services/usage).
 export { buildKiroUsageResult, discoverKiroProfileArn } from "./usage/kiro.ts";
 
@@ -574,6 +575,8 @@ export const USAGE_FETCHER_PROVIDERS = [
   "opencode-zen",
   "xiaomi-mimo",
   "xai",
+  "xai-oauth",
+  "xao",
   "vertex",
   "vertex-partner",
   "codebuddy-cn",
@@ -666,6 +669,9 @@ export async function getUsageForProvider(
       return await getXiaomiMimoUsage(id || "");
     case "xai":
       return await getXaiUsage(id || "");
+    case "xai-oauth":
+    case "xao":
+      return await getXaiOauthUsage(id || "", accessToken, connection);
     case "codebuddy-cn":
       return await getCodeBuddyCnUsage(accessToken, apiKey, providerSpecificData);
     case "promptql":
@@ -1335,6 +1341,7 @@ export const __testing = {
   getMiniMaxUsage,
   getXiaomiMimoUsage,
   getXaiUsage,
+  getXaiOauthUsage,
   getVertexUsage,
   getMiniMaxAuthErrorMessage,
   getMiniMaxErrorSummary,


### PR DESCRIPTION
## **User description**
## Summary
- restore xAI OAuth (`xai-oauth`/`xao`) usage fetcher registration, dispatch, and test export
- restore Xiaomi MiMo token-plan models in the shared catalog
- restore Xiaomi token-plan OpenAI URL normalization and alternate-protocol auth headers

## Validation
- `npm exec -- node --import tsx --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/xai-oauth-usage.test.ts tests/unit/xiaomi-providers-registry.test.ts`
- 29 passed, 0 failed

## Known qgate blocker
The Zed and Zenmux suites in qgate run `33937512602` / job `101235921555` cannot load because the base contains the unrelated pre-existing `open-sse/executors/perplexity-web.ts:217` unexpected `}` syntax error. This PR does not modify that duplicate-definition/syntax lane or the PR #723 Z.ai/Zed close-marker changes.


___

## **CodeAnt-AI Description**
Restore xAI OAuth usage and Xiaomi token-plan provider support

### What Changed
- xAI OAuth connections now report usage and quota information again, including both `xai-oauth` and `xao` provider names
- Xiaomi MiMo token-plan accounts can use the supported MiMo models with the correct request URL
- Alternate provider protocols now apply their configured authentication headers when sending requests

### Impact
`✅ Working xAI OAuth usage tracking`
`✅ Restored Xiaomi MiMo token-plan access`
`✅ Correct authentication for alternate provider protocols`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
