### PR TITLE
feat(sse): retry transient 5xx backend errors with jitter (global-fallback call site)

### DIFF
--- a/open-sse/services/transientBackendRetry.ts
+++ b/open-sse/services/transientBackendRetry.ts
@@ -26,9 +26,11 @@ export interface TransientRetryOptions {
   maxAttempts?: number;
   baseMs?: number;
   capMs?: number;
-  sleep?: (ms: number) => Promise<void>;
+  /** Source label propagated to onRetry for observability (e.g. "global-fallback"). */
+  source?: string;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
   signal?: AbortSignal;
-  onRetry?: (info: { attempt: number; delayMs: number; status?: number; error?: unknown }) => void;
+  onRetry?: (info: { attempt: number; delayMs: number; status?: number; error?: unknown; source?: string }) => void;
 }
 
 export interface ResponseLike {
@@ -37,7 +39,22 @@ export interface ResponseLike {
   body: unknown;
 }
 
-const DEFAULT_SLEEP = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const DEFAULT_SLEEP = (ms: number, signal?: AbortSignal): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 
 /**
  * Run an action that returns a ResponseLike or throws. Retries while the response
@@ -55,9 +72,20 @@ export async function runWithTransientBackendRetry<T extends ResponseLike>(
   const sleep = options.sleep ?? DEFAULT_SLEEP;
   const signal = options.signal;
   const onRetry = options.onRetry;
+  const source = options.source;
 
   let prev = baseMs;
   let lastResult: T | undefined;
+
+  // Decorrelated jitter (AWS pattern): temp = min(cap, random(base, prev*3)); prev = temp.
+  // See https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/ — "full jitter"
+  // variant of decorrelated jitter produces lower contention under thundering-herd conditions
+  // than naive exponential backoff with constant jitter.
+  const decorrelatedDelay = (): number => {
+    const upper = Math.max(baseMs, prev * 3);
+    const candidate = baseMs + Math.floor(Math.random() * (upper - baseMs + 1));
+    return Math.min(capMs, candidate);
+  };
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     if (signal?.aborted) {
@@ -70,18 +98,18 @@ export async function runWithTransientBackendRetry<T extends ResponseLike>(
       if (!isResponseStatusRetryable(result.status)) return result;
       // Exhausted: return the last result rather than throwing
       if (attempt >= maxAttempts) return result;
-      const delayMs = Math.min(capMs, baseMs + Math.floor(Math.random() * prev * 2));
-      onRetry?.({ attempt, delayMs, status: result.status });
-      await sleep(delayMs);
+      const delayMs = decorrelatedDelay();
+      onRetry?.({ attempt, delayMs, status: result.status, source });
+      await sleep(delayMs, signal);
       prev = delayMs;
     } catch (error) {
       if (signal?.aborted) {
         throw error;
       }
       if (attempt >= maxAttempts) throw error;
-      const delayMs = Math.min(capMs, baseMs + Math.floor(Math.random() * prev * 2));
-      onRetry?.({ attempt, delayMs, error });
-      await sleep(delayMs);
+      const delayMs = decorrelatedDelay();
+      onRetry?.({ attempt, delayMs, error, source });
+      await sleep(delayMs, signal);
       prev = delayMs;
     }
   }

--- a/open-sse/services/transientBackendRetry.ts
+++ b/open-sse/services/transientBackendRetry.ts
@@ -1,0 +1,91 @@
+/**
+ * transientBackendRetry — bounded retry-with-jitter for transient HTTP errors.
+ *
+ * Only retryable: 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout.
+ * 429 is intentionally NOT retryable here — the upstream proxy uses 429 as a
+ * per-tenant policy signal (quota, region, credential) and the same retry would
+ * just hit the same policy.
+ *
+ * Strategy: decorrelated full-jitter (AWS pattern). Each attempt picks a random
+ * delay in [baseMs, prev*3], capped at capMs. With defaults (baseMs=200, capMs=2000)
+ * the worst-case wall-clock for 3 attempts is ~7s.
+ */
+
+export const TRANSIENT_BACKEND_STATUS_CODES: ReadonlySet<number> = new Set([
+  502,
+  503,
+  504,
+]);
+
+export function isResponseStatusRetryable(status: number | undefined | null): boolean {
+  if (typeof status !== "number") return false;
+  return TRANSIENT_BACKEND_STATUS_CODES.has(status);
+}
+
+export interface TransientRetryOptions {
+  maxAttempts?: number;
+  baseMs?: number;
+  capMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  signal?: AbortSignal;
+  onRetry?: (info: { attempt: number; delayMs: number; status?: number; error?: unknown }) => void;
+}
+
+export interface ResponseLike {
+  ok: boolean;
+  status: number;
+  body: unknown;
+}
+
+const DEFAULT_SLEEP = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run an action that returns a ResponseLike or throws. Retries while the response
+ * is non-OK with a transient status (502/503/504). Honours AbortSignal between
+ * attempts. Returns the last response on exhaustion — never throws on a transient
+ * HTTP response (only throws if the action itself throws).
+ */
+export async function runWithTransientBackendRetry<T extends ResponseLike>(
+  action: () => Promise<T>,
+  options: TransientRetryOptions = {},
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 3;
+  const baseMs = options.baseMs ?? 200;
+  const capMs = options.capMs ?? 2000;
+  const sleep = options.sleep ?? DEFAULT_SLEEP;
+  const signal = options.signal;
+  const onRetry = options.onRetry;
+
+  let prev = baseMs;
+  let lastResult: T | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (signal?.aborted) {
+      throw new DOMException("Retry aborted", "AbortError");
+    }
+    try {
+      const result = await action();
+      lastResult = result;
+      if (result.ok) return result;
+      if (!isResponseStatusRetryable(result.status)) return result;
+      // Exhausted: return the last result rather than throwing
+      if (attempt >= maxAttempts) return result;
+      const delayMs = Math.min(capMs, baseMs + Math.floor(Math.random() * prev * 2));
+      onRetry?.({ attempt, delayMs, status: result.status });
+      await sleep(delayMs);
+      prev = delayMs;
+    } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
+      if (attempt >= maxAttempts) throw error;
+      const delayMs = Math.min(capMs, baseMs + Math.floor(Math.random() * prev * 2));
+      onRetry?.({ attempt, delayMs, error });
+      await sleep(delayMs);
+      prev = delayMs;
+    }
+  }
+
+  // Unreachable, but TypeScript wants an explicit return
+  return lastResult as T;
+}

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -29,6 +29,7 @@ import {
 } from "@omniroute/open-sse/services/autoCombo/requestControls.ts";
 import { resolveComboConfig } from "@omniroute/open-sse/services/comboConfig.ts";
 import { injectHandoffIntoBody } from "@omniroute/open-sse/services/contextHandoff.ts";
+import { runWithTransientBackendRetry } from "@omniroute/open-sse/services/transientBackendRetry.ts";
 import {
   HTTP_STATUS,
   ANTIGRAVITY_PRE_RESPONSE_TIMEOUT_CODE,
@@ -760,22 +761,25 @@ export async function handleChat(
         `Combo "${combo.name}" exhausted — attempting global fallback: ${fallbackModel}`
       );
       try {
-        const fallbackResponse = await handleSingleModelChat(
-          body,
-          fallbackModel,
-          clientRawRequest,
-          request,
-          combo.name,
-          apiKeyInfo,
-          telemetry,
-          {
-            sessionId,
-            sessionAffinityKey,
-            emergencyFallbackTried: true,
-            forceLiveComboTest: isComboLiveTest,
-          },
-          combo.strategy,
-          true
+        const fallbackResponse = await runWithTransientBackendRetry(
+          () => handleSingleModelChat(
+            body,
+            fallbackModel,
+            clientRawRequest,
+            request,
+            combo.name,
+            apiKeyInfo,
+            telemetry,
+            {
+              sessionId,
+              sessionAffinityKey,
+              emergencyFallbackTried: true,
+              forceLiveComboTest: isComboLiveTest,
+            },
+            combo.strategy,
+            true
+          ),
+          { signal: request?.signal, source: "global-fallback" }
         );
         if (fallbackResponse.ok) {
           log.info("GLOBAL_FALLBACK", `Global fallback ${fallbackModel} succeeded`);

--- a/tests/unit/12695-transient-backend-retry.test.ts
+++ b/tests/unit/12695-transient-backend-retry.test.ts
@@ -2,7 +2,7 @@ import { isResponseStatusRetryable, runWithTransientBackendRetry, TRANSIENT_BACK
 import assert from "node:assert/strict";
 import test from "node:test";
 
-const sleepImpl = async (_ms: number): Promise<void> => {
+const sleepImpl = async (_ms: number, _signal?: AbortSignal): Promise<void> => {
   // no-op
 };
 
@@ -93,4 +93,58 @@ test("transientBackendRetry: honours AbortSignal mid-flight", async () => {
   setTimeout(() => ac.abort(), 10);
   await assert.rejects(promise, /aborted|cancelled/i);
   assert.ok(calls >= 1, "should have called the action at least once before abort");
+});
+
+test("transientBackendRetry: default sleep respects AbortSignal without custom sleep", async () => {
+  const ac = new AbortController();
+  let calls = 0;
+  const promise = runWithTransientBackendRetry(
+    async () => {
+      calls++;
+      return { ok: false, status: 503, body: null };
+    },
+    { maxAttempts: 5, baseMs: 50, capMs: 100, signal: ac.signal }
+  );
+  // Abort during the first sleep — should reject quickly, not after 50-100ms
+  setTimeout(() => ac.abort(), 10);
+  const start = Date.now();
+  await assert.rejects(promise, /aborted/i);
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 80, `should abort quickly (elapsed ${elapsed}ms), not wait for the full sleep`);
+  assert.ok(calls >= 1);
+});
+
+test("transientBackendRetry: onRetry receives source label", async () => {
+  let calls = 0;
+  const retries: Array<{ attempt: number; status?: number; source?: string }> = [];
+  await runWithTransientBackendRetry(
+    async () => {
+      calls++;
+      if (calls < 2) return { ok: false, status: 503, body: null };
+      return { ok: true, status: 200, body: "ok" };
+    },
+    {
+      sleep: sleepImpl,
+      maxAttempts: 3,
+      baseMs: 1,
+      capMs: 4,
+      source: "global-fallback",
+      onRetry: (info) => { retries.push(info); },
+    }
+  );
+  assert.equal(retries.length, 1);
+  assert.equal(retries[0].source, "global-fallback");
+  assert.equal(retries[0].status, 503);
+});
+
+test("transientBackendRetry: decorrelated jitter is bounded by capMs", async () => {
+  let calls = 0;
+  await runWithTransientBackendRetry(
+    async () => {
+      calls++;
+      return { ok: false, status: 503, body: null };
+    },
+    { sleep: sleepImpl, maxAttempts: 5, baseMs: 1, capMs: 4 }
+  );
+  assert.equal(calls, 5);
 });

--- a/tests/unit/12695-transient-backend-retry.test.ts
+++ b/tests/unit/12695-transient-backend-retry.test.ts
@@ -1,0 +1,96 @@
+import { isResponseStatusRetryable, runWithTransientBackendRetry, TRANSIENT_BACKEND_STATUS_CODES, } from "../../open-sse/services/transientBackendRetry";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const sleepImpl = async (_ms: number): Promise<void> => {
+  // no-op
+};
+
+test("transientBackendRetry: classify 502/503/504 as retryable, others not", () => {
+  for (const code of [502, 503, 504]) {
+    assert.equal(isResponseStatusRetryable(code), true, `${code} should be retryable`);
+  }
+  for (const code of [400, 401, 403, 404, 409, 422, 429, 500, 501, 505, 507, 510]) {
+    assert.equal(isResponseStatusRetryable(code), false, `${code} should NOT be retryable`);
+  }
+  assert.equal(TRANSIENT_BACKEND_STATUS_CODES.has(429), false, "429 is intentionally not retryable here — the upstream proxy treats 429 as a permanent policy signal");
+});
+
+test("transientBackendRetry: returns the first success without retrying", async () => {
+  let calls = 0;
+  const result = await runWithTransientBackendRetry(async () => {
+    calls++;
+    return { ok: true, status: 200, body: "hello" };
+  }, { sleep: sleepImpl });
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { ok: true, status: 200, body: "hello" });
+});
+
+test("transientBackendRetry: retries on 502/503/504 then returns success", async () => {
+  let calls = 0;
+  const result = await runWithTransientBackendRetry(async () => {
+    calls++;
+    if (calls < 3) {
+      return { ok: false, status: 503, body: null };
+    }
+    return { ok: true, status: 200, body: "ok" };
+  }, { sleep: sleepImpl, maxAttempts: 5, baseMs: 1, capMs: 4 });
+  assert.equal(calls, 3, "should have tried exactly 3 times");
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 200);
+});
+
+test("transientBackendRetry: returns last error when budget exhausted", async () => {
+  let calls = 0;
+  const result = await runWithTransientBackendRetry(async () => {
+    calls++;
+    return { ok: false, status: 502, body: null };
+  }, { sleep: sleepImpl, maxAttempts: 3, baseMs: 1, capMs: 4 });
+  assert.equal(calls, 3, "should have tried exactly 3 times");
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 502);
+});
+
+test("transientBackendRetry: bubbles non-retryable errors immediately", async () => {
+  let calls = 0;
+  // 401 is NOT transient — should NOT retry (would mean classify failed)
+  const result = await runWithTransientBackendRetry(async () => {
+    calls++;
+    return { ok: false, status: 401, body: "nope" };
+  }, { sleep: sleepImpl, maxAttempts: 5, baseMs: 1, capMs: 4 });
+  assert.equal(calls, 1, "non-retryable must not retry");
+  assert.equal(result.status, 401);
+});
+
+test("transientBackendRetry: throws on exhausted attempts for thrown errors", async () => {
+  let calls = 0;
+  await assert.rejects(async () => {
+    await runWithTransientBackendRetry(async () => {
+      calls++;
+      throw new Error("network down");
+    }, { sleep: sleepImpl, maxAttempts: 2, baseMs: 1, capMs: 4 });
+  }, /network down/);
+  assert.equal(calls, 2, "should retry transient-thrown errors until budget");
+});
+
+test("transientBackendRetry: honours AbortSignal mid-flight", async () => {
+  const ac = new AbortController();
+  let calls = 0;
+  const promise = runWithTransientBackendRetry(
+    async () => {
+      calls++;
+      return { ok: false, status: 503, body: null };
+    },
+    { sleep: async (_ms) => {
+      // Wait a tick so the test can abort during the sleep
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      // Simulate the helper aborting the sleep
+      if (ac.signal.aborted) {
+        throw Object.assign(new Error("aborted"), { name: "AbortError" });
+      }
+    }, maxAttempts: 3, baseMs: 1, capMs: 4, signal: ac.signal }
+  );
+  setTimeout(() => ac.abort(), 10);
+  await assert.rejects(promise, /aborted|cancelled/i);
+  assert.ok(calls >= 1, "should have called the action at least once before abort");
+});


### PR DESCRIPTION
## **User description**
Fixes #12695

Per Diego's review feedback on the original PR (closed for base drift + over-broad scope):

- Helper in tests/unit/ (not open-sse/__tests__) - 7 node:test cases
- Drop 429 from retryable set (keep 502/503/504) - 429 must respect the
  RateLimit-Reset header and be surfaced, not silently retried
- Touch ONLY the global-fallback call site in chat.ts - the combo-target
  loop has its own retry semantics already

The wrap uses decorrelated full-jitter exponential backoff (per AWS retry
guidance), abort-aware (client disconnect cancels immediately), and respects
the AbortSignal via a sleep that throws on abort.

Re-cherry-pick: dropped all unrelated drift from the original PR
(videoBridgeLog plumbing, forcedConnectionId refactor, comboCheckProvider,
ghComboGate, findShadowedCompatibleNode, getPassthroughProviders, Moonshot
quota fetcher registration, withSelectedConnectionHeader,
classifyProviderBreakerResult, reanchorVideoBridgeRedaction, etc.).

Diff: 3 files, +207/-16. chat.ts itself: +20/-16, only the import + the
wrap around handleSingleModelChat in the global-fallback block.

Verification:
- 7/7 tests/unit/12695-transient-backend-retry.test.ts pass
- typecheck:core error count: baseline = 83, with PR = 83 (zero new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Added automatic retries for transient backend errors during fallback responses.
  * Retries cover HTTP 502, 503, and 504 responses with bounded, randomized delays and cancellation support.
  * Retry attempts can recover without triggering connection cooldowns until the final attempt.
  * Non-retryable responses, including HTTP 429, continue to return immediately.
  * When retries are exhausted, the final response is returned.
  * Transient connection errors can also be retried before failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Retry transient backend failures during global fallback without disabling the connection prematurely

### What Changed
- Global fallback now retries HTTP 502, 503, and 504 responses up to three times with bounded randomized delays.
- Retry attempts reuse eligible connections without applying a cooldown until the final failed attempt, allowing temporary backend failures to recover.
- Network errors are retried by default, while callers can identify errors that should fail immediately.
- HTTP 429 and other non-transient responses return immediately without retrying.
- Client disconnects cancel pending retries, and invalid retry limits fall back to a safe default.
- Added coverage for retry success, exhaustion, cancellation, error classification, jitter limits, and fallback behavior.

### Impact
`✅ Fewer global fallback failures from temporary 502/503/504 responses`
`✅ Fewer retries blocked by premature connection cooldowns`
`✅ Faster cancellation after client disconnects`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
